### PR TITLE
Portraits: render with the scene camera so armour customization shows

### DIFF
--- a/TFTV/TFTVIncidents/PortraitGenerator.cs
+++ b/TFTV/TFTVIncidents/PortraitGenerator.cs
@@ -623,7 +623,15 @@ namespace TFTV.TFTVIncidents
                 EnableCharacterLight(builder, displayData.CharacterLightObjectName);
                 lightRig = CreatePortraitLightRig(subject.transform);
 
-                BlankSubjectForTest(subject);
+                // Apply the customization as the very last thing before the shutter. It is applied
+                // once already when the build finishes, but anything that re-creates an item's
+                // visuals after that point - a rebuild pass finishing late, a skin swapped when the
+                // merged tags changed - brings in fresh renderers with no property block on them, and
+                // the operative renders untinted. Forcing colours in a frame earlier proved to change
+                // nothing on screen while switching renderers off at this point blanked the portrait,
+                // which is what the gap between those two moments looks like.
+                RefreshAddonTags(builder.AddonsManager);
+                HideCoveredAddonVisuals(builder.AddonsManager);
 
                 bool hasNose = builder.AddonsManager?.FindTransform("Nose", rigBonesOnly: true) != null;
                 SquadPortraitsDef.RenderPortraitParams renderParams = new SquadPortraitsDef.RenderPortraitParams
@@ -658,34 +666,6 @@ namespace TFTV.TFTVIncidents
                 RenderSettings.ambientIntensity = ambientIntensityBefore;
                 RenderSettings.reflectionIntensity = reflectionBefore;
             }
-        }
-
-        // TEMPORARY EXPERIMENT - not a fix. Switches off every renderer on the subject in the instant
-        // before it is handed to the portrait renderer. Forcing magenta onto the built items changed
-        // nothing on screen, which leaves a blunter question: is the image we get actually this
-        // subject? A blank portrait means it is, and the paint is being ignored somewhere between the
-        // property block and the draw. A portrait that still shows the operative means the image comes
-        // from something else entirely, and nothing done to this subject was ever going to matter.
-        private const bool BlankSubjectForTestEnabled = true;
-
-        private static void BlankSubjectForTest(GameObject subject)
-        {
-            if (!BlankSubjectForTestEnabled)
-            {
-                return;
-            }
-
-            int disabled = 0;
-            foreach (Renderer renderer in subject.GetComponentsInChildren<Renderer>(true))
-            {
-                if (renderer != null && renderer.enabled)
-                {
-                    renderer.enabled = false;
-                    disabled++;
-                }
-            }
-
-            TFTVLogger.Always($"{LogPrefix} [test] disabled {disabled} renderer(s) on the subject before rendering.");
         }
 
         /// <summary>

--- a/TFTV/TFTVIncidents/PortraitGenerator.cs
+++ b/TFTV/TFTVIncidents/PortraitGenerator.cs
@@ -386,6 +386,7 @@ namespace TFTV.TFTVIncidents
 
                 manager.SetAutorefreshOnTagsChanged(true);
                 RefreshAddonTags(manager);
+                ForceTestColours(manager);
                 HideCoveredAddonVisuals(manager);
                 ApplyFaceCorruption(builder, character, level);
                 CommonCharacterUtils.ResetCharacterAnimation(builder);
@@ -491,6 +492,43 @@ namespace TFTV.TFTVIncidents
                 .Where(item => item.VisualRoot != null && item.VisualRoot.gameObject.activeSelf)
                 .Select(item => item.ItemDef?.name ?? "?")
                 .ToArray();
+        }
+
+        // TEMPORARY EXPERIMENT - not a fix. Paints every built item in colours nothing in the game
+        // would ever choose, through the same HighlightController calls Item.RefreshTags uses. If the
+        // portrait comes out magenta and green, the customization pipeline reaches the pixels and the
+        // argument is only ever about which colour the tags resolve to. If it comes out unchanged, the
+        // paint is being ignored or overwritten somewhere after we apply it, and the material on the
+        // renderer is the next thing to look at rather than the tags. Set to false to disable.
+        private const bool ForceTestColoursEnabled = true;
+
+        private static void ForceTestColours(AddonsManager manager)
+        {
+            if (!ForceTestColoursEnabled || manager?.RootAddon == null)
+            {
+                return;
+            }
+
+            int painted = 0;
+            foreach (Item item in manager.RootAddon.OfType<Item>())
+            {
+                HighlightControllerComponent controller = item.VisualRoot != null
+                    ? item.VisualRoot.gameObject.GetComponent<HighlightControllerComponent>()
+                    : null;
+
+                if (controller == null)
+                {
+                    continue;
+                }
+
+                controller.StartCustomization();
+                controller.CustomizeColor("_PrimaryColor", Color.magenta);
+                controller.CustomizeColor("_SecondaryColor", Color.green);
+                controller.ApplyCustomization();
+                painted++;
+            }
+
+            TFTVLogger.Always($"{LogPrefix} [test] forced magenta/green onto {painted} item(s).");
         }
 
         /// <summary>

--- a/TFTV/TFTVIncidents/PortraitGenerator.cs
+++ b/TFTV/TFTVIncidents/PortraitGenerator.cs
@@ -660,6 +660,14 @@ namespace TFTV.TFTVIncidents
                 // which is what the gap between those two moments looks like.
                 RefreshAddonTags(builder.AddonsManager);
                 HideCoveredAddonVisuals(builder.AddonsManager);
+                LogPatternState(builder.AddonsManager, "subject");
+
+                AddonsManager squadBay = GameUtl.CurrentLevel()?.GetComponent<GeoLevelController>()?
+                    .SceneReferences?.SquadBay?.CharacterBuilder?.AddonsManager;
+                if (squadBay != null)
+                {
+                    LogPatternState(squadBay, "squadbay");
+                }
 
                 bool hasNose = builder.AddonsManager?.FindTransform("Nose", rigBonesOnly: true) != null;
                 SquadPortraitsDef.RenderPortraitParams renderParams = new SquadPortraitsDef.RenderPortraitParams
@@ -693,6 +701,70 @@ namespace TFTV.TFTVIncidents
                 RenderSettings.ambientLight = ambientLightBefore;
                 RenderSettings.ambientIntensity = ambientIntensityBefore;
                 RenderSettings.reflectionIntensity = reflectionBefore;
+            }
+        }
+
+        // TEMPORARY - the customization screen shows this operative with a dark, patterned armour and
+        // the portrait shows the pale factory texture, from the same tags. Writing _PrimaryColor
+        // changed nothing even on the material, so the colours are almost certainly gated behind the
+        // pattern. Dump what the pattern tag carries and what actually reached the torso material and
+        // its property block, for our subject and for the squad bay builder when it holds a character
+        // (that one is the personnel screen's own model, the one that looks right).
+        private static void LogPatternState(AddonsManager manager, string label)
+        {
+            try
+            {
+                if (manager?.RootAddon == null)
+                {
+                    return;
+                }
+
+                CustomizationPatternTagDef pattern = manager.MergeWithAddonsTags.OfType<CustomizationPatternTagDef>().FirstOrDefault();
+                if (pattern == null)
+                {
+                    TFTVLogger.Always($"{LogPrefix} [pattern:{label}] no pattern tag in the merged tags.");
+                    return;
+                }
+
+                TFTVLogger.Always($"{LogPrefix} [pattern:{label}] tag={pattern.name} param={pattern.ShaderParamName} " +
+                    $"texture={(pattern.PatternTexture != null ? pattern.PatternTexture.name : "NULL")} " +
+                    $"tiling={pattern.TilingXName}/{pattern.TilingYName} extra={pattern.AdditionalParamName}");
+
+                foreach (Item item in manager.RootAddon.OfType<Item>())
+                {
+                    if (item.VisualRoot == null || !item.VisualRoot.gameObject.activeSelf)
+                    {
+                        continue;
+                    }
+
+                    Renderer renderer = item.GetHighlightableRenderers()?.FirstOrDefault(r => r != null && !(r is ParticleSystemRenderer));
+                    Material material = renderer != null ? renderer.sharedMaterial : null;
+                    if (material == null)
+                    {
+                        continue;
+                    }
+
+                    MaterialPropertyBlock block = new MaterialPropertyBlock();
+                    renderer.GetPropertyBlock(block);
+
+                    Texture blockTexture = block.GetTexture(pattern.ShaderParamName);
+                    Texture materialTexture = material.HasProperty(pattern.ShaderParamName)
+                        ? material.GetTexture(pattern.ShaderParamName)
+                        : null;
+
+                    TFTVLogger.Always($"{LogPrefix} [pattern:{label}] {item.ItemDef?.name} " +
+                        $"materialHasParam={material.HasProperty(pattern.ShaderParamName)} " +
+                        $"materialTex={(materialTexture != null ? materialTexture.name : "-")} " +
+                        $"blockTex={(blockTexture != null ? blockTexture.name : "-")} " +
+                        $"blockPrimary={block.GetColor("_PrimaryColor")} " +
+                        $"blockTilingX={block.GetFloat(pattern.TilingXName)} " +
+                        $"materialPrimary={(material.HasProperty("_PrimaryColor") ? material.GetColor("_PrimaryColor").ToString() : "-")}");
+                    break;
+                }
+            }
+            catch (Exception e)
+            {
+                TFTVLogger.Error(e);
             }
         }
 

--- a/TFTV/TFTVIncidents/PortraitGenerator.cs
+++ b/TFTV/TFTVIncidents/PortraitGenerator.cs
@@ -624,13 +624,10 @@ namespace TFTV.TFTVIncidents
                 EnableCharacterLight(builder, displayData.CharacterLightObjectName);
                 lightRig = CreatePortraitLightRig(subject.transform);
 
-                // Apply the customization as the very last thing before the shutter. It is applied
-                // once already when the build finishes, but anything that re-creates an item's
-                // visuals after that point - a rebuild pass finishing late, a skin swapped when the
-                // merged tags changed - brings in fresh renderers with no property block on them, and
-                // the operative renders untinted. Forcing colours in a frame earlier proved to change
-                // nothing on screen while switching renderers off at this point blanked the portrait,
-                // which is what the gap between those two moments looks like.
+                // Belt and braces, not the fix: the customization is already applied when the build
+                // finishes, and this re-applies it in case anything re-created an item's visuals
+                // since - a rebuild pass finishing late, a skin swapped when the merged tags changed
+                // - which would leave fresh renderers with no property block on them.
                 RefreshAddonTags(builder.AddonsManager);
                 HideCoveredAddonVisuals(builder.AddonsManager);
                 return CapturePortrait(builder, resolution);

--- a/TFTV/TFTVIncidents/PortraitGenerator.cs
+++ b/TFTV/TFTVIncidents/PortraitGenerator.cs
@@ -1,4 +1,6 @@
-﻿using Base.Core;
+﻿using Base.Cameras;
+
+using Base.Core;
 using PhoenixPoint.Common.Core;
 using PhoenixPoint.Common.Entities;
 using PhoenixPoint.Common.Entities.Addons;
@@ -14,7 +16,6 @@ using PhoenixPoint.Geoscape.View.ViewModules;
 using PhoenixPoint.Tactical.Entities;
 using PhoenixPoint.Tactical.Entities.Animations;
 using PhoenixPoint.Tactical.Entities.Equipments;
-using PhoenixPoint.Tactical.UI.SoldierPortraits;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -291,8 +292,6 @@ namespace TFTV.TFTVIncidents
                 rendered.filterMode = FilterMode.Trilinear;
                 rendered.anisoLevel = 4;
 
-                DumpPortraitForInspection(rendered, character);
-
                 onDone?.Invoke(Sprite.Create(
                     rendered,
                     new Rect(0f, 0f, rendered.width, rendered.height),
@@ -302,32 +301,6 @@ namespace TFTV.TFTVIncidents
             finally
             {
                 UnityEngine.Object.Destroy(builder.gameObject);
-            }
-        }
-
-        // TEMPORARY - writes the finished portrait to disk so the render can be looked at directly
-        // instead of described. Every theory so far has been argued from log numbers; this shows what
-        // the camera actually produced: the framing, what is in shot, and what colour it came out.
-        private const bool DumpPortraitsEnabled = true;
-
-        private static void DumpPortraitForInspection(Texture2D portrait, GeoCharacter character)
-        {
-            if (!DumpPortraitsEnabled || portrait == null)
-            {
-                return;
-            }
-
-            try
-            {
-                string name = string.Join("_", (character.DisplayName ?? "unknown")
-                    .Split(System.IO.Path.GetInvalidFileNameChars()));
-                string path = System.IO.Path.Combine(Application.persistentDataPath, $"TFTV_Portrait_{name}.png");
-                System.IO.File.WriteAllBytes(path, portrait.EncodeToPNG());
-                TFTVLogger.Always($"{LogPrefix} [test] wrote {path}");
-            }
-            catch (Exception e)
-            {
-                TFTVLogger.Error(e);
             }
         }
 
@@ -660,27 +633,7 @@ namespace TFTV.TFTVIncidents
                 // which is what the gap between those two moments looks like.
                 RefreshAddonTags(builder.AddonsManager);
                 HideCoveredAddonVisuals(builder.AddonsManager);
-                LogPatternState(builder.AddonsManager, "subject");
-
-                AddonsManager squadBay = GameUtl.CurrentLevel()?.GetComponent<GeoLevelController>()?
-                    .SceneReferences?.SquadBay?.CharacterBuilder?.AddonsManager;
-                if (squadBay != null)
-                {
-                    LogPatternState(squadBay, "squadbay");
-                }
-
-                bool hasNose = builder.AddonsManager?.FindTransform("Nose", rigBonesOnly: true) != null;
-                SquadPortraitsDef.RenderPortraitParams renderParams = new SquadPortraitsDef.RenderPortraitParams
-                {
-                    RenderedPortraitsResolution = resolution,
-                    TargetBoneName = hasNose ? "Nose" : "Head",
-                    CameraFoV = CameraFoV,
-                    CameraDistance = hasNose ? NoseDistance : HeadDistance,
-                    CameraHeight = 0f,
-                    CameraSide = 0f
-                };
-
-                return SoldierPortraitUtil.RenderSoldierNoCopy(subject, renderParams, null);
+                return CapturePortrait(builder, resolution);
             }
             finally
             {
@@ -704,67 +657,66 @@ namespace TFTV.TFTVIncidents
             }
         }
 
-        // TEMPORARY - the customization screen shows this operative with a dark, patterned armour and
-        // the portrait shows the pale factory texture, from the same tags. Writing _PrimaryColor
-        // changed nothing even on the material, so the colours are almost certainly gated behind the
-        // pattern. Dump what the pattern tag carries and what actually reached the torso material and
-        // its property block, for our subject and for the squad bay builder when it holds a character
-        // (that one is the personnel screen's own model, the one that looks right).
-        private static void LogPatternState(AddonsManager manager, string label)
+        /// <summary>
+        /// Renders the subject with a camera copied from the one the game draws the world with.
+        ///
+        /// The game's own capture path (SoldierPortraitUtil -> RenderingEnvironment) builds a bare
+        /// camera and forces RenderingPath.Forward on it, and the character shader's customization -
+        /// armour colour and pattern - does not survive that: vanilla's own rendered tactical
+        /// portraits come out in factory colours for the same reason. Copying the live camera keeps
+        /// the shader on the path it takes in the scene, which is where the customization shows.
+        /// </summary>
+        private static Texture2D CapturePortrait(AddonsCharacterBuilder builder, Vector2Int resolution)
         {
+            Transform target = builder.AddonsManager?.FindTransform("Nose", rigBonesOnly: true)
+                ?? builder.AddonsManager?.FindTransform("Head", rigBonesOnly: true)
+                ?? builder.transform;
+
+            float distance = target.name == "Head" ? HeadDistance : NoseDistance;
+
+            RenderTexture renderTexture = RenderTexture.GetTemporary(
+                resolution.x, resolution.y, 24, RenderTextureFormat.ARGB32);
+
+            GameObject cameraHost = new GameObject("[TFTV]PortraitCamera");
+            RenderTexture previouslyActive = RenderTexture.active;
+
             try
             {
-                if (manager?.RootAddon == null)
+                Camera camera = cameraHost.AddComponent<Camera>();
+                Camera sceneCamera = GameUtl.GameComponent<CameraManager>()?.Camera;
+                if (sceneCamera != null)
                 {
-                    return;
+                    camera.CopyFrom(sceneCamera);
                 }
 
-                CustomizationPatternTagDef pattern = manager.MergeWithAddonsTags.OfType<CustomizationPatternTagDef>().FirstOrDefault();
-                if (pattern == null)
-                {
-                    TFTVLogger.Always($"{LogPrefix} [pattern:{label}] no pattern tag in the merged tags.");
-                    return;
-                }
+                camera.enabled = false;
+                camera.targetTexture = renderTexture;
+                camera.cullingMask = 1 << LayerMask.NameToLayer("Characters");
+                camera.clearFlags = CameraClearFlags.SolidColor;
+                camera.backgroundColor = new Color(0f, 0f, 0f, 0f);
+                camera.allowHDR = false;
+                camera.allowMSAA = false;
+                camera.orthographic = false;
+                camera.fieldOfView = CameraFoV;
+                camera.nearClipPlane = 0.01f;
+                camera.farClipPlane = 2.5f;
 
-                TFTVLogger.Always($"{LogPrefix} [pattern:{label}] tag={pattern.name} param={pattern.ShaderParamName} " +
-                    $"texture={(pattern.PatternTexture != null ? pattern.PatternTexture.name : "NULL")} " +
-                    $"tiling={pattern.TilingXName}/{pattern.TilingYName} extra={pattern.AdditionalParamName}");
+                camera.transform.position = target.position + target.forward * distance;
+                camera.transform.LookAt(target.position);
 
-                foreach (Item item in manager.RootAddon.OfType<Item>())
-                {
-                    if (item.VisualRoot == null || !item.VisualRoot.gameObject.activeSelf)
-                    {
-                        continue;
-                    }
+                camera.Render();
 
-                    Renderer renderer = item.GetHighlightableRenderers()?.FirstOrDefault(r => r != null && !(r is ParticleSystemRenderer));
-                    Material material = renderer != null ? renderer.sharedMaterial : null;
-                    if (material == null)
-                    {
-                        continue;
-                    }
-
-                    MaterialPropertyBlock block = new MaterialPropertyBlock();
-                    renderer.GetPropertyBlock(block);
-
-                    Texture blockTexture = block.GetTexture(pattern.ShaderParamName);
-                    Texture materialTexture = material.HasProperty(pattern.ShaderParamName)
-                        ? material.GetTexture(pattern.ShaderParamName)
-                        : null;
-
-                    TFTVLogger.Always($"{LogPrefix} [pattern:{label}] {item.ItemDef?.name} " +
-                        $"materialHasParam={material.HasProperty(pattern.ShaderParamName)} " +
-                        $"materialTex={(materialTexture != null ? materialTexture.name : "-")} " +
-                        $"blockTex={(blockTexture != null ? blockTexture.name : "-")} " +
-                        $"blockPrimary={block.GetColor("_PrimaryColor")} " +
-                        $"blockTilingX={block.GetFloat(pattern.TilingXName)} " +
-                        $"materialPrimary={(material.HasProperty("_PrimaryColor") ? material.GetColor("_PrimaryColor").ToString() : "-")}");
-                    break;
-                }
+                RenderTexture.active = renderTexture;
+                Texture2D portrait = new Texture2D(resolution.x, resolution.y, TextureFormat.RGBA32, mipChain: true);
+                portrait.ReadPixels(new Rect(0f, 0f, resolution.x, resolution.y), 0, 0, recalculateMipMaps: true);
+                portrait.Apply();
+                return portrait;
             }
-            catch (Exception e)
+            finally
             {
-                TFTVLogger.Error(e);
+                RenderTexture.active = previouslyActive;
+                UnityEngine.Object.Destroy(cameraHost);
+                RenderTexture.ReleaseTemporary(renderTexture);
             }
         }
 

--- a/TFTV/TFTVIncidents/PortraitGenerator.cs
+++ b/TFTV/TFTVIncidents/PortraitGenerator.cs
@@ -291,6 +291,8 @@ namespace TFTV.TFTVIncidents
                 rendered.filterMode = FilterMode.Trilinear;
                 rendered.anisoLevel = 4;
 
+                DumpPortraitForInspection(rendered, character);
+
                 onDone?.Invoke(Sprite.Create(
                     rendered,
                     new Rect(0f, 0f, rendered.width, rendered.height),
@@ -300,6 +302,32 @@ namespace TFTV.TFTVIncidents
             finally
             {
                 UnityEngine.Object.Destroy(builder.gameObject);
+            }
+        }
+
+        // TEMPORARY - writes the finished portrait to disk so the render can be looked at directly
+        // instead of described. Every theory so far has been argued from log numbers; this shows what
+        // the camera actually produced: the framing, what is in shot, and what colour it came out.
+        private const bool DumpPortraitsEnabled = true;
+
+        private static void DumpPortraitForInspection(Texture2D portrait, GeoCharacter character)
+        {
+            if (!DumpPortraitsEnabled || portrait == null)
+            {
+                return;
+            }
+
+            try
+            {
+                string name = string.Join("_", (character.DisplayName ?? "unknown")
+                    .Split(System.IO.Path.GetInvalidFileNameChars()));
+                string path = System.IO.Path.Combine(Application.persistentDataPath, $"TFTV_Portrait_{name}.png");
+                System.IO.File.WriteAllBytes(path, portrait.EncodeToPNG());
+                TFTVLogger.Always($"{LogPrefix} [test] wrote {path}");
+            }
+            catch (Exception e)
+            {
+                TFTVLogger.Error(e);
             }
         }
 

--- a/TFTV/TFTVIncidents/PortraitGenerator.cs
+++ b/TFTV/TFTVIncidents/PortraitGenerator.cs
@@ -386,7 +386,6 @@ namespace TFTV.TFTVIncidents
 
                 manager.SetAutorefreshOnTagsChanged(true);
                 RefreshAddonTags(manager);
-                ForceTestColours(manager);
                 HideCoveredAddonVisuals(manager);
                 ApplyFaceCorruption(builder, character, level);
                 CommonCharacterUtils.ResetCharacterAnimation(builder);
@@ -492,43 +491,6 @@ namespace TFTV.TFTVIncidents
                 .Where(item => item.VisualRoot != null && item.VisualRoot.gameObject.activeSelf)
                 .Select(item => item.ItemDef?.name ?? "?")
                 .ToArray();
-        }
-
-        // TEMPORARY EXPERIMENT - not a fix. Paints every built item in colours nothing in the game
-        // would ever choose, through the same HighlightController calls Item.RefreshTags uses. If the
-        // portrait comes out magenta and green, the customization pipeline reaches the pixels and the
-        // argument is only ever about which colour the tags resolve to. If it comes out unchanged, the
-        // paint is being ignored or overwritten somewhere after we apply it, and the material on the
-        // renderer is the next thing to look at rather than the tags. Set to false to disable.
-        private const bool ForceTestColoursEnabled = true;
-
-        private static void ForceTestColours(AddonsManager manager)
-        {
-            if (!ForceTestColoursEnabled || manager?.RootAddon == null)
-            {
-                return;
-            }
-
-            int painted = 0;
-            foreach (Item item in manager.RootAddon.OfType<Item>())
-            {
-                HighlightControllerComponent controller = item.VisualRoot != null
-                    ? item.VisualRoot.gameObject.GetComponent<HighlightControllerComponent>()
-                    : null;
-
-                if (controller == null)
-                {
-                    continue;
-                }
-
-                controller.StartCustomization();
-                controller.CustomizeColor("_PrimaryColor", Color.magenta);
-                controller.CustomizeColor("_SecondaryColor", Color.green);
-                controller.ApplyCustomization();
-                painted++;
-            }
-
-            TFTVLogger.Always($"{LogPrefix} [test] forced magenta/green onto {painted} item(s).");
         }
 
         /// <summary>
@@ -661,6 +623,8 @@ namespace TFTV.TFTVIncidents
                 EnableCharacterLight(builder, displayData.CharacterLightObjectName);
                 lightRig = CreatePortraitLightRig(subject.transform);
 
+                BlankSubjectForTest(subject);
+
                 bool hasNose = builder.AddonsManager?.FindTransform("Nose", rigBonesOnly: true) != null;
                 SquadPortraitsDef.RenderPortraitParams renderParams = new SquadPortraitsDef.RenderPortraitParams
                 {
@@ -694,6 +658,34 @@ namespace TFTV.TFTVIncidents
                 RenderSettings.ambientIntensity = ambientIntensityBefore;
                 RenderSettings.reflectionIntensity = reflectionBefore;
             }
+        }
+
+        // TEMPORARY EXPERIMENT - not a fix. Switches off every renderer on the subject in the instant
+        // before it is handed to the portrait renderer. Forcing magenta onto the built items changed
+        // nothing on screen, which leaves a blunter question: is the image we get actually this
+        // subject? A blank portrait means it is, and the paint is being ignored somewhere between the
+        // property block and the draw. A portrait that still shows the operative means the image comes
+        // from something else entirely, and nothing done to this subject was ever going to matter.
+        private const bool BlankSubjectForTestEnabled = true;
+
+        private static void BlankSubjectForTest(GameObject subject)
+        {
+            if (!BlankSubjectForTestEnabled)
+            {
+                return;
+            }
+
+            int disabled = 0;
+            foreach (Renderer renderer in subject.GetComponentsInChildren<Renderer>(true))
+            {
+                if (renderer != null && renderer.enabled)
+                {
+                    renderer.enabled = false;
+                    disabled++;
+                }
+            }
+
+            TFTVLogger.Always($"{LogPrefix} [test] disabled {disabled} renderer(s) on the subject before rendering.");
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes the armour customization in incident portraits. Confirmed working in game.

## What was wrong

Not the tags. Every tag-side theory in #41, #42 and #43 was measured and eliminated:

- the identity's colour and pattern tags reach the builder intact (`identity` and `customization` match in the log)
- the palette resolves them to the right colours
- those colours sit in the renderers' `MaterialPropertyBlock`s at the moment of the render

Two experiments then bracketed it. Forcing magenta into those property blocks — and afterwards straight onto the material instances — changed nothing on screen. Disabling the *same* renderers at the *same* moment produced a blank portrait. So the renderers were right, the timing was right, and the paint still never reached the pixels.

The missing fact: **vanilla's own rendered tactical portraits lose armour colour and pattern too.** The capture path is what drops them. `SoldierPortraitUtil.RenderSoldierNoCopy` hands the subject to `RenderingEnvironment`, which builds a bare camera and forces `RenderingPath.Forward`, and the character shader's customization does not survive that path. The personnel screen looks right because the scene camera draws it.

## The change

`CapturePortrait` renders the subject with a camera of our own, copied from `CameraManager.Camera` so the shader takes the path it takes in the live scene:

```csharp
camera.CopyFrom(sceneCamera);
camera.targetTexture = renderTexture;
camera.cullingMask  = 1 << LayerMask.NameToLayer("Characters");
camera.transform.position = target.position + target.forward * distance;
camera.transform.LookAt(target.position);
camera.Render();
```

Framing is unchanged — the Nose bone at the same distance and FoV `SoldierFrame` used. The subject also no longer gets teleported to `RenderingEnvironment`'s staging origin; it renders where it stands. Net diff is +76/−14 in one file.

## Verified

Blaine Hargreaves, customization screen vs portrait: `PRIMARY COLOR 1` / `SECONDARY COLOR 1` / `ARMOR PATTERN 9` now renders as dark gunmetal with the pattern lines and orange accents in the portrait, matching the screen. Previously the portrait showed the pale factory texture.

## For the reviewer

- **The intermediate commits are throwaway experiments** — forced test colours, blanking the subject, PNG dumps of the render. Every one of them is removed again by `9700e4ca`; the net diff above is what actually lands. Squash-merging is reasonable here.
- **`RefreshAddonTags` before the capture is a safety net, not the fix.** It was added under a theory that turned out to be wrong (paint lost between build and shutter). It is kept because the confirmed-working build has it and it costs one refresh pass, but nothing depends on it. Its comment says so.
- **Diagnosing this by log was a dead end.** What settled it was writing the render to a PNG and comparing it against a screenshot of the customization screen. Worth reaching for early next time a render looks wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
