### PR TITLE
Portraits: build on our own character builder, drop the reimplemented render path

### DIFF
--- a/TFTV/TFTVIncidents/PortraitGenerator.cs
+++ b/TFTV/TFTVIncidents/PortraitGenerator.cs
@@ -2,7 +2,6 @@
 using PhoenixPoint.Common.Core;
 using PhoenixPoint.Common.Entities;
 using PhoenixPoint.Common.Entities.Addons;
-using PhoenixPoint.Common.Entities.GameTagsSharedData;
 using PhoenixPoint.Common.Entities.GameTags;
 using PhoenixPoint.Common.Entities.GameTagsTypes;
 using PhoenixPoint.Common.Entities.Items;
@@ -12,6 +11,7 @@ using PhoenixPoint.Geoscape.Levels;
 using PhoenixPoint.Geoscape.View.DataObjects;
 using PhoenixPoint.Geoscape.View.ViewModules;
 using PhoenixPoint.Tactical.Entities;
+using PhoenixPoint.Tactical.Entities.Animations;
 using PhoenixPoint.Tactical.Entities.Equipments;
 using PhoenixPoint.Tactical.UI.SoldierPortraits;
 using System;
@@ -25,6 +25,11 @@ namespace TFTV.TFTVIncidents
     /// <summary>
     /// Renders the currently selected incident operative's face and shows it in the
     /// encounter UI's leader picture slot. Driven by IncidentResolutionUI leader selection.
+    ///
+    /// The character is built on a private builder of our own and handed to the game's own
+    /// portrait renderer. Everything about the build mirrors UIModuleActorCycle.DisplaySoldier
+    /// (the personnel screen), so a portrait shows the same armour, colours and face the
+    /// personnel screen shows for that operative.
     /// </summary>
     internal static class PortraitGenerator
     {
@@ -37,31 +42,26 @@ namespace TFTV.TFTVIncidents
 
         // Module a portrait was last applied to, so the cache can detach its sprite from the
         // leader image before destroying it (a destroyed texture left assigned to the Image
-        // renders as garbage — typically the last thing rendered, e.g. the personnel screen).
+        // renders as garbage).
         private static UIModuleSiteEncounters _appliedModule;
 
-        private static readonly PortraitRenderProfile Profile = new PortraitRenderProfile
-        {
-            CameraFoV = 40f,
-            NoseDistance = 0.80f,
-            JawDistance = 0.92f,
-            HeadDistance = 0.88f,
-            MinCameraNearClip = 0.02f,
-            MaxCameraFarClip = 25f,
-            ApplyPostProcess = false,
-            PostGamma = 0.95f,
-            PostContrast = 1.05f,
-            PostSharpen = 0.08f
-        };
-
-        // Render target is sized to the leader pic slot's on-screen size (clamped),
-        // so the portrait matches the display resolution instead of a fixed 1024px.
+        // Render target is sized to the leader pic slot's on-screen size (clamped), so the
+        // portrait matches the display resolution instead of a fixed 1024px.
         private const int MinPortraitResolution = 128;
         private const int MaxPortraitResolution = 1024;
         private const int FallbackPortraitResolution = 512;
 
-        // Generous: the first rebuild of a session waits on addon assets being loaded from disk.
+        // Framing of the head close-up.
+        private const float CameraFoV = 40f;
+        private const float NoseDistance = 0.80f;
+        private const float HeadDistance = 0.88f;
+
+        // Generous: the first build of a session waits on addon assets being loaded from disk.
         private const float RebuildTimeoutSeconds = 20f;
+
+        // Where the subject stands while it builds - far from anything the geoscape camera sees.
+        // The renderer moves it to its own staging origin for the actual render.
+        private static readonly Vector3 SubjectStagingPosition = new Vector3(1000f, 1000f, 1000f);
 
         // Shader property the corruption (Delirium) face effect is driven by.
         private const string CorruptionShaderPropertyName = "_MaskContrast";
@@ -92,11 +92,7 @@ namespace TFTV.TFTVIncidents
                     return;
                 }
 
-                CoroutineRunner runner = GetCoroutineRunner();
-                if (runner != null)
-                {
-                    runner.StartCoroutine(RenderAndApply(module, character));
-                }
+                GetCoroutineRunner()?.StartCoroutine(RenderAndApply(module, character));
             }
             catch (Exception e)
             {
@@ -158,15 +154,8 @@ namespace TFTV.TFTVIncidents
                     _appliedModule.EncounterLeaderImage.sprite = null;
                 }
 
-                if (_appliedModule.EncunterLeaderGroup != null)
-                {
-                    _appliedModule.EncunterLeaderGroup.SetActive(false);
-                }
-
-                if (_appliedModule.EncunterLeaderInkGroup != null)
-                {
-                    _appliedModule.EncunterLeaderInkGroup.SetActive(false);
-                }
+                _appliedModule.EncunterLeaderGroup?.SetActive(false);
+                _appliedModule.EncunterLeaderInkGroup?.SetActive(false);
             }
             catch (Exception e)
             {
@@ -205,17 +194,6 @@ namespace TFTV.TFTVIncidents
                 if (portrait == null)
                 {
                     yield break;
-                }
-
-                // Replace any stale entry (should not normally exist).
-                if (Cache.TryGetValue(characterId, out Sprite stale) && stale != null && stale != portrait)
-                {
-                    if (stale.texture != null)
-                    {
-                        UnityEngine.Object.Destroy(stale.texture);
-                    }
-
-                    UnityEngine.Object.Destroy(stale);
                 }
 
                 Cache[characterId] = portrait;
@@ -282,125 +260,25 @@ namespace TFTV.TFTVIncidents
         private static IEnumerator RenderPortrait(GeoCharacter character, Vector2Int resolution, Action<Sprite> onDone)
         {
             GeoLevelController level = GameUtl.CurrentLevel()?.GetComponent<GeoLevelController>();
-            if (level?.SceneReferences == null)
+            if (level == null)
             {
-                Debug.LogWarning($"{LogPrefix} Geo scene references are missing.");
                 onDone?.Invoke(null);
                 yield break;
             }
 
-            AddonsCharacterBuilder sourceBuilder = ResolveSourceBuilder(level);
-            if (sourceBuilder == null)
-            {
-                Debug.LogWarning($"{LogPrefix} No usable CharacterBuilder found (UICaptureEnvironment/SquadBay).");
-                onDone?.Invoke(null);
-                yield break;
-            }
-
-            LogBuilderTint(sourceBuilder, "source");
-
-            AddonsCharacterBuilder tempBuilder = UnityEngine.Object.Instantiate(sourceBuilder);
-
-            // Park the clone far away from the capture environment while it builds. Instantiate puts
-            // it exactly where the source builder stands — the spot the personnel screen renders — so
-            // leaving it there lets it show up in that view (vanilla's portrait builder does the same).
-            tempBuilder.transform.position = new Vector3(1000f, 1000f, 1000f);
-            tempBuilder.ProcessRigidbodiesAndJoints = false;
-            tempBuilder.gameObject.SetActive(true);
-
-            bool rebuildDone = false;
-            Action rebuiltCallback = () => rebuildDone = true;
-            tempBuilder.OnCharacterRebuilded += rebuiltCallback;
-
+            UnitDisplayData displayData = new UnitDisplayData(character, GameUtl.GameComponent<SharedData>());
+            AddonsCharacterBuilder builder = CreateSubjectBuilder();
             try
             {
-                SharedData sharedData = GameUtl.GameComponent<SharedData>();
-                UnitDisplayData displayData = new UnitDisplayData(character, sharedData);
-
-                bool rigChanged;
-                CommonCharacterUtils.DisplayCharacter(tempBuilder, displayData, out rigChanged);
-
-                // Mirror UIModuleActorCycle.DisplaySoldier: copy the character's tags (they carry the
-                // customization — armor colors, patterns, face, hair) and pass ONLY armour items to the
-                // rebuild, letting the addons manager derive the customized body parts from the tags.
-                // Autorefresh stays OFF across the rebuild and is re-enabled once it completes: turning
-                // it back on replays the deferred tag change, which is what fills MergeWithAddonsTags and
-                // runs Item.RefreshTags() (the customization pass) on the freshly built addons.
-                tempBuilder.AddonsManager.SetAutorefreshOnTagsChanged(false);
-                tempBuilder.AddonsManager.GameTags.Clear();
-                tempBuilder.AddonsManager.GameTags.AddRange(displayData.GameTags);
-
-                List<ItemDef> armourItems = displayData.ArmourItems
-                    .Where(i => i != null && !IsHelmetOrAttachment(i))
-                    .ToList();
-
-                if (armourItems.Count == 0)
+                bool built = false;
+                yield return BuildSubject(builder, character, displayData, level, ok => built = ok);
+                if (!built)
                 {
-                    // Naked characters (e.g. civilians) have no armour to imply a body — fall back
-                    // to their explicit body parts.
-                    armourItems = character.GetBodyParts()
-                        .OfType<ItemDef>()
-                        .Where(i => i != null && !IsHelmetOrAttachment(i))
-                        .Distinct()
-                        .ToList();
-                }
-
-                CommonCharacterUtils.RebuildCharacter(tempBuilder, armourItems, null, null);
-
-                // The first render of a session usually has to wait on addon assets: when an addon
-                // is not loaded yet, StartRebuildCharacter hands off to the asset loader and only
-                // starts rebuilding once loading finishes, which takes far longer than a couple of
-                // frames. Wait on wall-clock time rather than a frame count.
-                float waitDeadline = Time.realtimeSinceStartup + RebuildTimeoutSeconds;
-                while (!rebuildDone && Time.realtimeSinceStartup < waitDeadline)
-                {
-                    yield return null;
-                }
-
-                if (!rebuildDone)
-                {
-                    Debug.LogWarning($"{LogPrefix} Character rebuild timed out after {RebuildTimeoutSeconds}s.");
                     onDone?.Invoke(null);
                     yield break;
                 }
 
-                tempBuilder.AddonsManager.SetAutorefreshOnTagsChanged(true);
-
-                // Apply the customization (armor colors/patterns, skin, hair, eye colors) to the addons
-                // that were just built. Re-enabling autorefresh above only replays the deferred tag
-                // change when the tag set actually differs from what the cloned builder already had, so
-                // do the work of AddonsManager.OnGameTagsChanged explicitly instead of relying on it.
-                ApplyCustomizationTags(tempBuilder, character);
-                ApplyFaceCorruption(tempBuilder, character, level);
-
-                CommonCharacterUtils.ResetCharacterAnimation(tempBuilder);
-                // Let skinned meshes settle (and the customization materials apply) to avoid
-                // one-frame ghosting and untextured artifacts.
-                yield return null;
-                yield return null;
-
-                // The rig carries its own character light (what lights the model on the personnel
-                // screen) — make sure it is on at the proper intensity for the render.
-                TryEnableCharacterLight(tempBuilder, displayData);
-
-                Texture2D rendered = RenderTextureWithPortraitLights(level, tempBuilder.gameObject, resolution, true, out bool usedIsolation);
-
-                // Layer isolation keeps the surrounding scene out of the portrait, but if it yields an
-                // empty image (nothing matched the camera's single-layer mask) fall back to a plain
-                // render so a portrait always appears.
-                if (usedIsolation && (rendered == null || !HasVisibleContent(rendered)))
-                {
-                    TFTVLogger.Always($"{LogPrefix} Isolated render produced no visible pixels; retrying without isolation.");
-
-                    if (rendered != null)
-                    {
-                        UnityEngine.Object.Destroy(rendered);
-                    }
-
-                    RestoreIsolatedLayers();
-                    rendered = RenderTextureWithPortraitLights(level, tempBuilder.gameObject, resolution, false, out _);
-                }
-
+                Texture2D rendered = RenderSubject(builder, displayData, resolution);
                 if (rendered == null)
                 {
                     onDone?.Invoke(null);
@@ -412,145 +290,195 @@ namespace TFTV.TFTVIncidents
                 rendered.filterMode = FilterMode.Trilinear;
                 rendered.anisoLevel = 4;
 
-                if (Profile.ApplyPostProcess)
-                {
-                    rendered = ApplyPostProcess(rendered, Profile.PostGamma, Profile.PostContrast, Profile.PostSharpen);
-                }
-
-                Sprite sprite = Sprite.Create(
+                onDone?.Invoke(Sprite.Create(
                     rendered,
                     new Rect(0f, 0f, rendered.width, rendered.height),
                     new Vector2(0.5f, 0.5f),
-                    100f);
-
-                onDone?.Invoke(sprite);
+                    100f));
             }
             finally
             {
-                tempBuilder.OnCharacterRebuilded -= rebuiltCallback;
-                UnityEngine.Object.Destroy(tempBuilder.gameObject);
+                UnityEngine.Object.Destroy(builder.gameObject);
             }
         }
 
         /// <summary>
-        /// Recomputes the addons manager's merged tag list and refreshes every addon from it —
-        /// the same work AddonsManager.OnGameTagsChanged does. Item.RefreshTags() reads
-        /// MergeWithAddonsTags to tint materials, so without this the model renders with default
-        /// (untinted) materials: no armor colors or patterns, and pale skin/hair/eyes.
+        /// A character builder of our own, built from nothing.
+        ///
+        /// It must not be cloned off a scene builder (UICaptureEnvironment / SquadBay): Instantiate
+        /// copies the meshes that builder currently displays - the soldier the personnel screen was
+        /// last showing - and those copies belong to no addons manager, so nothing ever removes them
+        /// and they end up in the portrait alongside the operative.
         /// </summary>
-        private static void ApplyCustomizationTags(AddonsCharacterBuilder builder, GeoCharacter character)
+        private static AddonsCharacterBuilder CreateSubjectBuilder()
         {
+            // Inactive first: Awake runs on activation, and it must see the fields below.
+            GameObject host = new GameObject("[TFTV]PortraitSubject");
+            host.SetActive(false);
+            host.transform.position = SubjectStagingPosition;
+
+            AddonsCharacterBuilder builder = host.AddComponent<AddonsCharacterBuilder>();
+            builder.AddonsManagerDef = null;   // DisplayCharacter installs the operative's own rig.
+            builder.TacCharacterDef = null;
+            builder.Addons.Clear();
+            builder.ProcessRigidbodiesAndJoints = false;
+
+            // DisplayCharacter routes the rig's animator controller through this component.
+            host.AddComponent<TacActorAnimActions>();
+
+            host.SetActive(true);
+            return builder;
+        }
+
+        /// <summary>
+        /// Builds the operative on the given builder, following UIModuleActorCycle.DisplaySoldier and
+        /// its OnCharacterRebuilded step: tags first with autorefresh off, rebuild, then autorefresh
+        /// back on - which is what applies the customization (armour colours and patterns, skin, hair,
+        /// eyes) to the addons that were just built.
+        /// </summary>
+        private static IEnumerator BuildSubject(AddonsCharacterBuilder builder, GeoCharacter character, UnitDisplayData displayData, GeoLevelController level, Action<bool> onDone)
+        {
+            bool rebuilt = false;
+            Action onRebuilt = () => rebuilt = true;
+            builder.OnCharacterRebuilded += onRebuilt;
             try
             {
-                AddonsManager manager = builder?.AddonsManager;
-                if (manager?.RootAddon == null || character == null)
-                {
-                    return;
-                }
+                CommonCharacterUtils.DisplayCharacter(builder, displayData, out bool _);
 
-                // Source the tags from the character rather than from manager.GameTags: the rebuild
-                // manipulates the manager's tag list, so by this point it may no longer carry the
-                // identity's customization tags.
-                List<GameTagDef> mergeable = character.GameTags
-                    .Where(tag => tag != null && AddonMergeGameTagsWithManagerAttribute.ShouldAddonMergeTagsWithAddonManager(tag.GetType()))
+                AddonsManager manager = builder.AddonsManager;
+                manager.SetAutorefreshOnTagsChanged(false);
+                manager.GameTags.Clear();
+                manager.GameTags.AddRange(displayData.GameTags);
+
+                // Helmets and head attachments hide the face the portrait is about; this is vanilla's
+                // showHelmet: false. The body itself comes from the armour items, exactly as on the
+                // personnel screen - an unarmoured operative carries their bare body parts there.
+                List<ItemDef> armour = displayData.ArmourItems
+                    .Where(item => item != null && !IsHelmetOrAttachment(item))
                     .ToList();
 
-                manager.MergeWithAddonsTags.ReplaceRange(mergeable);
+                CommonCharacterUtils.RebuildCharacter(builder, armour, null);
 
-                int refreshed = 0;
-                foreach (Addon addon in manager.RootAddon)
+                // When an addon is not loaded yet the rebuild hands off to the asset loader and only
+                // starts once loading finishes, which takes far longer than a couple of frames.
+                float deadline = Time.realtimeSinceStartup + RebuildTimeoutSeconds;
+                while (!rebuilt && Time.realtimeSinceStartup < deadline)
                 {
-                    if (addon == null)
-                    {
-                        continue;
-                    }
-
-                    addon.RefreshTags();
-                    refreshed++;
+                    yield return null;
                 }
 
-                // Item.RefreshTags() skips color customization entirely when the merged tags contain
-                // the conditional-customization tag, unless the item opts in via AlwaysCustomizeColor.
-                bool conditional = mergeable.Any(t => t is ConditionalCustomizationTagDef);
+                if (!rebuilt)
+                {
+                    TFTVLogger.Always($"{LogPrefix} Rebuild of {character.DisplayName} timed out after {RebuildTimeoutSeconds}s.");
+                    onDone?.Invoke(false);
+                    yield break;
+                }
 
-                TFTVLogger.Always($"{LogPrefix} Customization for {character.DisplayName}: " +
-                    $"characterTags={character.GameTags.Count} mergeable={mergeable.Count} " +
-                    $"colorTags={mergeable.Count(t => t is CustomizationColorTagDef)} " +
-                    $"patternTags={mergeable.Count(t => t is CustomizationPatternTagDef)} " +
-                    $"conditionalTag={conditional} addonsRefreshed={refreshed}");
+                manager.SetAutorefreshOnTagsChanged(true);
+                RefreshAddonTags(manager);
+                HideCoveredAddonVisuals(manager);
+                ApplyFaceCorruption(builder, character, level);
+                CommonCharacterUtils.ResetCharacterAnimation(builder);
 
-                ForceApplyCustomizationColors(manager, mergeable);
-                LogAddonCustomizationState(manager, mergeable);
+                // One line per portrait: what the operative is actually made of. Anything unexpected
+                // in here (a bare body part next to the armour that covers it, a missing armour piece)
+                // is what a wrong-looking portrait will be made of too.
+                TFTVLogger.Always($"{LogPrefix} {character.DisplayName} built from {string.Join(", ", VisibleItemNames(manager))}");
+
+                // Let the skinned meshes settle into the pose before the render.
+                yield return null;
+
+                onDone?.Invoke(true);
             }
-            catch (Exception e)
+            finally
             {
-                TFTVLogger.Error(e);
+                builder.OnCharacterRebuilded -= onRebuilt;
             }
         }
 
         /// <summary>
-        /// Diagnostic: reports, per built item, whether it is in a state where the customization pass
-        /// can tint it (visual root present, highlightable renderers found, AlwaysCustomizeColor).
+        /// Recomputes the manager's merged tag list and refreshes every addon from it - the same work
+        /// AddonsManager.OnGameTagsChanged does when autorefresh is turned back on. Doing it explicitly
+        /// costs nothing and makes the customization pass unconditional rather than dependent on the
+        /// tag list's change bookkeeping.
         /// </summary>
-        private static void LogAddonCustomizationState(AddonsManager manager, List<GameTagDef> mergeable)
+        private static void RefreshAddonTags(AddonsManager manager)
         {
-            try
+            if (manager?.RootAddon == null)
             {
-                int logged = 0;
-                foreach (Addon addon in manager.RootAddon)
+                return;
+            }
+
+            manager.MergeWithAddonsTags.ReplaceRange(manager.GameTags
+                .Where(tag => tag != null && AddonMergeGameTagsWithManagerAttribute.ShouldAddonMergeTagsWithAddonManager(tag.GetType())));
+
+            foreach (Addon addon in manager.RootAddon)
+            {
+                addon?.RefreshTags();
+            }
+        }
+
+        /// <summary>
+        /// Hides the visuals of every addon that a stronger addon in the same slot covers - the bare
+        /// body parts under an armour piece, mainly. The engine does this as addons attach; enforcing
+        /// it once more after the build keeps a bare torso or arm from showing through the armour when
+        /// an attach order left it visible.
+        /// </summary>
+        private static void HideCoveredAddonVisuals(AddonsManager manager)
+        {
+            if (manager?.RootAddon == null)
+            {
+                return;
+            }
+
+            foreach (Addon addon in manager.RootAddon)
+            {
+                foreach (Addon.AddonSlotImpl slot in addon.ProvidedSlots)
                 {
-                    Item item = addon as Item;
-                    if (item == null || logged >= 8)
+                    Addon strong = slot?.StrongAddon;
+                    if (strong == null || strong.AddonDef.HideWeakVisuals == AddonDef.HideMode.Show)
                     {
                         continue;
                     }
 
-                    int rendererCount = 0;
-                    try
-                    {
-                        IEnumerable<Renderer> renderers = item.GetHighlightableRenderers();
-                        rendererCount = renderers == null ? -1 : renderers.Count();
-                    }
-                    catch
-                    {
-                        rendererCount = -2;
-                    }
+                    bool recursive = strong.AddonDef.HideWeakVisuals == AddonDef.HideMode.HideAllRecursively;
 
-                    // Read the tint back off the first renderer: an unset property reads as
-                    // (0,0,0,0), which distinguishes "customization never applied" from
-                    // "applied but looks unchanged".
-                    string tintReadback = "n/a";
-                    List<CustomizationColorTagDef> colorTags = mergeable?.OfType<CustomizationColorTagDef>().ToList();
-                    if (colorTags != null && colorTags.Count > 0 && rendererCount > 0)
+                    foreach (Addon weak in slot.WeakAddons)
                     {
-                        try
+                        if (weak == null || weak.OwnTags.OfType<AlwaysVisibleAddonTagDef>().Any())
                         {
-                            Renderer first = item.GetHighlightableRenderers().FirstOrDefault();
-                            if (first != null)
+                            continue;
+                        }
+
+                        // Same reach as Addon.HideVisualsUsingHidePolicy: the covered addon alone,
+                        // or the whole branch under it when the covering addon hides recursively.
+                        foreach (Addon covered in recursive ? weak.AsEnumerable() : new[] { weak })
+                        {
+                            if (covered?.VisualRoot != null)
                             {
-                                MaterialPropertyBlock readback = new MaterialPropertyBlock();
-                                first.GetPropertyBlock(readback);
-                                tintReadback = string.Join(" ", colorTags
-                                    .Select(t => $"{t.ShaderParamName}={readback.GetColor(t.ShaderParamName)}")
-                                    .ToArray());
+                                covered.VisualRoot.gameObject.SetActive(false);
                             }
                         }
-                        catch (Exception readbackError)
-                        {
-                            tintReadback = "error:" + readbackError.GetType().Name;
-                        }
                     }
-
-                    TFTVLogger.Always($"{LogPrefix}   item={item.ItemDef?.name ?? "null"} " +
-                        $"visualRoot={(item.VisualRoot != null)} renderers={rendererCount} " +
-                        $"alwaysCustomize={item.ItemDef?.AlwaysCustomizeColor} tint[{tintReadback}]");
-                    logged++;
                 }
             }
-            catch (Exception e)
+        }
+
+        /// <summary>
+        /// Item defs the subject actually shows, for the build log line.
+        /// </summary>
+        private static string[] VisibleItemNames(AddonsManager manager)
+        {
+            if (manager?.RootAddon == null)
             {
-                TFTVLogger.Error(e);
+                return new string[0];
             }
+
+            return manager.RootAddon
+                .OfType<Item>()
+                .Where(item => item.VisualRoot != null && item.VisualRoot.gameObject.activeSelf)
+                .Select(item => item.ItemDef?.name ?? "?")
+                .ToArray();
         }
 
         /// <summary>
@@ -561,24 +489,14 @@ namespace TFTV.TFTVIncidents
         {
             try
             {
-                if (character == null || character.IsMutoid || level == null)
+                if (character == null || character.IsMutoid || level == null || (float)character.CharacterStats.Corruption <= 0f)
                 {
                     return;
                 }
 
                 AddonsManager manager = builder?.AddonsManager;
-                if (manager?.RootAddon == null || manager.RigRoot == null)
-                {
-                    return;
-                }
-
-                if ((float)character.CharacterStats.Corruption <= 0f)
-                {
-                    return;
-                }
-
                 TacticalPerceptionDef perception = character.TemplateDef?.ComponentSetDef?.GetComponentDef<TacticalPerceptionDef>();
-                if (perception == null)
+                if (manager?.RootAddon == null || perception == null)
                 {
                     return;
                 }
@@ -589,11 +507,9 @@ namespace TFTV.TFTVIncidents
                     return;
                 }
 
-                float shaderValue = level.CorruptedHorizonsSettings.CorruptionSettings
-                    .CalculateCorruptionShaderValue(character.CharacterStats.CorruptionProgressRel);
-
                 MaterialPropertyBlock propertyBlock = new MaterialPropertyBlock();
-                propertyBlock.SetFloat(CorruptionShaderPropertyName, shaderValue);
+                propertyBlock.SetFloat(CorruptionShaderPropertyName, level.CorruptedHorizonsSettings.CorruptionSettings
+                    .CalculateCorruptionShaderValue(character.CharacterStats.CorruptionProgressRel));
 
                 foreach (TacticalItem item in ((ItemSlot)headSlot).GetAllDirectItems(onlyBodyparts: true))
                 {
@@ -624,155 +540,70 @@ namespace TFTV.TFTVIncidents
         }
 
         /// <summary>
-        /// Enables the rig's built-in character light (referenced by the template's
-        /// CharacterLightObjectName) at the intensity the personnel screen uses.
+        /// Renders the built subject with the game's own soldier portrait renderer.
+        ///
+        /// That renderer stages the subject at its private origin and frames it with a camera culled
+        /// to the Characters layer and clipped 2.5m out, so nothing else in the scene can reach the
+        /// image - all we have to do is light the subject and make sure it is on that layer.
         /// </summary>
-        private static bool TryEnableCharacterLight(AddonsCharacterBuilder builder, UnitDisplayData displayData)
+        private static Texture2D RenderSubject(AddonsCharacterBuilder builder, UnitDisplayData displayData, Vector2Int resolution)
         {
-            try
-            {
-                if (builder?.AddonsManager == null || string.IsNullOrEmpty(displayData?.CharacterLightObjectName))
-                {
-                    return false;
-                }
+            GameObject subject = builder.gameObject;
+            SetLayerRecursively(subject, LayerMask.NameToLayer("Characters"));
 
-                Transform lightTransform = builder.AddonsManager.FindTransform(displayData.CharacterLightObjectName, rigBonesOnly: true);
-                Light characterLight = lightTransform != null ? lightTransform.GetComponent<Light>() : null;
-                if (characterLight == null)
-                {
-                    TFTVLogger.Always($"{LogPrefix} Character light '{displayData.CharacterLightObjectName}' not found on builder rig.");
-                    return false;
-                }
+            List<Light> disabledLights = new List<Light>();
+            GameObject lightRig = null;
 
-                characterLight.gameObject.SetActive(true);
-                characterLight.enabled = true;
-                if (LightingSettingsCharacters.Instance != null)
-                {
-                    characterLight.intensity = LightingSettingsCharacters.Instance.CharacterLightsIntensity;
-                }
-
-                return true;
-            }
-            catch (Exception e)
-            {
-                TFTVLogger.Error(e);
-                return false;
-            }
-        }
-
-        private static Texture2D RenderTextureWithPortraitLights(GeoLevelController level, GameObject characterObject, Vector2Int resolution, bool allowIsolation, out bool usedIsolation)
-        {
-            LightsPicker lightsPicker = characterObject.GetComponentInChildren<LightsPicker>(true);
-
-            // Always render with the game's own portrait/capture camera: a bare camera created from
-            // scratch renders nothing here. Isolation is done by narrowing THAT camera's culling mask
-            // to a free layer holding only this character, and is undone with the rest of its state.
-            Camera usedCamera = ResolvePortraitCamera(level, lightsPicker, characterObject);
-            usedIsolation = false;
-
-            HashSet<Light> worldLightsToRestore = new HashSet<Light>();
-            GameObject syntheticRig = null;
-            List<Renderer> hiddenVisuals = null;
-
-            float ambientIntensityBefore = RenderSettings.ambientIntensity;
-            Color ambientLightBefore = RenderSettings.ambientLight;
             UnityEngine.Rendering.AmbientMode ambientModeBefore = RenderSettings.ambientMode;
+            Color ambientLightBefore = RenderSettings.ambientLight;
+            float ambientIntensityBefore = RenderSettings.ambientIntensity;
             float reflectionBefore = RenderSettings.reflectionIntensity;
 
-            CameraState cameraState = CaptureCameraState(usedCamera);
-
             try
             {
-                // Mirror the vanilla tactical squad-portrait setup (SquadMemberScrollerController.FinishPortraitCrt):
-                // ambient (forced to Flat so this works regardless of the scene's ambient source) and
-                // reflections off, all world lights disabled, and a dedicated portrait rig at full intensity.
+                // Mirror the vanilla tactical squad-portrait setup (SquadMemberScrollerController):
+                // flat ambient, no reflections, no world lights, a dedicated portrait rig.
                 RenderSettings.ambientMode = UnityEngine.Rendering.AmbientMode.Flat;
                 RenderSettings.ambientLight = new Color(0.26f, 0.27f, 0.30f);
                 RenderSettings.ambientIntensity = 1f;
                 RenderSettings.reflectionIntensity = 0f;
-                ApplyCameraOverrides(usedCamera);
-
-                // RenderingEnvironment stages the subject at a fixed world origin (0, 1500, 0) and,
-                // when it creates the camera itself, renders with no culling restrictions - so anything
-                // else occupying that spot is captured too. Switch off every renderer that is not part
-                // of the subject for the duration of the render.
-                hiddenVisuals = new List<Renderer>();
-                foreach (Renderer foreign in UnityEngine.Object.FindObjectsOfType<Renderer>())
-                {
-                    if (foreign == null
-                        || !foreign.enabled
-                        || foreign.transform.IsChildOf(characterObject.transform))
-                    {
-                        continue;
-                    }
-
-                    foreign.enabled = false;
-                    hiddenVisuals.Add(foreign);
-                }
-
-                TFTVLogger.Always($"{LogPrefix} Suppressed {hiddenVisuals.Count} foreign renderer(s) for the portrait render.");
-
-                if (allowIsolation && usedCamera != null && TryIsolateOnFreeLayer(characterObject, out int isolationLayer))
-                {
-                    usedCamera.cullingMask = 1 << isolationLayer;
-                    usedIsolation = true;
-                }
 
                 foreach (Light light in UnityEngine.Object.FindObjectsOfType<Light>())
                 {
-                    if (light == null || !light.isActiveAndEnabled)
+                    // Never disable the character's own lights (the rig carries one).
+                    if (light == null || !light.isActiveAndEnabled || light.transform.IsChildOf(subject.transform))
                     {
                         continue;
                     }
 
-                    // Never disable the character's own lights (rig character light, portrait rigs).
-                    if (light.transform.IsChildOf(characterObject.transform))
-                    {
-                        continue;
-                    }
-
-                    worldLightsToRestore.Add(light);
                     light.gameObject.SetActive(false);
+                    disabledLights.Add(light);
                 }
 
-                if (lightsPicker != null && lightsPicker.LightSet != null && lightsPicker.LightSet.Count > 0)
-                {
-                    // Tactical-style builder: use its own portrait rigs, like vanilla does.
-                    lightsPicker.PickLights();
-                }
-                else
-                {
-                    // The geoscape capture-environment builder carries no LightsPicker (its lighting
-                    // lives in the environment scene, out of reach at the render origin), so light the
-                    // character with a synthetic three-point rig. The rig's own character light is far
-                    // too dim to carry the portrait on its own (CharacterLightsIntensity defaults to
-                    // 0.15), so it only ever supplements this rig.
-                    syntheticRig = CreatePortraitLightRig(characterObject.transform);
-                }
+                EnableCharacterLight(builder, displayData.CharacterLightObjectName);
+                lightRig = CreatePortraitLightRig(subject.transform);
 
-                return RenderWithAnchorFallback(characterObject, usedCamera, resolution);
+                bool hasNose = builder.AddonsManager?.FindTransform("Nose", rigBonesOnly: true) != null;
+                SquadPortraitsDef.RenderPortraitParams renderParams = new SquadPortraitsDef.RenderPortraitParams
+                {
+                    RenderedPortraitsResolution = resolution,
+                    TargetBoneName = hasNose ? "Nose" : "Head",
+                    CameraFoV = CameraFoV,
+                    CameraDistance = hasNose ? NoseDistance : HeadDistance,
+                    CameraHeight = 0f,
+                    CameraSide = 0f
+                };
+
+                return SoldierPortraitUtil.RenderSoldierNoCopy(subject, renderParams, null);
             }
             finally
             {
-                RestoreCameraState(usedCamera, cameraState);
-
-                if (hiddenVisuals != null)
+                if (lightRig != null)
                 {
-                    foreach (Renderer restored in hiddenVisuals)
-                    {
-                        if (restored != null)
-                        {
-                            restored.enabled = true;
-                        }
-                    }
+                    UnityEngine.Object.Destroy(lightRig);
                 }
 
-                if (syntheticRig != null)
-                {
-                    UnityEngine.Object.Destroy(syntheticRig);
-                }
-
-                foreach (Light light in worldLightsToRestore)
+                foreach (Light light in disabledLights)
                 {
                     if (light != null)
                     {
@@ -780,7 +611,6 @@ namespace TFTV.TFTVIncidents
                     }
                 }
 
-                lightsPicker?.DisableAllControlledLights();
                 RenderSettings.ambientMode = ambientModeBefore;
                 RenderSettings.ambientLight = ambientLightBefore;
                 RenderSettings.ambientIntensity = ambientIntensityBefore;
@@ -789,22 +619,54 @@ namespace TFTV.TFTVIncidents
         }
 
         /// <summary>
-        /// Three-point portrait rig out of directional lights, parented to the character so the angles
-        /// stay relative to where the face points. Directional lights are position-independent, so they
-        /// work at the far-away render origin where scene point/spot lights cannot reach. Angles are
-        /// kept close to horizontal so the top of the head does not blow out.
+        /// Turns on the rig's built-in character light (what lights the model on the personnel screen).
+        /// It is far too dim to carry a portrait on its own, so it only supplements the portrait rig.
         /// </summary>
-        private static GameObject CreatePortraitLightRig(Transform character)
+        private static void EnableCharacterLight(AddonsCharacterBuilder builder, string lightObjectName)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(lightObjectName))
+                {
+                    return;
+                }
+
+                Transform lightTransform = builder.AddonsManager?.FindTransform(lightObjectName, rigBonesOnly: true);
+                Light characterLight = lightTransform != null ? lightTransform.GetComponent<Light>() : null;
+                if (characterLight == null)
+                {
+                    return;
+                }
+
+                characterLight.gameObject.SetActive(true);
+                characterLight.enabled = true;
+                if (LightingSettingsCharacters.Instance != null)
+                {
+                    characterLight.intensity = LightingSettingsCharacters.Instance.CharacterLightsIntensity;
+                }
+            }
+            catch (Exception e)
+            {
+                TFTVLogger.Error(e);
+            }
+        }
+
+        /// <summary>
+        /// Three-point portrait rig of directional lights, parented to the subject so the angles stay
+        /// relative to where the face points. Directional lights are position-independent, so they work
+        /// at the staging origin where scene point/spot lights cannot reach. Angles are kept close to
+        /// horizontal so the top of the head does not blow out.
+        /// </summary>
+        private static GameObject CreatePortraitLightRig(Transform subject)
         {
             GameObject rig = new GameObject("[TFTV]PortraitLightRig");
-            rig.transform.SetParent(character, false);
+            rig.transform.SetParent(subject, false);
 
-            // Key: warm, from the character's front-left, slightly above eye level.
+            // Key: warm, from the front-left, slightly above eye level.
             AddRigLight(rig.transform, "Key", new Vector3(15f, 205f, 0f), new Color(1f, 0.96f, 0.90f), 1.05f);
-            // Fill: cool and soft, from the front-right, at eye level — also lifts the armor.
+            // Fill: cool and soft, from the front-right, at eye level - also lifts the armour.
             AddRigLight(rig.transform, "Fill", new Vector3(5f, 150f, 0f), new Color(0.78f, 0.82f, 0.92f), 0.55f);
-            // Rim: from behind at eye level, separates hair/shoulders from the dark background.
-            // Kept low so it does not burn bright edges onto the face.
+            // Rim: from behind at eye level, separating hair and shoulders from the dark background.
             AddRigLight(rig.transform, "Rim", new Vector3(0f, 20f, 0f), new Color(0.90f, 0.93f, 1f), 0.20f);
 
             return rig;
@@ -823,415 +685,9 @@ namespace TFTV.TFTVIncidents
             light.shadows = LightShadows.None;
         }
 
-        private static Texture2D RenderWithAnchorFallback(GameObject characterObject, Camera usedCamera, Vector2Int resolution)
-        {
-            string[] anchors = { "Nose", "Jaw", "Head" };
-            float[] distances = { Profile.NoseDistance, Profile.JawDistance, Profile.HeadDistance };
-
-            for (int i = 0; i < anchors.Length; i++)
-            {
-                var p = new SquadPortraitsDef.RenderPortraitParams
-                {
-                    RenderedPortraitsResolution = resolution,
-                    TargetBoneName = anchors[i],
-                    CameraFoV = Profile.CameraFoV,
-                    CameraDistance = distances[i],
-                    CameraHeight = 0f,
-                    CameraSide = 0f
-                };
-
-                Texture2D t = SoldierPortraitUtil.RenderSoldierNoCopy(characterObject, p, usedCamera);
-                if (t != null)
-                {
-                    return t;
-                }
-            }
-
-            // Last chance: explicit head render. SoldierPortraitUtil will fallback to root if bone is missing.
-            var fallback = new SquadPortraitsDef.RenderPortraitParams
-            {
-                RenderedPortraitsResolution = resolution,
-                TargetBoneName = "Head",
-                CameraFoV = Profile.CameraFoV,
-                CameraDistance = Profile.HeadDistance,
-                CameraHeight = 0f,
-                CameraSide = 0f
-            };
-
-            return SoldierPortraitUtil.RenderSoldierNoCopy(characterObject, fallback, usedCamera);
-        }
-
-        private static AddonsCharacterBuilder ResolveSourceBuilder(GeoLevelController level)
-        {
-            AddonsCharacterBuilder captureBuilder = level.SceneReferences.UICaptureEnvironment?.CharacterBuilder;
-            if (captureBuilder != null)
-            {
-                return captureBuilder;
-            }
-
-            Debug.LogWarning($"{LogPrefix} UICaptureEnvironment is missing; falling back to SquadBay.CharacterBuilder.");
-            return level.SceneReferences.SquadBay?.CharacterBuilder;
-        }
-
-        /// <summary>
-        /// Moves the character (and everything under it) onto an isolated layer and returns a private
-        /// camera that renders only that layer. RenderingEnvironment never restricts the culling mask,
-        /// so a shared camera captures whatever else happens to sit at the render origin — which is how
-        /// the personnel screen's model and backdrop ended up in the portrait. The clone is destroyed
-        /// after the render, so its layers do not need restoring.
-        /// </summary>
-        // Original layers of everything moved for an isolated render, so a fallback render can undo it.
-        private static readonly List<KeyValuePair<GameObject, int>> _isolatedLayers = new List<KeyValuePair<GameObject, int>>();
-
-        private static void RecordLayer(GameObject target)
-        {
-            if (target != null)
-            {
-                _isolatedLayers.Add(new KeyValuePair<GameObject, int>(target, target.layer));
-            }
-        }
-
-        private static void RestoreIsolatedLayers()
-        {
-            foreach (KeyValuePair<GameObject, int> entry in _isolatedLayers)
-            {
-                if (entry.Key != null)
-                {
-                    entry.Key.layer = entry.Value;
-                }
-            }
-
-            _isolatedLayers.Clear();
-        }
-
-        /// <summary>
-        /// True when the render actually produced something — sampled sparsely, since a fully
-        /// transparent result means the camera saw nothing.
-        /// </summary>
-        private static bool HasVisibleContent(Texture2D texture)
-        {
-            try
-            {
-                if (texture == null)
-                {
-                    return false;
-                }
-
-                Color32[] pixels = texture.GetPixels32();
-                if (pixels == null || pixels.Length == 0)
-                {
-                    return false;
-                }
-
-                int visible = 0;
-                int step = Mathf.Max(1, pixels.Length / 4096);
-                for (int i = 0; i < pixels.Length; i += step)
-                {
-                    if (pixels[i].a > 16)
-                    {
-                        visible++;
-                        if (visible > 16)
-                        {
-                            return true;
-                        }
-                    }
-                }
-
-                TFTVLogger.Always($"{LogPrefix} Render appears empty (visible samples={visible}).");
-                return false;
-            }
-            catch (Exception e)
-            {
-                TFTVLogger.Error(e);
-                return true;
-            }
-        }
-
-        private static readonly string[] CustomizationColorParams =
-        {
-            "_PrimaryColor",
-            "_SecondaryColor",
-            "_HairColor",
-            "_IrisColor"
-        };
-
-        /// <summary>
-        /// Diagnostic: dumps the customization colors currently on a builder's items, so the clone can
-        /// be compared against the builder the personnel screen itself uses.
-        /// </summary>
-        private static void LogBuilderTint(AddonsCharacterBuilder builder, string label)
-        {
-            try
-            {
-                AddonsManager manager = builder?.AddonsManager;
-                if (manager?.RootAddon == null)
-                {
-                    TFTVLogger.Always($"{LogPrefix} [{label}] no addons manager/root to inspect.");
-                    return;
-                }
-
-                int logged = 0;
-                foreach (Addon addon in manager.RootAddon)
-                {
-                    Item item = addon as Item;
-                    if (item?.VisualRoot == null || logged >= 4)
-                    {
-                        continue;
-                    }
-
-                    Renderer renderer = item.GetHighlightableRenderers().FirstOrDefault();
-                    if (renderer == null)
-                    {
-                        continue;
-                    }
-
-                    MaterialPropertyBlock block = new MaterialPropertyBlock();
-                    renderer.GetPropertyBlock(block);
-
-                    string values = string.Join(" ", CustomizationColorParams
-                        .Select(param => $"{param}={block.GetColor(param)}")
-                        .ToArray());
-
-                    TFTVLogger.Always($"{LogPrefix} [{label}] item={item.ItemDef?.name ?? "null"} {values}");
-                    logged++;
-                }
-            }
-            catch (Exception e)
-            {
-                TFTVLogger.Error(e);
-            }
-        }
-
-        /// <summary>
-        /// Finds the first palette that actually knows this tag. Vanilla picks a single palette up
-        /// front and takes its fallback when the tag is absent, which is what leaves faction-coloured
-        /// armor flat grey.
-        /// </summary>
-        private static bool TryResolveCustomizationColor(HumanCustomizationDef customization, CustomizationColorTagDef colorTag, out Color color)
-        {
-            CustomizationColorPaletteDef[] palettes =
-            {
-                customization.CustomizationPaletteDef,
-                customization.NPCPaletteDef,
-                customization.FancyVehicleCustomizationPaletteDef
-            };
-
-            foreach (CustomizationColorPaletteDef palette in palettes)
-            {
-                if (palette == null)
-                {
-                    continue;
-                }
-
-                Color candidate = palette.MatchColor(colorTag);
-                if (candidate != palette.FallbackColor)
-                {
-                    color = candidate;
-                    return true;
-                }
-            }
-
-            color = Color.white;
-            return false;
-        }
-
-        /// <summary>
-        /// Writes each renderer's own material color back into its property block for the given
-        /// parameters, undoing a fallback tint that was applied for a tag no palette matched.
-        /// </summary>
-        private static void RestoreMaterialColors(Item item, List<CustomizationColorTagDef> colorTags)
-        {
-            if (colorTags == null || colorTags.Count == 0)
-            {
-                return;
-            }
-
-            foreach (Renderer renderer in item.GetHighlightableRenderers())
-            {
-                if (renderer == null || renderer is ParticleSystemRenderer)
-                {
-                    continue;
-                }
-
-                Material material = renderer.sharedMaterial;
-                if (material == null)
-                {
-                    continue;
-                }
-
-                MaterialPropertyBlock block = new MaterialPropertyBlock();
-                renderer.GetPropertyBlock(block);
-
-                bool changed = false;
-                foreach (CustomizationColorTagDef colorTag in colorTags)
-                {
-                    if (!string.IsNullOrEmpty(colorTag.ShaderParamName) && material.HasProperty(colorTag.ShaderParamName))
-                    {
-                        block.SetColor(colorTag.ShaderParamName, material.GetColor(colorTag.ShaderParamName));
-                        changed = true;
-                    }
-                }
-
-                if (changed)
-                {
-                    renderer.SetPropertyBlock(block);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Applies the customization colors directly to every built item. Item.RefreshTags() skips
-        /// colors whenever the merged tags carry the conditional-customization tag (which this
-        /// character has) unless the item opts in with AlwaysCustomizeColor, which leaves armor
-        /// looking untinted in the portrait.
-        /// </summary>
-        private static void ForceApplyCustomizationColors(AddonsManager manager, List<GameTagDef> mergeable)
-        {
-            try
-            {
-                SharedGameTagsDataDef shared = GameUtl.GameComponent<SharedData>()?.SharedGameTags;
-                HumanCustomizationDef customization = shared?.HumanCustomization;
-                if (customization == null || manager?.RootAddon == null)
-                {
-                    return;
-                }
-
-                bool anyFancy = mergeable.Any(tag => tag is CustomizationFancyTagDef);
-                int customized = 0;
-                int skipped = 0;
-
-                foreach (Addon addon in manager.RootAddon)
-                {
-                    Item item = addon as Item;
-                    if (item?.VisualRoot == null)
-                    {
-                        continue;
-                    }
-
-                    HighlightControllerComponent controller = item.VisualRoot.gameObject.GetComponent<HighlightControllerComponent>();
-                    if (controller == null)
-                    {
-                        continue;
-                    }
-
-                    controller.StartCustomization();
-                    List<CustomizationColorTagDef> unmatched = new List<CustomizationColorTagDef>();
-
-                    foreach (GameTagDef tag in mergeable)
-                    {
-                        CustomizationColorTagDef colorTag = tag as CustomizationColorTagDef;
-                        if (colorTag != null)
-                        {
-                            if (TryResolveCustomizationColor(customization, colorTag, out Color color))
-                            {
-                                controller.CustomizeColor(colorTag.ShaderParamName, color);
-                            }
-                            else
-                            {
-                                // No palette knows this tag. Item.RefreshTags has already written the
-                                // palette fallback (flat grey) for it, so put the material's own color
-                                // back rather than leaving the armor washed out.
-                                unmatched.Add(colorTag);
-                                skipped++;
-                            }
-
-                            continue;
-                        }
-
-                        CustomizationFancyTagDef fancyTag = tag as CustomizationFancyTagDef;
-                        if (fancyTag != null)
-                        {
-                            controller.CustomizeFancy(fancyTag);
-                            continue;
-                        }
-
-                        CustomizationPatternTagDef patternTag = tag as CustomizationPatternTagDef;
-                        if (patternTag != null)
-                        {
-                            controller.CustomizePattern(patternTag);
-                        }
-                    }
-
-                    controller.ApplyCustomization();
-                    RestoreMaterialColors(item, unmatched);
-                    customized++;
-                }
-
-                TFTVLogger.Always($"{LogPrefix} Force-applied customization to {customized} item(s); skipped {skipped} unmatched color(s), anyFancy={anyFancy}.");
-            }
-            catch (Exception e)
-            {
-                TFTVLogger.Error(e);
-            }
-        }
-
-        /// <summary>
-        /// Moves the character's renderers onto a free layer so the portrait camera can be narrowed
-        /// to just them. Original layers are recorded BEFORE anything is changed, so they can be put
-        /// back if the isolated render turns out empty.
-        /// </summary>
-        private static bool TryIsolateOnFreeLayer(GameObject characterObject, out int layer)
-        {
-            layer = ResolveIsolationLayer();
-            if (layer < 0)
-            {
-                TFTVLogger.Always($"{LogPrefix} No free layer for portrait isolation; rendering without it.");
-                return false;
-            }
-
-            // Culling keys off each renderer's own GameObject layer, so move those explicitly rather
-            // than trusting that every visual is a transform child of the builder.
-            Renderer[] renderers = characterObject.GetComponentsInChildren<Renderer>(true);
-            if (renderers == null || renderers.Length == 0)
-            {
-                TFTVLogger.Always($"{LogPrefix} No renderers under the builder; rendering without isolation.");
-                return false;
-            }
-
-            _isolatedLayers.Clear();
-            foreach (Transform transform in characterObject.GetComponentsInChildren<Transform>(true))
-            {
-                RecordLayer(transform?.gameObject);
-            }
-
-            foreach (Renderer renderer in renderers)
-            {
-                RecordLayer(renderer?.gameObject);
-            }
-
-            SetLayerRecursively(characterObject, layer);
-            foreach (Renderer renderer in renderers)
-            {
-                if (renderer != null)
-                {
-                    renderer.gameObject.layer = layer;
-                }
-            }
-
-            TFTVLogger.Always($"{LogPrefix} Isolated {renderers.Length} renderer(s) on layer {layer} for the portrait render.");
-            return true;
-        }
-
-        /// <summary>
-        /// Highest layer with no name assigned — unnamed layers are unused by the project, so nothing
-        /// else in the scene renders on it.
-        /// </summary>
-        private static int ResolveIsolationLayer()
-        {
-            for (int layer = 31; layer >= 8; layer--)
-            {
-                if (string.IsNullOrEmpty(LayerMask.LayerToName(layer)))
-                {
-                    return layer;
-                }
-            }
-
-            return -1;
-        }
-
         private static void SetLayerRecursively(GameObject target, int layer)
         {
-            if (target == null)
+            if (target == null || layer < 0)
             {
                 return;
             }
@@ -1243,152 +699,26 @@ namespace TFTV.TFTVIncidents
             }
         }
 
-        private static Camera ResolvePortraitCamera(GeoLevelController level, LightsPicker lightsPicker, GameObject characterObject)
+        /// <summary>
+        /// Same test as UIModuleActorCycle.IsHelmetOrAttachment.
+        /// </summary>
+        private static bool IsHelmetOrAttachment(ItemDef armourItem)
         {
-            Camera camera = lightsPicker?.UsedCamera;
-            if (camera != null)
-            {
-                return camera;
-            }
-
-            camera = level.SceneReferences.UICaptureEnvironment?.CameraArm?.CaptureCamera;
-            if (camera != null)
-            {
-                return camera;
-            }
-
-            camera = characterObject.GetComponentsInChildren<Camera>(true).FirstOrDefault();
-            if (camera != null)
-            {
-                return camera;
-            }
-
-            Debug.LogWarning($"{LogPrefix} No portrait camera found; allowing SoldierPortraitUtil to create an internal camera.");
-            return null;
-        }
-
-        private static CameraState CaptureCameraState(Camera camera)
-        {
-            if (camera == null)
-            {
-                return default(CameraState);
-            }
-
-            return new CameraState
-            {
-                FieldOfView = camera.fieldOfView,
-                NearClipPlane = camera.nearClipPlane,
-                FarClipPlane = camera.farClipPlane,
-                AllowHDR = camera.allowHDR,
-                CullingMask = camera.cullingMask
-            };
-        }
-
-        private static void ApplyCameraOverrides(Camera camera)
-        {
-            if (camera == null)
-            {
-                return;
-            }
-
-            // Only clamp the clip planes for the close-up; FoV comes from the render params
-            // and HDR is left as-is, matching the vanilla portrait path.
-            camera.nearClipPlane = Mathf.Min(camera.nearClipPlane, Profile.MinCameraNearClip);
-            camera.farClipPlane = Mathf.Min(camera.farClipPlane, Profile.MaxCameraFarClip);
-        }
-
-        private static void RestoreCameraState(Camera camera, CameraState state)
-        {
-            if (camera == null)
-            {
-                return;
-            }
-
-            camera.fieldOfView = state.FieldOfView;
-            camera.nearClipPlane = state.NearClipPlane;
-            camera.farClipPlane = state.FarClipPlane;
-            camera.allowHDR = state.AllowHDR;
-            camera.cullingMask = state.CullingMask;
-        }
-
-        private static Texture2D ApplyPostProcess(Texture2D source, float gamma, float contrast, float sharpen)
-        {
-            if (source == null)
-            {
-                return null;
-            }
-
-            Texture2D output = new Texture2D(source.width, source.height, TextureFormat.RGBA32, false);
-            for (int y = 0; y < source.height; y++)
-            {
-                for (int x = 0; x < source.width; x++)
-                {
-                    Color c = source.GetPixel(x, y);
-                    c.r = Mathf.Pow(Mathf.Clamp01(c.r), gamma);
-                    c.g = Mathf.Pow(Mathf.Clamp01(c.g), gamma);
-                    c.b = Mathf.Pow(Mathf.Clamp01(c.b), gamma);
-
-                    c.r = Mathf.Clamp01((c.r - 0.5f) * contrast + 0.5f);
-                    c.g = Mathf.Clamp01((c.g - 0.5f) * contrast + 0.5f);
-                    c.b = Mathf.Clamp01((c.b - 0.5f) * contrast + 0.5f);
-
-                    if (x > 0 && x < source.width - 1 && y > 0 && y < source.height - 1)
-                    {
-                        Color n = source.GetPixel(x, y + 1);
-                        Color s = source.GetPixel(x, y - 1);
-                        Color e = source.GetPixel(x + 1, y);
-                        Color w = source.GetPixel(x - 1, y);
-                        Color edge = (n + s + e + w) * 0.25f;
-                        c = Color.Lerp(c, c + (c - edge), sharpen);
-                        c.r = Mathf.Clamp01(c.r);
-                        c.g = Mathf.Clamp01(c.g);
-                        c.b = Mathf.Clamp01(c.b);
-                    }
-
-                    output.SetPixel(x, y, c);
-                }
-            }
-
-            output.Apply(false, false);
-            return output;
-        }
-
-        private static bool IsHelmetOrAttachment(ItemDef armorItem)
-        {
-            if (armorItem?.RequiredSlotBinds == null)
+            if (armourItem?.RequiredSlotBinds == null)
             {
                 return false;
             }
 
-            bool headAttachment = false;
-            bool headSlot = false;
-
-            foreach (AddonDef.RequiredSlotBind slotBind in armorItem.RequiredSlotBinds)
+            foreach (AddonDef.RequiredSlotBind slotBind in armourItem.RequiredSlotBinds)
             {
                 ItemSlotDef slot = slotBind.RequiredSlot as ItemSlotDef;
-                if (slot == null)
+                if (slot != null && (slot.SlotName == "Head" || slot.SlotName == "HeadAttachment"))
                 {
-                    continue;
-                }
-
-                if (slot.SlotName == "HeadAttachment")
-                {
-                    headAttachment = true;
-                }
-                else if (slot.SlotName == "Head")
-                {
-                    headSlot = true;
+                    return true;
                 }
             }
 
-            if (headAttachment)
-            {
-                return true;
-            }
-
-            // For portraits, any item occupying the head slot is prone to detached-mesh artifacts.
-            // Keep the actual face via tags; remove head-slot equipment entirely.
-            return headSlot;
+            return false;
         }
 
         private static CoroutineRunner GetCoroutineRunner()
@@ -1399,35 +729,11 @@ namespace TFTV.TFTVIncidents
                 return null;
             }
 
-            CoroutineRunner runner = level.GetComponent<CoroutineRunner>();
-            return runner ?? level.gameObject.AddComponent<CoroutineRunner>();
+            return level.GetComponent<CoroutineRunner>() ?? level.gameObject.AddComponent<CoroutineRunner>();
         }
 
         private sealed class CoroutineRunner : MonoBehaviour
         {
-        }
-
-        private struct PortraitRenderProfile
-        {
-            public float CameraFoV;
-            public float NoseDistance;
-            public float JawDistance;
-            public float HeadDistance;
-            public float MinCameraNearClip;
-            public float MaxCameraFarClip;
-            public bool ApplyPostProcess;
-            public float PostGamma;
-            public float PostContrast;
-            public float PostSharpen;
-        }
-
-        private struct CameraState
-        {
-            public float FieldOfView;
-            public float NearClipPlane;
-            public float FarClipPlane;
-            public bool AllowHDR;
-            public int CullingMask;
         }
     }
 }


### PR DESCRIPTION
## What this fixes

**Stale renders mixed into the portrait.** `Player.log` shows `UICaptureEnvironment is missing; falling back to SquadBay.CharacterBuilder` — the generator was cloning *the personnel screen's own* character builder. `Object.Instantiate` copies the meshes that builder is currently displaying, and those copies belong to no addons manager, so nothing ever removes them: they render alongside the operative. That is exactly why it only happened after visiting the personnel screen, which is what leaves meshes on that builder.

**Armour not showing its customization.** The generator had grown its own reimplementation of the game's colour rules — a three-palette search, a forced customization pass and a material-colour restore. `TFTV.log` shows the result: one operative's armour ended up carrying alpha-0 *material default* colours, while another's matched the personnel screen exactly. Colours now come from the game's own `Item.RefreshTags`, so a portrait shows what the personnel screen shows.

## What changed

- **Own builder, created from nothing** (`CreateSubjectBuilder`) instead of cloning a scene builder — no inherited meshes, ever.
- **The build is vanilla verbatim**: `UIModuleActorCycle.DisplaySoldier` plus its `OnCharacterRebuilded` step, with `RefreshAddonTags` (the exact body of `AddonsManager.OnGameTagsChanged`) so the customization pass no longer depends on the tag list's change bookkeeping firing.
- **`HideCoveredAddonVisuals`** reapplies the engine's own hide policy after the build, so a bare torso or arm cannot show through the armour covering it.
- **Render simplified**: subject forced onto the Characters layer, world lights off, three-point rig, one call.

## Removed, and why

`SoldierFrame.FrameCamera` — which runs *inside* the vanilla renderer, after our code sets the mask — overwrites `camera.cullingMask` with the Characters layer and clips at 2.5 m. So the layer-isolation path could only ever produce an empty image (hence the fallback it needed), and disabling ~981 scene renderers per portrait bought nothing: nothing off that layer, or beyond 2.5 m of the staging origin, can reach the render.

Gone with it: camera state capture/override/restore, empty-render detection and retry, the post-process pass, and the anchor-fallback loop (dead code — `RenderSoldierNoCopy` never returns null). The ~120 lines of tint diagnostics are replaced by one log line per portrait naming the parts the operative is built from.

1433 → 739 lines (−945/+251).

## For the reviewer

Compile-verified only — the game was not run. Worth knowing when testing: colours now match the personnel screen by construction. If an operative's armour still looks flat, it will look flat on the personnel screen too — with the conditional-customization tag present, vanilla only recolours items whose def sets `AlwaysCustomizeColor`. The new log line says which parts were built, which is the fastest way to tell that case apart from a real regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
