### PR TITLE
Fix agenda tracker entries silently disappearing (research, manufactu…

### DIFF
--- a/TFTV/TFTVAAAgenda/AgendaPatches.cs
+++ b/TFTV/TFTVAAAgenda/AgendaPatches.cs
@@ -20,6 +20,7 @@ using PhoenixPoint.Geoscape.Levels.Objectives;
 using PhoenixPoint.Geoscape.View;
 using PhoenixPoint.Geoscape.View.ViewControllers;
 using PhoenixPoint.Geoscape.View.ViewModules;
+using PhoenixPoint.Geoscape.View.ViewServices;
 using PhoenixPoint.Geoscape.View.ViewStates;
 using System;
 using System.Collections.Generic;
@@ -695,7 +696,7 @@ namespace TFTV.AgendaTracker
         [HarmonyPatch(typeof(UIModuleFactionAgendaTracker), "UpdateData", new Type[] { })]
         public static class UIModuleFactionAgendaTracker_UpdateDataNoArgs_Patch
         {
-            public static void Postfix(UIModuleFactionAgendaTracker __instance)
+            public static void Postfix(UIModuleFactionAgendaTracker __instance, GeoFaction ____faction)
             {
                 try
                 {
@@ -706,9 +707,66 @@ namespace TFTV.AgendaTracker
                         AgendaConstants.PendingPurge.RemoveWhere(e => !stillPresent.Contains(e));
                     }
 
+                    EnsureLiveVanillaTrackers(____faction);
+
                     AgendaConstants.OrderElements.Invoke(__instance, null);
                 }
                 catch (Exception e) { TFTVLogger.Error(e); }
+            }
+
+            // Vanilla only (re)creates rows for the current research, the current manufacture
+            // item, in-progress vehicle actions and building/repairing facilities from
+            // InitialSetup() - and InitialSetup() only runs when the player changes geoscape
+            // selection (deselecting/selecting a vehicle). There is no live event hookup in
+            // vanilla UIModuleFactionAgendaTracker for any of these. So when e.g. a research or
+            // manufacture item finishes and the next one in queue starts automatically while the
+            // player hasn't touched geoscape selection since (out on a mission, fast-forwarding
+            // time, managing a base, etc.), the old row is disposed by the per-second tick but no
+            // row is ever created for the new current item - from the player's perspective the
+            // agenda entry just vanishes until they next reselect something on the geoscape.
+            //
+            // This mirrors InitialSetup()'s own conditions and reuses vanilla's own Add methods
+            // (skipping any object that already has a live row), so it is idempotent and safe to
+            // run every tick; any gap self-heals within about a second.
+            private static void EnsureLiveVanillaTrackers(GeoFaction faction)
+            {
+                if (faction == null) return;
+
+                ResearchElement currentResearch = faction.Research?.Current;
+                if (currentResearch != null && AgendaHelpers.FindTrackedElement(currentResearch) == null)
+                {
+                    AgendaConstants.OnResearchStartedMethod?.Invoke(AgendaConstants.factionTracker, new object[] { currentResearch });
+                }
+
+                ItemManufacturing.ManufactureQueueItem currentManufacture = faction.Manufacture?.Current;
+                if (currentManufacture != null && AgendaHelpers.FindTrackedElement(currentManufacture) == null)
+                {
+                    AgendaConstants.OnItemStartedManufacturingMethod?.Invoke(AgendaConstants.factionTracker, new object[] { currentManufacture });
+                }
+
+                foreach (GeoVehicle vehicle in faction.Vehicles)
+                {
+                    if (VehicleActionsViewService.GetCurrentActionTime(vehicle) > TimeUnit.Zero
+                        && AgendaHelpers.FindTrackedElement(vehicle) == null)
+                    {
+                        AgendaConstants.OnVehicleActionMethod?.Invoke(AgendaConstants.factionTracker, new object[] { vehicle });
+                    }
+                }
+
+                if (faction is GeoPhoenixFaction phoenixFaction)
+                {
+                    foreach (GeoPhoenixBase pxBase in phoenixFaction.Bases)
+                    {
+                        foreach (GeoPhoenixFacility facility in pxBase.Layout.Facilities)
+                        {
+                            if ((facility.IsRepairing || (facility.IsBuilding && facility.ConstructionTime != TimeUnit.Zero))
+                                && AgendaHelpers.FindTrackedElement(facility) == null)
+                            {
+                                AgendaConstants.OnFacilityBuildingMethod?.Invoke(AgendaConstants.factionTracker, new object[] { facility });
+                            }
+                        }
+                    }
+                }
             }
         }
 

--- a/TFTV/TFTVAAAgenda/AgendaTracker.cs
+++ b/TFTV/TFTVAAAgenda/AgendaTracker.cs
@@ -73,6 +73,20 @@ namespace TFTV.AgendaTracker
         internal static readonly MethodInfo Dispose =
             typeof(UIModuleFactionAgendaTracker).GetMethod("Dispose", BindingFlags.NonPublic | BindingFlags.Instance);
 
+        // Vanilla only ever calls these from InitialSetup() - there is no live event hookup in
+        // UIModuleFactionAgendaTracker itself for research/manufacturing/vehicle/facility
+        // changes. Reflected here so EnsureLiveVanillaTrackers() (AgendaPatches.cs) can add a
+        // row the moment the underlying item becomes current, instead of waiting for the next
+        // InitialSetup() rebuild (i.e. the next geoscape selection change).
+        internal static readonly MethodInfo OnResearchStartedMethod =
+            typeof(UIModuleFactionAgendaTracker).GetMethod("OnResearchStarted", BindingFlags.NonPublic | BindingFlags.Instance);
+        internal static readonly MethodInfo OnItemStartedManufacturingMethod =
+            typeof(UIModuleFactionAgendaTracker).GetMethod("OnItemStartedManufacturing", BindingFlags.NonPublic | BindingFlags.Instance);
+        internal static readonly MethodInfo OnVehicleActionMethod =
+            typeof(UIModuleFactionAgendaTracker).GetMethod("OnVehicleAction", BindingFlags.NonPublic | BindingFlags.Instance);
+        internal static readonly MethodInfo OnFacilityBuildingMethod =
+            typeof(UIModuleFactionAgendaTracker).GetMethod("OnFacilityBuilding", BindingFlags.NonPublic | BindingFlags.Instance);
+
         // Cached reflected fields on GeoVehicle for exploration time
         internal static readonly FieldInfo ExplorationUpdateableField =
             typeof(GeoVehicle).GetField("_explorationUpdateable", BindingFlags.NonPublic | BindingFlags.Instance);


### PR DESCRIPTION
…ring, vehicles, facilities)

Vanilla UIModuleFactionAgendaTracker only (re)creates rows for the current research, current manufacture item, in-progress vehicle actions, and building/repairing facilities from InitialSetup(), which itself only runs when the player changes geoscape selection. There is no live event hookup for any of these types, so when the currently-tracked item finishes and the next one in queue auto-starts (e.g. research completing while the player is on a mission), the old row is disposed on schedule but no row is ever created for the new current item until the player happens to reselect something on the geoscape - the agenda entry just vanishes in the meantime.

Add EnsureLiveVanillaTrackers(), run every second alongside the existing UpdateData() postfix, which reconciles the tracker against the faction's actual current state and adds any missing row via vanilla's own Add methods, mirroring InitialSetup()'s conditions. It's idempotent (skips anything already tracked), so any gap self-heals within about a second instead of requiring a geoscape reselection.