### PR TITLE
Incident portraits: fix blank render from layer isolation, add tint readback

### DIFF
--- a/TFTV/TFTVIncidents/PortraitGenerator.cs
+++ b/TFTV/TFTVIncidents/PortraitGenerator.cs
@@ -1,4 +1,4 @@
-using Base.Core;
+﻿using Base.Core;
 using PhoenixPoint.Common.Core;
 using PhoenixPoint.Common.Entities.Addons;
 using PhoenixPoint.Common.Entities.GameTags;
@@ -458,7 +458,7 @@ namespace TFTV.TFTVIncidents
                     $"patternTags={mergeable.Count(t => t is CustomizationPatternTagDef)} " +
                     $"conditionalTag={conditional} addonsRefreshed={refreshed}");
 
-                LogAddonCustomizationState(manager);
+                LogAddonCustomizationState(manager, mergeable);
             }
             catch (Exception e)
             {
@@ -470,7 +470,7 @@ namespace TFTV.TFTVIncidents
         /// Diagnostic: reports, per built item, whether it is in a state where the customization pass
         /// can tint it (visual root present, highlightable renderers found, AlwaysCustomizeColor).
         /// </summary>
-        private static void LogAddonCustomizationState(AddonsManager manager)
+        private static void LogAddonCustomizationState(AddonsManager manager, List<GameTagDef> mergeable)
         {
             try
             {
@@ -494,9 +494,32 @@ namespace TFTV.TFTVIncidents
                         rendererCount = -2;
                     }
 
+                    // Read the tint back off the first renderer: an unset property reads as
+                    // (0,0,0,0), which distinguishes "customization never applied" from
+                    // "applied but looks unchanged".
+                    string tintReadback = "n/a";
+                    CustomizationColorTagDef colorTag = mergeable?.OfType<CustomizationColorTagDef>().FirstOrDefault();
+                    if (colorTag != null && rendererCount > 0)
+                    {
+                        try
+                        {
+                            Renderer first = item.GetHighlightableRenderers().FirstOrDefault();
+                            if (first != null)
+                            {
+                                MaterialPropertyBlock readback = new MaterialPropertyBlock();
+                                first.GetPropertyBlock(readback);
+                                tintReadback = $"{colorTag.ShaderParamName}={readback.GetColor(colorTag.ShaderParamName)}";
+                            }
+                        }
+                        catch (Exception readbackError)
+                        {
+                            tintReadback = "error:" + readbackError.GetType().Name;
+                        }
+                    }
+
                     TFTVLogger.Always($"{LogPrefix}   item={item.ItemDef?.name ?? "null"} " +
                         $"visualRoot={(item.VisualRoot != null)} renderers={rendererCount} " +
-                        $"alwaysCustomize={item.ItemDef?.AlwaysCustomizeColor}");
+                        $"alwaysCustomize={item.ItemDef?.AlwaysCustomizeColor} tint[{tintReadback}]");
                     logged++;
                 }
             }
@@ -816,7 +839,25 @@ namespace TFTV.TFTVIncidents
                 return null;
             }
 
+            // Culling keys off each renderer's own GameObject layer, so move those explicitly rather
+            // than trusting that every visual is a transform child of the builder.
+            Renderer[] renderers = characterObject.GetComponentsInChildren<Renderer>(true);
+            if (renderers == null || renderers.Length == 0)
+            {
+                TFTVLogger.Always($"{LogPrefix} No renderers under the builder; falling back to a shared camera.");
+                return null;
+            }
+
             SetLayerRecursively(characterObject, layer);
+            foreach (Renderer renderer in renderers)
+            {
+                if (renderer != null)
+                {
+                    renderer.gameObject.layer = layer;
+                }
+            }
+
+            TFTVLogger.Always($"{LogPrefix} Isolated {renderers.Length} renderer(s) on layer {layer} for the portrait render.");
 
             cameraObject = new GameObject("[TFTV]PortraitCamera");
             Camera camera = cameraObject.AddComponent<Camera>();


### PR DESCRIPTION
## What changed

Follow-up to #31, which introduced layer isolation to stop the personnel screen's scene bleeding into portraits — but made portraits render blank.

### Blank render (regression fix)

Unity culls by each **renderer's own** GameObject layer. The previous change set the layer on the builder root and recursed through transform children, which did not reliably move the addon visuals, so the camera's single-layer culling mask matched nothing and every render came back empty.

Every `Renderer` under the builder is now moved to the isolation layer explicitly. If no renderers are found, isolation is skipped and the shared camera is used instead, so a portrait always renders. The log reports either `Isolated N renderer(s) on layer X` or the fallback.

### Armor customization (diagnostics narrowed)

The captured log rules out the conditional-tag theory as the cause for armor:

```
characterTags=21 mergeable=13 colorTags=4 patternTags=1 conditionalTag=True addonsRefreshed=18
  item=NJ_Jugg_BIO_Torso_BodyPartDef visualRoot=True renderers=1 alwaysCustomize=True
  item=Human_Head_BodyPartDef        visualRoot=True renderers=5 alwaysCustomize=False
```

`conditionalTag=True` does make `Item.RefreshTags()` skip colors for items without `AlwaysCustomizeColor`, which explains the untinted **skin** parts (and the pale scalp/eyelids seen earlier). But the actual armor pieces report `AlwaysCustomizeColor=True` and have renderers, so vanilla's own logic should tint them.

This build reads the color back off the first renderer's property block. An unset property reads as `(0,0,0,0)`, so `tint[_PrimaryColor=RGBA(…)]` with real values means the customization landed and something later overrides it, while all-zero means the write never happened.

## Notes for review

- The isolation fallback guarantees portraits render even where isolation cannot be established.
- The customization change here is diagnostics only, pending one more log capture.
- Compile-verified and deployed to the local TestMod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)