### PR TITLE
Incident portraits: hide the squad bay, stop writing palette fallback grey

### DIFF
--- a/TFTV/TFTVIncidents/PortraitGenerator.cs
+++ b/TFTV/TFTVIncidents/PortraitGenerator.cs
@@ -955,19 +955,12 @@ namespace TFTV.TFTVIncidents
                     hidden.Add(candidate);
                 }
 
-                GameObject captureEnvironment = level?.SceneReferences?.UICaptureEnvironment?.gameObject;
-                bool cameraLivesThere = usedCamera != null
-                    && captureEnvironment != null
-                    && usedCamera.transform.IsChildOf(captureEnvironment.transform);
-
-                if (captureEnvironment != null
-                    && captureEnvironment.activeSelf
-                    && !cameraLivesThere
-                    && !characterObject.transform.IsChildOf(captureEnvironment.transform))
-                {
-                    captureEnvironment.SetActive(false);
-                    hidden.Add(captureEnvironment);
-                }
+                // The capture environment and the squad bay both hold character models and scenery.
+                // The squad bay matters most here: it is where the personnel screen builds its
+                // soldiers, and it is the builder we clone from when the capture environment is
+                // absent, so its contents are exactly what bleeds into the portrait.
+                TryHideSceneRoot(level?.SceneReferences?.UICaptureEnvironment?.gameObject, characterObject, usedCamera, hidden);
+                TryHideSceneRoot(level?.SceneReferences?.SquadBay?.gameObject, characterObject, usedCamera, hidden);
 
                 if (hidden.Count > 0)
                 {
@@ -980,6 +973,28 @@ namespace TFTV.TFTVIncidents
             }
 
             return hidden;
+        }
+
+        private static void TryHideSceneRoot(GameObject root, GameObject characterObject, Camera usedCamera, List<GameObject> hidden)
+        {
+            if (root == null || !root.activeSelf)
+            {
+                return;
+            }
+
+            // Never hide something the render itself depends on.
+            if (characterObject.transform.IsChildOf(root.transform))
+            {
+                return;
+            }
+
+            if (usedCamera != null && usedCamera.transform.IsChildOf(root.transform))
+            {
+                return;
+            }
+
+            root.SetActive(false);
+            hidden.Add(root);
         }
 
         /// <summary>
@@ -1001,6 +1016,7 @@ namespace TFTV.TFTVIncidents
 
                 bool anyFancy = mergeable.Any(tag => tag is CustomizationFancyTagDef);
                 int customized = 0;
+                int skipped = 0;
 
                 foreach (Addon addon in manager.RootAddon)
                 {
@@ -1023,11 +1039,21 @@ namespace TFTV.TFTVIncidents
                         CustomizationColorTagDef colorTag = tag as CustomizationColorTagDef;
                         if (colorTag != null)
                         {
-                            Color color = customization.CustomizationPaletteDef.ContainsColor(colorTag)
-                                ? customization.CustomizationPaletteDef.MatchColor(colorTag)
+                            CustomizationColorPaletteDef palette = customization.CustomizationPaletteDef.ContainsColor(colorTag)
+                                ? customization.CustomizationPaletteDef
                                 : (anyFancy
-                                    ? customization.FancyVehicleCustomizationPaletteDef.MatchColor(colorTag)
-                                    : customization.NPCPaletteDef.MatchColor(colorTag));
+                                    ? customization.FancyVehicleCustomizationPaletteDef
+                                    : customization.NPCPaletteDef);
+
+                            Color color = palette.MatchColor(colorTag);
+
+                            // A fallback result means this palette has no entry for the tag; writing it
+                            // would paint the item flat grey rather than customize it.
+                            if (color == palette.FallbackColor)
+                            {
+                                skipped++;
+                                continue;
+                            }
 
                             controller.CustomizeColor(colorTag.ShaderParamName, color);
                             continue;
@@ -1051,7 +1077,7 @@ namespace TFTV.TFTVIncidents
                     customized++;
                 }
 
-                TFTVLogger.Always($"{LogPrefix} Force-applied customization to {customized} item(s).");
+                TFTVLogger.Always($"{LogPrefix} Force-applied customization to {customized} item(s); skipped {skipped} unmatched color(s), anyFancy={anyFancy}.");
             }
             catch (Exception e)
             {


### PR DESCRIPTION
## What changed

Follow-up to #35. Two logs plus the observation that visiting the personnel tab *before* triggering an incident makes the bleed-through worse identified the real cause of both remaining problems.

### Stale renders — the squad bay was never hidden

`Player.log` reports:

```
[WARN] [TFTV][PortraitGenerator] UICaptureEnvironment is missing; falling back to SquadBay.CharacterBuilder.
```

The capture environment does not exist in the incident UI, so the builder is cloned from the **SquadBay** — which is exactly where the personnel screen builds its soldier models. The previous hiding pass only considered the capture environment (null here) and other `AddonsCharacterBuilder`s, so it never touched the squad bay contents. That explains why opening the personnel tab first makes it worse: it populates the squad bay with built models, and those mix into the render.

Both the capture environment and the squad bay roots are now deactivated for the duration of the render and restored afterwards, guarded so neither the render target nor the camera in use is ever hidden.

### Armor customization — the force-apply was painting it grey

The expanded readback shows the answer:

```
tint[_HairColor=RGBA(0.519, 0.340, 0.169, 1) _IrisColor=RGBA(0.914, 0.463, 0.141, 1)
     _PrimaryColor=RGBA(0.502, 0.502, 0.502, 1) _SecondaryColor=RGBA(0.502, 0.502, 0.502, 1)]
```

`0.502` grey is `CustomizationColorPaletteDef.FallbackColor` — i.e. the palette has no entry for those tags. Hair and iris resolved to real colors; the two armor colors did not. So the force-apply introduced in #35 was painting the armor **flat grey** over whatever the material naturally shows, which is worse than leaving it alone.

Colors that resolve to the palette fallback are now skipped, so the material keeps its own appearance. The log additionally reports `skipped N unmatched color(s), anyFancy=…`.

## Notes for review

- `anyFancy` matters: the palette choice branches on whether the character carries a fancy tag, and if it is true the fancy-vehicle palette is queried, which would never contain armor color tags. If the log confirms `anyFancy=True`, the follow-up is to query the NPC/faction palette for armor colors regardless.
- Background on the difficulty: faction colors are copied onto the character identity by `ApplyFactionCustomization`, so the tags look present and correct, but they only resolve through the right palette — and vanilla's own path skips them for this character due to the conditional-customization tag.
- Compile-verified and deployed to the local TestMod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)