### PR TITLE
Incident portraits: actually suppress foreign renderers, log source builder colors

### DIFF
--- a/TFTV/TFTVIncidents/PortraitGenerator.cs
+++ b/TFTV/TFTVIncidents/PortraitGenerator.cs
@@ -297,6 +297,8 @@ namespace TFTV.TFTVIncidents
                 yield break;
             }
 
+            LogBuilderTint(sourceBuilder, "source");
+
             AddonsCharacterBuilder tempBuilder = UnityEngine.Object.Instantiate(sourceBuilder);
 
             // Park the clone far away from the capture environment while it builds. Instantiate puts
@@ -690,11 +692,25 @@ namespace TFTV.TFTVIncidents
                 RenderSettings.reflectionIntensity = 0f;
                 ApplyCameraOverrides(usedCamera);
 
-                // When RenderingEnvironment creates the camera internally (the usual case here) it has
-                // no culling restrictions, so anything else standing at the render origin lands in the
-                // portrait - that is the personnel screen model and backdrop. Hide those meanwhile.
+                // RenderingEnvironment stages the subject at a fixed world origin (0, 1500, 0) and,
+                // when it creates the camera itself, renders with no culling restrictions - so anything
+                // else occupying that spot is captured too. Switch off every renderer that is not part
+                // of the subject for the duration of the render.
                 hiddenVisuals = new List<Renderer>();
-                List<Renderer> hidden = hiddenVisuals;
+                foreach (Renderer foreign in UnityEngine.Object.FindObjectsOfType<Renderer>())
+                {
+                    if (foreign == null
+                        || !foreign.enabled
+                        || foreign.transform.IsChildOf(characterObject.transform))
+                    {
+                        continue;
+                    }
+
+                    foreign.enabled = false;
+                    hiddenVisuals.Add(foreign);
+                }
+
+                TFTVLogger.Always($"{LogPrefix} Suppressed {hiddenVisuals.Count} foreign renderer(s) for the portrait render.");
 
                 if (allowIsolation && usedCamera != null && TryIsolateOnFreeLayer(characterObject, out int isolationLayer))
                 {
@@ -928,6 +944,61 @@ namespace TFTV.TFTVIncidents
             {
                 TFTVLogger.Error(e);
                 return true;
+            }
+        }
+
+        private static readonly string[] CustomizationColorParams =
+        {
+            "_PrimaryColor",
+            "_SecondaryColor",
+            "_HairColor",
+            "_IrisColor"
+        };
+
+        /// <summary>
+        /// Diagnostic: dumps the customization colors currently on a builder's items, so the clone can
+        /// be compared against the builder the personnel screen itself uses.
+        /// </summary>
+        private static void LogBuilderTint(AddonsCharacterBuilder builder, string label)
+        {
+            try
+            {
+                AddonsManager manager = builder?.AddonsManager;
+                if (manager?.RootAddon == null)
+                {
+                    TFTVLogger.Always($"{LogPrefix} [{label}] no addons manager/root to inspect.");
+                    return;
+                }
+
+                int logged = 0;
+                foreach (Addon addon in manager.RootAddon)
+                {
+                    Item item = addon as Item;
+                    if (item?.VisualRoot == null || logged >= 4)
+                    {
+                        continue;
+                    }
+
+                    Renderer renderer = item.GetHighlightableRenderers().FirstOrDefault();
+                    if (renderer == null)
+                    {
+                        continue;
+                    }
+
+                    MaterialPropertyBlock block = new MaterialPropertyBlock();
+                    renderer.GetPropertyBlock(block);
+
+                    string values = string.Join(" ", CustomizationColorParams
+                        .Select(param => $"{param}={block.GetColor(param)}")
+                        .ToArray());
+
+                    TFTVLogger.Always($"{LogPrefix} [{label}] item={item.ItemDef?.name ?? "null"} {values}");
+                    logged++;
+                }
+            }
+            catch (Exception e)
+            {
+                TFTVLogger.Error(e);
             }
         }
 


### PR DESCRIPTION
## What changed

Follow-up to #37, which reported no improvement. The cause was a defect in that patch rather than a wrong theory.

### Renderer suppression never ran (regression fix)

The suppression loop introduced in #37 was written into a helper function that the same edit deleted, so it never executed and the render kept capturing whatever else stood at the staging origin. The missing `Suppressed N foreign renderer(s)` line in the captured log confirms it. The loop now lives directly in the render path, where it runs.

### Customization — measurable progress, plus a direct A/B

The log shows the material-color restore working. Blaine Hargreaves went from flat `0.502` grey to:

```
_PrimaryColor=RGBA(0.772, 0.836, 0.925)  _SecondaryColor=RGBA(0.500, 0.111, 0.237)
```

which reads as genuine NJ armor colors — his tags match no palette (`skipped 28`), so the material's own colors are used instead of the grey fallback. Sophia Brown, whose tags do resolve (`skipped 0`), keeps her real white-and-red values.

Both characters now produce plausible colors, but whether they match the personnel screen cannot be determined from this side. So the same color readback is now dumped from the builder we clone **from** — after a visit to the personnel screen it still holds the last soldier that screen displayed:

```
[TFTV][PortraitGenerator] [source] item=NJ_Jugg_BIO_Torso_BodyPartDef _PrimaryColor=… _SecondaryColor=… …
```

Comparing those `[source]` lines against the per-item lines beneath them shows definitively whether the clone diverges from the working screen. If they are identical, colors were never the problem and the investigation moves to lighting or shader keywords.

## Notes for review

- With suppression finally executing, the background bleed may simply be resolved; the log now reports a suppression count.
- Compile-verified and deployed to the local TestMod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)