### PR TITLE
Portraits: take the armour colours from the faction, not just the identity

### DIFF
--- a/TFTV/TFTVIncidents/PortraitGenerator.cs
+++ b/TFTV/TFTVIncidents/PortraitGenerator.cs
@@ -351,12 +351,23 @@ namespace TFTV.TFTVIncidents
                 manager.GameTags.AddRange(displayData.GameTags);
 
                 // A character's own tag list can still be carrying the template's default
-                // customization - flat grey armour, no pattern - because GeoCharacter.ReinitTags
-                // applies the identity's tags last and only runs when the character's stats are
-                // recalculated. Opening the personnel screen is one of the things that triggers it,
-                // which is why a portrait taken beforehand came out uncustomized and the same
-                // operative looked right afterwards. Merge the identity over the character's tags
-                // the way ReinitTags does, on our own builder's list rather than on the character.
+                // customization - flat grey armour - because GeoCharacter.ReinitTags composes it as
+                // template tags, then the faction's unit tags, then the identity's, and only runs
+                // when the character's stats are recalculated. An operative whose list was last
+                // built before its faction was known keeps the template's grey, which is what the
+                // portrait was rendering; opening the personnel screen forces a recalculation, which
+                // is why the same operative looked right there and afterwards here too.
+                //
+                // Redo those last two steps in the same order on our own list, leaving the character
+                // untouched. The faction supplies the armour colours for an ordinary soldier; the
+                // identity overrides them for anyone actually customized, and an authored character
+                // (whose colours are template tags) keeps what they came with.
+                GeoFactionDef factionDef = character.Faction?.Def;
+                if (factionDef != null)
+                {
+                    manager.GameTags.MergeRange(factionDef.UnitsAdditionalTags, GameTagAddMode.ReplaceExistingExclusive);
+                }
+
                 character.Identity?.ApplyGameTags(manager.GameTags);
 
                 // Helmets and head attachments hide the face the portrait is about; this is vanilla's
@@ -393,6 +404,8 @@ namespace TFTV.TFTVIncidents
                 // in here (a bare body part next to the armour that covers it, a missing armour piece)
                 // is what a wrong-looking portrait will be made of too.
                 TFTVLogger.Always($"{LogPrefix} {character.DisplayName} built from {string.Join(", ", VisibleItemNames(manager))} " +
+                    $"| faction {factionDef?.name ?? "none"} (customization tags: " +
+                    $"{factionDef?.UnitsAdditionalTags?.Count(tag => tag is CustomizationTagDef) ?? 0}) " +
                     $"| customization {string.Join(", ", CustomizationTagNames(manager))}");
 
                 // Let the skinned meshes settle into the pose before the render.


### PR DESCRIPTION
Third and final piece of the portrait work: #39 fixed the stale renders, #41 applied the character's identity to the build, and this supplies the step between them that actually carries armour colour.

## What the last run showed

With #41 in, every operative still built with `CustomizationColorTagDef_0` — the palette's grey default — except one:

```
Angel  ... | customization CustomizationHairColorTagDef_1, CustomizationEyeColorTagDef_1,
             CustomizationColorTagDef_0, CustomizationSecondaryColorTagDef_0, CustomizationPatternTagDef_3
Sophia ... | customization CustomizationHairColorTagDef_3, CustomizationEyeColorTagDef_0,
             CustomizationColorTagDef_5, CustomizationSecondaryColorTagDef_7, CustomizationPatternTagDef_1
```

Sophia is an authored character whose colours are template tags (the same way TFTV sets Harlson's in `TFTVDefsInjectedOnlyOnce`), so she was never evidence that the identity path worked. Hair, eyes and patterns *do* vary per operative, so the identity merge from #41 lands correctly — it simply has nothing to say about armour colour.

## Where armour colour actually comes from

`GeoCharacter.ReinitTags` composes a character's tag list in three steps:

```
template tags  ->  FactionDef.UnitsAdditionalTags  ->  identity tags
```

The first and third were covered; the middle one was missing. It is also the only remaining candidate: the character's list held the faction's colour tag right after their personnel screen had been opened, and applying the identity yields the template grey, so the identity's colour tags are null and the template supplies only grey.

## The change

```csharp
GeoFactionDef factionDef = character.Faction?.Def;
if (factionDef != null)
{
    manager.GameTags.MergeRange(factionDef.UnitsAdditionalTags, GameTagAddMode.ReplaceExistingExclusive);
}

character.Identity?.ApplyGameTags(manager.GameTags);
```

Same order `ReinitTags` uses, still applied to **our builder's** tag list rather than to the character, so rendering a portrait has no side effects on game state. An ordinary soldier takes the faction's colours; a customized one is overridden by their identity; an authored character keeps the colours their template carries.

## For the reviewer

The per-portrait log line now names the faction and counts the customization tags it carries:

```
Angel built from ... | faction PX_GeoFactionDef (customization tags: 3) | customization CustomizationColorTagDef_8, ...
```

That is deliberate: if this still renders grey, a `0` in that field says the colours live on `GeoFactionViewDef.PrimaryColorTag`/`SecondaryColorTag` instead — the pair `CharacterIdentity.ApplyFactionCustomization` writes into identities — and that is a one-line follow-up rather than another diagnostic round-trip.

Underlying all of this: these characters' tag lists are stale because `ReinitTags` only runs when stats are recalculated. Anything else in the mod reading `character.GameTags` for appearance before that point sees the same defaults. Fixing it at the source would mean forcing a recalculation on those characters, which mutates game state — deliberately not done here.

Compile-verified; the diagnosis comes from real runs, the fix itself has not been play-tested yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
