### PR TITLE
Portraits: take Delirium on the face from the mod's own calculation

### DIFF
--- a/TFTV/TFTVIncidents/PortraitGenerator.cs
+++ b/TFTV/TFTVIncidents/PortraitGenerator.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using TFTV.TFTVUI.Personnel;
 using UnityEngine;
 
 namespace TFTV.TFTVIncidents
@@ -530,7 +531,7 @@ namespace TFTV.TFTVIncidents
         {
             try
             {
-                if (character == null || character.IsMutoid || level == null || (float)character.CharacterStats.Corruption <= 0f)
+                if (character == null || character.IsMutoid || level == null)
                 {
                     return;
                 }
@@ -549,8 +550,7 @@ namespace TFTV.TFTVIncidents
                 }
 
                 MaterialPropertyBlock propertyBlock = new MaterialPropertyBlock();
-                propertyBlock.SetFloat(CorruptionShaderPropertyName, level.CorruptedHorizonsSettings.CorruptionSettings
-                    .CalculateCorruptionShaderValue(character.CharacterStats.CorruptionProgressRel));
+                propertyBlock.SetFloat(CorruptionShaderPropertyName, ResolveCorruptionShaderValue(character, level));
 
                 foreach (TacticalItem item in ((ItemSlot)headSlot).GetAllDirectItems(onlyBodyparts: true))
                 {
@@ -651,6 +651,30 @@ namespace TFTV.TFTVIncidents
                 RenderSettings.ambientLight = ambientLightBefore;
                 RenderSettings.ambientIntensity = ambientIntensityBefore;
                 RenderSettings.reflectionIntensity = reflectionBefore;
+            }
+        }
+
+        /// <summary>
+        /// How much Delirium shows on the face, by the mod's reckoning rather than the game's.
+        ///
+        /// TFTV tones the effect down and folds stamina into it, and it does so by patching
+        /// CharacterStats.CorruptionProgressRel - but only while DeliriumFaceShader's hook names the
+        /// character being drawn, which is how the personnel screen and the tactical squad portraits
+        /// get the reduced value. Set the same hook around the read so an incident portrait shows the
+        /// same face as those screens instead of the untouched vanilla amount.
+        /// </summary>
+        private static float ResolveCorruptionShaderValue(GeoCharacter character, GeoLevelController level)
+        {
+            GeoCharacter previousHook = DeliriumFaceShader.HookToCharacterForDeliriumShader;
+            DeliriumFaceShader.HookToCharacterForDeliriumShader = character;
+            try
+            {
+                return level.CorruptedHorizonsSettings.CorruptionSettings
+                    .CalculateCorruptionShaderValue(character.CharacterStats.CorruptionProgressRel);
+            }
+            finally
+            {
+                DeliriumFaceShader.HookToCharacterForDeliriumShader = previousHook;
             }
         }
 


### PR DESCRIPTION
Follow-up to #44, which fixed the armour customization in incident portraits. This makes the *face* match the rest of the mod too.

## What was wrong

TFTV renders less Delirium on a face than the base game and folds stamina into the amount. It does that in `DeliriumFaceShader` by patching `CharacterStats.get_CorruptionProgressRel`:

```csharp
if (__instance.Corruption - TFTVDelirium.CalculateStaminaEffectOnDelirium(geoCharacter) > 0)
    __result = (Corruption - CalculateStaminaEffectOnDelirium(geoCharacter)) / 20;
else
    __result = 0.05f;
```

The override only applies **while a hook field names the character being drawn**. Both vanilla call sites get it because TFTV brackets them with prefix/postfix patches that set and clear that hook — `UIModuleActorCycle.SetupFaceCorruptionShader` for the personnel screen, `SquadMemberScrollerController.SetupFaceCorruptionShader` for tactical squad portraits.

The incident portrait doesn't go through either patched method. It read `CorruptionProgressRel` with no hook set, got the untouched vanilla value, and rendered corrupted operatives harder than they appear anywhere else in the mod.

## The change

`ResolveCorruptionShaderValue` sets the same hook around the read, saving and restoring any previous value so it cannot disturb a call already in flight:

```csharp
GeoCharacter previousHook = DeliriumFaceShader.HookToCharacterForDeliriumShader;
DeliriumFaceShader.HookToCharacterForDeliriumShader = character;
try
{
    return level.CorruptedHorizonsSettings.CorruptionSettings
        .CalculateCorruptionShaderValue(character.CharacterStats.CorruptionProgressRel);
}
finally
{
    DeliriumFaceShader.HookToCharacterForDeliriumShader = previousHook;
}
```

Reusing the mod's own mechanism rather than reimplementing the formula means the portrait keeps matching if that formula changes.

## Also in this PR

Dropped the early return on zero corruption. Vanilla applies the shader value whatever the corruption level is; bailing out left an uncorrupted face at whatever the material happened to default to, instead of the clean value the personnel screen and tactical portraits explicitly set. It now applies at every level, matching them.

## For the reviewer

- Face shader input only — it cannot affect the armour customization fixed in #44.
- Not yet play-tested against a corrupted operative side by side with the personnel screen. If a difference remains, the next thing to check is whether the stamina lookup behaves the same for incident crew as for roster soldiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
