### PR TITLE
Base rework: document the affinity rules, and let the player pick who is spent

### DIFF
--- a/Dist/Assets/Localization/TFTV_AircraftRework_Localization.csv
+++ b/Dist/Assets/Localization/TFTV_AircraftRework_Localization.csv
@@ -178,16 +178,16 @@ KEY_BASE_PING_SCAN_OPTION,Text,,Initiate a Scan,,,,,,,,
 KEY_BASE_RANSACK_TOOLTIP,Text,,"Permanently destroys the Phoenix base; receive resources as from demolishing every facility at the base (and a little extra, amount depending on Difficulty).",,,,,,,,
 KEY_BASE_RANSACK_OPTION,Text,,Ransack,,,,,,,,
 KEY_BASE_OUTPOST_OPTION,Text,,Set up an Outpost,,,,,,,,
-KEY_BASE_OUTPOST_TOOLTIP,Text,,"You cannot build any facilities at an Outpost nor receive any income nor other advantages from existing facilities at an Outpost. Aircraft and Units at the Outpost heal, repair and recover Stamina at half the rate they would at a regular Base with the corresponding facilities. Outposts can also help detecting nearby Pandoran Colonies after an attack on a Haven. Outposts cannot be attacked and can be later upgraded to a regular Base costing half the resources and 3 personnel. Takes 24 hours to complete.",,,,,,,,
+KEY_BASE_OUTPOST_TOOLTIP,Text,,"You cannot build any facilities at an Outpost nor receive any income nor other advantages from existing facilities at an Outpost. Aircraft and Units at the Outpost heal, repair and recover Stamina at half the rate they would at a regular Base with the corresponding facilities. Outposts can also help detecting nearby Pandoran Colonies after an attack on a Haven. Outposts cannot be attacked and can be later upgraded to a regular Base costing half the resources and 3 personnel. Takes 24 hours to complete. Personnel with the Psycho-Sociology Affinity count as 3 Personnel toward the Personnel cost.",,,,,,,,
 KEY_BASE_OUTPOST_UPGRADE_OPTION,Text,,Upgrade to regular Base,,,,,,,,
 KEY_BASE_ACTIVATE_OPTION,Text,,Activate the Base,,,,,,,,
-KEY_BASE_OUTPOST_UPGRADE_TOOLTIP,Text,,Upgrade the Outpost to a regular Base. Takes 48 hours to complete.,,,,,,,,
-KEY_BASE_ACTIVATE_OPTION_TOOLTIP,Text,,Activate the Base. Any damaged Facilities will still need to be repaired after the activation. Takes 72 hours to complete.,,,,,,,,
+KEY_BASE_OUTPOST_UPGRADE_TOOLTIP,Text,,Upgrade the Outpost to a regular Base. Takes 48 hours to complete. Personnel with the Psycho-Sociology Affinity count as 3 Personnel toward the Personnel cost.,,,,,,,,
+KEY_BASE_ACTIVATE_OPTION_TOOLTIP,Text,,Activate the Base. Any damaged Facilities will still need to be repaired after the activation. Takes 72 hours to complete. Personnel with the Psycho-Sociology Affinity count as 3 Personnel toward the Personnel cost.,,,,,,,,
 KEY_BASE_ALREADY_LOOTED,Text,,You have already looted this place!,,,,,,,,
 KEY_BASE_VISIT_TO_LOOT,Text,,Explore the base to get valuable loot!,,,,,,,,
 KEY_BASE_LOOT_YOU_FOUND,Text,,You found:,,,,,,,,
 KEY_OUTPOST_ACTIVATED_TITLE,Text,,Outpost operational,,,,,,,,
-KEY_OUTPOST_ACTIVATED_DESCRIPTION,Text,,"You have finished building an Outpost. You cannot build any facilities at an Outpost nor receive any income nor other advantages from existing facilities at an Outpost. Aircraft and Units at the Outpost heal, repair and recover Stamina at half the rate they would at a regular Base with the corresponding facilities. Outposts can also help detecting nearby Pandoran Colonies after an attack on a Haven. Outposts cannot be attacked and can be later upgraded to a regular Base costing half the resources and 3 personnel.",,,,,,,,
+KEY_OUTPOST_ACTIVATED_DESCRIPTION,Text,,"You have finished building an Outpost. You cannot build any facilities at an Outpost nor receive any income nor other advantages from existing facilities at an Outpost. Aircraft and Units at the Outpost heal, repair and recover Stamina at half the rate they would at a regular Base with the corresponding facilities. Outposts can also help detecting nearby Pandoran Colonies after an attack on a Haven. Outposts cannot be attacked and can be later upgraded to a regular Base costing half the resources and 3 personnel. Personnel with the Psycho-Sociology Affinity count as 3 Personnel toward the Personnel cost.",,,,,,,,
 KEY_INCIDENT_START_OPTION,Text,,INITIATE INCIDENT RESOLUTION,,,,,,,,
 KEY_INCIDENT_START_OPTION_TOOLTIP,Text,,"Starts the Incident event. After choosing how to approach the Incident, Aircraft must stay at the Haven. Moving the Aircraft before the Incident is resolved will result in Failure. ",,,,,,,,
 KEY_AFFINITY_GEO_DESC_PSYCHO_SOCIOLOGY_OPTION_1,Text,,Geoscape Benefit: Haven Defense rewards +{0}%.,,,,,,,,
@@ -235,10 +235,10 @@ KEY_BASE_DISMISS_PERSON_PROMPT,Text,,"Are you sure you want to dismiss {0} from 
 KEY_GEOSCAPE_SOLDIERS_TT,Text,,Phoenix operatives on active field duty,,,,,,,,
 KEY_SOLDIERS_COUNT_TT,Text,,PERSONNEL - recruited / living quarters capacity,,,,,,,,
 KEY_RESEARCH_TOTAL_TT,Text,,"Research per hour generated (+ Research from personnel assigned to Research)
-(Research slots used/Research slots available). Each Research Lab generates 2 Research and provides 1 Slot to which Personnel not on active field duty can be assigned. Each Personnel assigned to Research generates 4 Research. 
+(Research slots used/Research slots available). Each Research Lab generates 2 Research and provides 1 Slot to which Personnel not on active field duty can be assigned. Each Personnel assigned to Research generates 2 Research, or more if they have an Affinity: 6 for Biotech, 4 for Compute, Occult and Psycho-Sociology. 
 The higher the number, the faster Technologies will be researched.",,,,,,,,
 KEY_PRODUCTION_TOTAL_TT,Text,,"Manufacturing per hour generated (+ Manufacturing from personnel assigned to Manufacturing)
-(Manufacturing slots used/Manufacturing slots available). Each Manufacturing Plant generates 2 Manufacturing and provides 1 Slot to which Personnel not on active field duty can be assigned. Each Personnel assigned to Manufacturing generates 4 Manufacturing. 
+(Manufacturing slots used/Manufacturing slots available). Each Manufacturing Plant generates 2 Manufacturing and provides 1 Slot to which Personnel not on active field duty can be assigned. Each Personnel assigned to Manufacturing generates 2 Manufacturing, or more if they have an Affinity: 6 for Machinery, 4 for Compute, Occult and Psycho-Sociology. 
 The higher the number, the faster the production of Equipment, Armor, Ground Vehicles and Aircraft.",,,,,,,,
 TFTV_TBTV_OCCULT_AFFINITY_REDUCTION,Text,,Occult affinity: {0} reduces Touched by the Void chance by {1}.,,,,,,,,
 KEY_BASE_RECRUITS_SPAWNED,Text,,"New personnel has arrived. Can be assigned to Manufacturing or Research, or deployed.",,,,,,,,
@@ -260,7 +260,12 @@ Tactical Benefits (choose one globally):
 
 - Allies recover +2 WP per Affinity Rank when activating Recovery.
 OR
-- Increase friendly Haven deployment by 50% per Affinity Rank.",,,,,,,,
+- Increase friendly Haven deployment by 50% per Affinity Rank.
+
+Base Duty Benefits (always active, do not scale with rank):
+
+- Generates 4 Research or 4 Manufacturing when assigned to a worker slot.
+- Counts as 3 Personnel when spent to set up an Outpost or to activate a Base.",,,,,,,,
 KEY_AFFINITY_EXPLORATION_ALL_BENEFITS,Text,,"Geoscape Benefits (choose one globally):
 
 - Exploration is 1 hour faster per Affinity Rank.
@@ -271,7 +276,11 @@ Tactical Benefits (choose one globally):
 
 - Enemies are 15% per Affinity Rank more likely to drop loot.
 OR
-- Gain immediate control of friendly Haven Defenders at mission start, and WP when extracting civilians (1 of each per Affinity Rank).",,,,,,,,
+- Gain immediate control of friendly Haven Defenders at mission start, and WP when extracting civilians (1 of each per Affinity Rank).
+
+Base Duty Benefits (always active, do not scale with rank):
+
+- Can be trained up to Level 6.",,,,,,,,
 KEY_AFFINITY_OCCULT_ALL_BENEFITS,Text,,"Geoscape Benefits (choose one globally):
 
 - Receive a 1 day per Affinity Rank warning before an attack on a Phoenix Base.
@@ -282,7 +291,12 @@ Tactical Benefits (choose one globally):
 
 - Reduce TBTV chance by 5% per Affinity Rank.
 OR
-- For all Allies, effect of Stamina on Delirium increased by 50% per Affinity Rank.",,,,,,,,
+- For all Allies, effect of Stamina on Delirium increased by 50% per Affinity Rank.
+
+Base Duty Benefits (always active, do not scale with rank):
+
+- Generates 4 Research or 4 Manufacturing when assigned to a worker slot.
+- Can be trained up to Level 5.",,,,,,,,
 KEY_AFFINITY_BIOTECH_ALL_BENEFITS,Text,,"Geoscape Benefits (choose one globally):
 
 - Operatives recover 30 HP per Affinity Rank after mission.
@@ -293,7 +307,11 @@ Tactical Benefits (choose one globally):
 
 - Gain passive ability: Using a Medkit or a Virophage Kit gives the target Ignore Pain status for 1 turn per Affinity Rank, allowing the target to ignore disabled limbs for that duration
 OR
-- Gain passive ability: Using any healing item or ability restores up to 3 WP per Affinity Rank that the target had lost to Delirium; lasts only for the duration of the mission.",,,,,,,,
+- Gain passive ability: Using any healing item or ability restores up to 3 WP per Affinity Rank that the target had lost to Delirium; lasts only for the duration of the mission.
+
+Base Duty Benefits (always active, do not scale with rank):
+
+- Generates 6 Research when assigned to a Research slot (2 Manufacturing on a Manufacturing slot).",,,,,,,,
 KEY_AFFINITY_MACHINERY_ALL_BENEFITS,Text,,"Geoscape Benefits (choose one globally):
 
 - Vehicles recover 150 HP per Affinity Rank after mission.
@@ -304,7 +322,11 @@ Tactical Benefits (choose one globally):
 
 - Gain active ability: Overdrive - restore 1 AP per Affinity Rank to a Vehicle or Operative with Bionics, but giving a 50% vulnerability to all damage types until the end of next turn (1 AP, 3 WP)
 OR
-- Gain passive ability: Using any healing item or ability restores up to 4 Armor per Affinity Rank on each body part of the target.",,,,,,,,
+- Gain passive ability: Using any healing item or ability restores up to 4 Armor per Affinity Rank on each body part of the target.
+
+Base Duty Benefits (always active, do not scale with rank):
+
+- Generates 6 Manufacturing when assigned to a Manufacturing slot (2 Research on a Research slot).",,,,,,,,
 KEY_AFFINITY_COMPUTE_ALL_BENEFITS,Text,,"Geoscape Benefits (choose one globally):
 
 - Aircraft speed increased by 10% per Affinity Rank.
@@ -315,21 +337,37 @@ Tactical Benefits (choose one globally):
 
 - Gain passive ability: Ground vehicles with character inside gain +3 movement and +10% accuracy per Affinity Rank.
 OR
-- For all Allies, Perception vs Pandorans increased by 1 per Affinity Rank out of 3 of the total amount of Delirium in the squad, up to +10 per Affinity Rank.",,,,,,,,
+- For all Allies, Perception vs Pandorans increased by 1 per Affinity Rank out of 3 of the total amount of Delirium in the squad, up to +10 per Affinity Rank.
+
+Base Duty Benefits (always active, do not scale with rank):
+
+- Generates 4 Research or 4 Manufacturing when assigned to a worker slot.
+- Can be trained up to Level 5.",,,,,,,,
 ALISTAIR_ON_INCIDENTS_0_TITLE,Text,,Incident,,,,,,,,
 ALISTAIR_ON_INCIDENTS_0_TEXT,Text,,"Director, we just learned of an incident taking place at a haven that we have visited previously. If we resolve it, perhaps we will learn something valuable, and it can't hurt to show the havens and the factions that we are trying to help.",,,,,,,,
 ALISTAIR_ON_INCIDENTS_1_TITLE,Text,,Human Resources,,,,,,,,
 ALISTAIR_ON_INCIDENTS_1_TEXT,Text,,"Director, we desperately need additional personnel, individuals who have what it takes to be in the Phoenix Project: ingenuity, intellectual curiosity and courage. It turns out that resolving incidents like this one might be the best way to attract new members; wanting to join up after seeing us at work attracts exactly the kind of people we are looking for.",,,,,,,,
 TUTORIAL_PERSONNEL_TITLE0,Text,,Personnel Management,,,,,,,,
-TUTORIAL_PERSONNEL_TEXT0,Text,,"Personnel can be assigned to generate additional Research or Manufacturing. Each Research Lab or Manufacturing Plant generates 2 Research or 2 Manufacturing and provides 1 worker slot. Each Personnel assigned to a worker slot generates 4 Research or 4 Manufacturing. 
+TUTORIAL_PERSONNEL_TEXT0,Text,,"Personnel can be assigned to generate additional Research or Manufacturing. Each Research Lab or Manufacturing Plant generates 2 Research or 2 Manufacturing and provides 1 worker slot. Each Personnel assigned to a worker slot generates 2 Research or 2 Manufacturing. 
+
+Personnel who have an Affinity may be better at this kind of work:
+
+- Biotech: 6 Research (2 Manufacturing).
+- Machinery: 6 Manufacturing (2 Research).
+- Compute, Occult or Psycho-Sociology: 4 Research or 4 Manufacturing.
+- Exploration: 2 Research or 2 Manufacturing, the same as Personnel without an Affinity.
+
+The Affinity of each Personnel is shown as an icon in the top right corner of their entry in the ASSIGNMENTS screen. Affinity benefits on base duty are always active and do not scale with the Affinity’s rank.
+
+Psycho-Sociology Personnel are trained administrators: they count as 3 Personnel when spent to set up an Outpost or to activate a Base.
 
 Personnel can also be deployed as regular Level 1 Operatives of the Class of your choosing. 
 
-If you have a Training Facility you can train Personnel up to Level 4 before deploying them. They will gain +2 Strength, + 1 Willpower and + 1 Speed per level trained. Training costs 10 Faction SP per final level trained. Training takes time, which can be shortened by acquiring certain Technologies, and can be terminated early, in which case you will be refunded the corresponding SP. 
+If you have a Training Facility you can train Personnel up to Level 4 before deploying them. Compute and Occult Personnel can be trained up to Level 5, and Exploration Personnel up to Level 6. They will gain +2 Strength, + 1 Willpower and + 1 Speed per level trained. Training costs 10 Faction SP per final level trained. Training takes time, which can be shortened by acquiring certain Technologies, and can be terminated early, in which case you will be refunded the corresponding SP. 
 
 You start the game with some Personnel, the number depending on difficulty (2 on Legend, 6 on Rookie). 
 
-You gain new Personnel by resolving Incidents; special timed events that occur from time to time at previously visited havens. 
+You gain new Personnel by resolving Incidents; special timed events that occur from time to time at previously visited havens. If the Operative leading the Incident has Rank 2 in an Affinity, one of the Personnel gained will have that same Affinity at Rank 1; if the leader has Rank 3, a second Personnel will also gain a different, randomly chosen Affinity at Rank 1. 
 
 On Hero difficulty and lower you also gain new Personnel periodically (1 on Hero, 3 on Rookie). You can override this setting on New Game start.
 
@@ -339,7 +377,7 @@ Some Dismissed operatives that have “Just a Grunt” perk, such as Mercenaries
 TUTORIAL_PERSONNEL_TITLE1,Text,,Acquiring New Personnel,,,,,,,,
 TUTORIAL_PERSONNEL_TEXT1,Text,,"You start the game with some Personnel, the number depending on difficulty (2 on Legend, 6 on Rookie). 
 
-You gain new Personnel by resolving Incidents; special timed events that occur from time to time at previously visited havens. 
+You gain new Personnel by resolving Incidents; special timed events that occur from time to time at previously visited havens. If the Operative leading the Incident has Rank 2 in an Affinity, one of the Personnel gained will have that same Affinity at Rank 1; if the leader has Rank 3, a second Personnel will also gain a different, randomly chosen Affinity at Rank 1. 
 
 On Hero difficulty and lower you also gain new Personnel periodically (1 on Hero, 3 on Rookie). You can override this setting on New Game start.
 
@@ -355,9 +393,13 @@ You then have the following options:
 
 1) Ransack the base: destroy the base, demolishing every facility at the base, including those that can't be demolished. The amount of resources depends on the difficulty setting, and can be overriden on New Game Start. 
 2) Establish an Outpost (pay 200 mat, 50 tech and 1 Personnel, takes 24 hours). Outposts provide some repair and healing, cannot be attacked, and can help detect nearby Pandoran Colonies after an attack on a Haven, but their facilities don't generate anything and you can't build or demolish facilities at them. Outposts can be upgraded to Bases. 
-3) Activate Base (pay 400 mat, 100 tech, 4 personnel, takes 72 hours, cost reduced by price of setting up an Outpost if upgrading from it). Get the regular Phoenix base. ",,,,,,,,
+3) Activate Base (pay 400 mat, 100 tech, 4 personnel, takes 72 hours, cost reduced by price of setting up an Outpost if upgrading from it). Get the regular Phoenix base. 
+
+Personnel with the Psycho-Sociology Affinity are trained administrators and count as 3 Personnel toward the Personnel cost of setting up an Outpost or activating a Base. ",,,,,,,,
 TUTORIAL_INCIDENTS_TITLE0,Text,,Incidents,,,,,,,,
 TUTORIAL_INCIDENTS_TEXT0,Text,,"Incidents are Geoscape Events that take time to resolve and are the primary way of securing new Personnel. You will get at least 2 Personnel for resolving an Incident successfully (among other rewards, such as Resources, Characters, Improved attitude from Faction and/or Haven Leader), and 1 Personnel if you attempt it but then move the Aircraft away before it is completed. 
+
+If the Operative leading the Incident has Rank 2 in an Affinity, one of the Personnel gained will have that same Affinity at Rank 1. If the leader has Rank 3, a second Personnel will also gain a different, randomly chosen Affinity at Rank 1. 
 
 Every 4-6 days, an Incident will occur at a previously visited haven, inviting you to resolve it within the next 5 days.
 
@@ -365,6 +407,8 @@ To initiate the Incident, you must travel to the haven with an Aircraft with at 
 TUTORIAL_INCIDENTS_TEXT1,Text,,"Every Incident can be resolved in two different ways. One of the choices will correspond to one Approach, and the other choice will allow 2 different Approaches. You have to select one of them. 
 
 You must also choose the Operative to lead the team. Completing the Incident successfully will give the Leading Operative the Affinity corresponding to the Approach taken, or increase the Rank in that Affinity. 
+
+Leading with an Operative who already has Rank 2 or Rank 3 in an Affinity also shapes the Personnel you gain: at Rank 2 one of them will have the leader’s Affinity at Rank 1, and at Rank 3 a second one will gain a different, randomly chosen Affinity at Rank 1. 
 
 You can also Cancel to return to the Incident later. 
 
@@ -377,5 +421,15 @@ TUTORIAL_AFFINITIES_TEXT0,Text,,"- Affinities are gained and advanced in rank by
 - All benefits are multiplied by the Affinity’s rank.
 - Affinity bonuses do not stack — only the highest-ranked specialist’s bonus applies.
 - Geoscape benefits apply to the Aircraft on which the Character is currently a passenger, Benefits in Tactical grant an ability to the Character with the Affinity.
-- Each Character can have only one Affinity.",,,,,,,,
+- Each Character can have only one Affinity.
+- Affinities also matter on base duty. They determine how much Research or Manufacturing a Personnel generates when assigned to a worker slot (Biotech 6 Research, Machinery 6 Manufacturing, Compute / Occult / Psycho-Sociology 4 of either, everyone else 2), how far they can be trained (Compute and Occult to Level 5, Exploration to Level 6), and how many Personnel they count as when spent on an Outpost or a Base activation (Psycho-Sociology counts as 3).
+- Unlike the Geoscape and Tactical benefits, these base duty benefits are always active and do not scale with the Affinity’s rank.
+- Resolving an Incident with a leader of Rank 2 gives one of the Personnel gained the leader’s Affinity at Rank 1; with a leader of Rank 3, a second Personnel gains a different, randomly chosen Affinity at Rank 1.",,,,,,,,
 KEY_BASE_EXPLORE_FIRST,Text,,Explore the base first to unlock these options.,,,,,,,,
+KEY_BASE_PERSONNEL_SELECT_TITLE,Text,,ASSIGN PERSONNEL,,,,,,,,
+KEY_BASE_PERSONNEL_SELECT_REQUIRED,Text,,{0} requires {1} Personnel. Pick who is posted to the site.,,,,,,,,
+KEY_BASE_PERSONNEL_SELECT_WARNING,Text,,Personnel posted to a site stay there for good. They leave the Phoenix Project roster and cannot normally be recovered.,,,,,,,,
+KEY_BASE_PERSONNEL_SELECT_COUNTER,Text,,Selected: {0} / {1},,,,,,,,
+KEY_BASE_PERSONNEL_SELECT_COUNTS_AS,Text,,"Administrator, counts as {0}",,,,,,,,
+KEY_BASE_PERSONNEL_SELECT_CONFIRM,Text,,CONFIRM,,,,,,,,
+KEY_BASE_PERSONNEL_SELECT_CANCEL,Text,,CANCEL,,,,,,,,

--- a/TFTV/TFTV.csproj
+++ b/TFTV/TFTV.csproj
@@ -156,6 +156,7 @@
     <Compile Include="TFTVAnniversaryCheats.cs" />
     <Compile Include="TFTVBackgrounds.cs" />
     <Compile Include="TFTVBaseRework\BaseActivation.cs" />
+    <Compile Include="TFTVBaseRework\BaseActivationPersonnelSelection.cs" />
     <Compile Include="TFTVBaseRework\BaseActivationUI.cs" />
     <Compile Include="TFTVBaseRework\BaseConstructionVisuals.cs" />
     <Compile Include="TFTVBaseRework\BaseExploration.cs" />
@@ -174,6 +175,7 @@
     <Compile Include="TFTVBaseRework\ResearchAndManufacturing.cs" />
     <Compile Include="TFTVBaseRework\TrainingFacilityRework.cs" />
     <Compile Include="TFTVBaseRework\BaseReworkActiveCheck.cs" />
+    <Compile Include="TFTVBaseRework\UI\AffinityBadgeTooltip.cs" />
     <Compile Include="TFTVBaseRework\UI\Harmony.cs" />
     <Compile Include="TFTVBaseRework\UI\Helpers.cs" />
     <Compile Include="TFTVBaseRework\UI\MonoBehaviours.cs" />

--- a/TFTV/TFTVBaseRework/BaseActivation.cs
+++ b/TFTV/TFTVBaseRework/BaseActivation.cs
@@ -249,7 +249,7 @@ namespace TFTV.TFTVBaseRework
             });
 
 
-            internal static bool TryQueueFullBaseFromActivationUI(GeoSite site, GeoPhoenixFaction faction, bool fromOutpost)
+            internal static bool TryQueueFullBaseFromActivationUI(GeoSite site, GeoPhoenixFaction faction, bool fromOutpost, IList<PersonnelInfo> chosenPersonnel = null)
             {
                 try
                 {
@@ -261,7 +261,7 @@ namespace TFTV.TFTVBaseRework
                         return false;
                     }
 
-                    return EstablishBase(site, faction, fromOutpost);
+                    return EstablishBase(site, faction, fromOutpost, chosenPersonnel);
                 }
                 catch (Exception ex)
                 {
@@ -270,7 +270,7 @@ namespace TFTV.TFTVBaseRework
                 }
             }
 
-            internal static bool TrySetOutpostFromActivationUI(GeoSite site, GeoPhoenixFaction faction)
+            internal static bool TrySetOutpostFromActivationUI(GeoSite site, GeoPhoenixFaction faction, IList<PersonnelInfo> chosenPersonnel = null)
             {
                 try
                 {
@@ -282,7 +282,7 @@ namespace TFTV.TFTVBaseRework
                         return false;
                     }
 
-                    return SetOutpost(site, faction);
+                    return SetOutpost(site, faction, chosenPersonnel);
                 }
                 catch (Exception ex)
                 {
@@ -313,11 +313,11 @@ namespace TFTV.TFTVBaseRework
                 }
             }
 
-            private static bool SetOutpost(GeoSite site, GeoPhoenixFaction faction)
+            private static bool SetOutpost(GeoSite site, GeoPhoenixFaction faction, IList<PersonnelInfo> chosenPersonnel)
             {
                 try
                 {
-                    if (!TryPayAndConsumePersonnel(faction, site, OutpostCost, 1))
+                    if (!TryPayAndConsumePersonnel(faction, site, OutpostCost, GetOutpostPersonnelCost(), chosenPersonnel))
                     {
                         return false;
                     }
@@ -332,13 +332,13 @@ namespace TFTV.TFTVBaseRework
                 }
             }
 
-            private static bool EstablishBase(GeoSite site, GeoPhoenixFaction faction, bool fromOutpost)
+            private static bool EstablishBase(GeoSite site, GeoPhoenixFaction faction, bool fromOutpost, IList<PersonnelInfo> chosenPersonnel)
             {
                 try
                 {
-                    int personnel = fromOutpost ? 3 : 4;
-                    ResourcePack cost = fromOutpost ? OutpostCost : FullBaseAdditionalCost;
-                    if (!TryPayAndConsumePersonnel(faction, site, cost, personnel))
+                    int personnel = GetBaseQueuePersonnelCost(fromOutpost);
+                    ResourcePack cost = GetBaseQueueCostPack(fromOutpost);
+                    if (!TryPayAndConsumePersonnel(faction, site, cost, personnel, chosenPersonnel))
                     {
                         return false;
                     }
@@ -353,7 +353,7 @@ namespace TFTV.TFTVBaseRework
                 }
             }
 
-            private static bool TryPayAndConsumePersonnel(GeoPhoenixFaction faction, GeoSite site, ResourcePack cost, int requiredPersonnel)
+            private static bool TryPayAndConsumePersonnel(GeoPhoenixFaction faction, GeoSite site, ResourcePack cost, int requiredPersonnel, IList<PersonnelInfo> chosenPersonnel)
             {
                 try
                 {
@@ -364,7 +364,11 @@ namespace TFTV.TFTVBaseRework
 
                     if (BaseReworkCheck.BaseReworkEnabled)
                     {
-                        if (!PersonnelData.TryConsumePersonnelForBaseActivation(faction, requiredPersonnel))
+                        bool consumed = chosenPersonnel != null && chosenPersonnel.Count > 0
+                            ? PersonnelData.TryConsumeSelectedPersonnelForBaseActivation(faction, chosenPersonnel, requiredPersonnel)
+                            : PersonnelData.TryConsumePersonnelForBaseActivation(faction, requiredPersonnel);
+
+                        if (!consumed)
                         {
                             return false;
                         }

--- a/TFTV/TFTVBaseRework/BaseActivationPersonnelSelection.cs
+++ b/TFTV/TFTVBaseRework/BaseActivationPersonnelSelection.cs
@@ -1,0 +1,427 @@
+using PhoenixPoint.Geoscape.Levels.Factions;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using TFTV.TFTVIncidents;
+using UnityEngine;
+using UnityEngine.UI;
+using Object = UnityEngine.Object;
+
+namespace TFTV.TFTVBaseRework
+{
+    /// <summary>
+    /// Lets the player pick which Personnel are spent on setting up an Outpost or activating a Base,
+    /// instead of letting the game choose. The pick is pre-filled with what the game would have taken,
+    /// so confirming straight away keeps the old behaviour.
+    /// </summary>
+    internal static class BaseActivationPersonnelSelection
+    {
+        private const string OverlayName = "TFTV_BaseActivation_PersonnelSelection";
+
+        private static readonly Color BackdropColor = new Color(0f, 0f, 0f, 0.75f);
+        private static readonly Color PanelColor = new Color(0.07f, 0.08f, 0.12f, 0.98f);
+        private static readonly Color RowNormalColor = new Color(0.12f, 0.14f, 0.18f, 0.9f);
+        private static readonly Color RowSelectedColor = new Color(0.25f, 0.45f, 0.70f, 0.9f);
+        private static readonly Color WarningColor = new Color(1f, 0.45f, 0.35f, 1f);
+        private static readonly Color ConfirmColor = new Color(0.25f, 0.45f, 0.30f, 0.95f);
+        private static readonly Color CancelColor = new Color(0.35f, 0.25f, 0.28f, 0.95f);
+        private static readonly Color DisabledColor = new Color(0.22f, 0.22f, 0.26f, 0.9f);
+
+        private const int TitleFontSize = 40;
+        private const int BodyFontSize = 28;
+        private const int RowFontSize = 26;
+        private const float RowHeight = 56f;
+        private const float ButtonHeight = 64f;
+
+        private static GameObject _overlay;
+
+        private sealed class Row
+        {
+            public PersonnelInfo Person;
+            public int Weight;
+            public bool Selected;
+            public Image Background;
+        }
+
+        /// <summary>
+        /// Opens the picker. Returns false when the UI could not be built or there is nothing to pick,
+        /// in which case the caller should fall back to the automatic selection.
+        /// </summary>
+        internal static bool TryShow(
+            Transform anchor,
+            GeoPhoenixFaction faction,
+            int requiredPersonnel,
+            string actionLabel,
+            Action<List<PersonnelInfo>> onConfirm)
+        {
+            try
+            {
+                if (anchor == null || faction == null || requiredPersonnel <= 0 || onConfirm == null)
+                {
+                    return false;
+                }
+
+                Canvas canvas = anchor.GetComponentInParent<Canvas>();
+                if (canvas == null)
+                {
+                    return false;
+                }
+
+                List<PersonnelInfo> eligible = PersonnelData.GetPersonnelEligibleForBaseActivation(faction);
+                List<PersonnelInfo> preselected = PersonnelData.PickDefaultPersonnelForBaseActivation(faction, requiredPersonnel);
+
+                if (eligible.Count == 0 || preselected == null)
+                {
+                    return false;
+                }
+
+                Close();
+                Build(canvas, eligible, preselected, requiredPersonnel, actionLabel, onConfirm);
+                return _overlay != null;
+            }
+            catch (Exception e)
+            {
+                TFTVLogger.Error(e);
+                Close();
+                return false;
+            }
+        }
+
+        internal static void Close()
+        {
+            if (_overlay != null)
+            {
+                Object.Destroy(_overlay);
+                _overlay = null;
+            }
+        }
+
+        private static void Build(
+            Canvas canvas,
+            List<PersonnelInfo> eligible,
+            List<PersonnelInfo> preselected,
+            int requiredPersonnel,
+            string actionLabel,
+            Action<List<PersonnelInfo>> onConfirm)
+        {
+            _overlay = new GameObject(OverlayName, typeof(RectTransform), typeof(Canvas), typeof(GraphicRaycaster), typeof(Image));
+            _overlay.transform.SetParent(canvas.transform, false);
+            // The host canvas may drive a layout group; the overlay fills the screen on its own.
+            _overlay.AddComponent<LayoutElement>().ignoreLayout = true;
+
+            Canvas overlayCanvas = _overlay.GetComponent<Canvas>();
+            overlayCanvas.overrideSorting = true;
+            overlayCanvas.sortingOrder = 500;
+
+            _overlay.GetComponent<Image>().color = BackdropColor;
+
+            RectTransform overlayRect = _overlay.GetComponent<RectTransform>();
+            overlayRect.anchorMin = Vector2.zero;
+            overlayRect.anchorMax = Vector2.one;
+            overlayRect.offsetMin = Vector2.zero;
+            overlayRect.offsetMax = Vector2.zero;
+
+            GameObject panel = new GameObject("Panel", typeof(RectTransform), typeof(Image), typeof(VerticalLayoutGroup));
+            panel.transform.SetParent(_overlay.transform, false);
+            panel.GetComponent<Image>().color = PanelColor;
+
+            RectTransform panelRect = panel.GetComponent<RectTransform>();
+            panelRect.anchorMin = new Vector2(0.22f, 0.15f);
+            panelRect.anchorMax = new Vector2(0.78f, 0.85f);
+            panelRect.offsetMin = Vector2.zero;
+            panelRect.offsetMax = Vector2.zero;
+
+            VerticalLayoutGroup panelLayout = panel.GetComponent<VerticalLayoutGroup>();
+            panelLayout.padding = new RectOffset(24, 24, 24, 24);
+            panelLayout.spacing = 12f;
+            panelLayout.childControlWidth = true;
+            panelLayout.childControlHeight = true;
+            panelLayout.childForceExpandWidth = true;
+            panelLayout.childForceExpandHeight = false;
+
+            AddLabel(panel.transform, TFTVCommonMethods.ConvertKeyToString("KEY_BASE_PERSONNEL_SELECT_TITLE"),
+                TitleFontSize, Color.yellow, TextAnchor.MiddleCenter, 56f);
+
+            AddLabel(panel.transform,
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    TFTVCommonMethods.ConvertKeyToString("KEY_BASE_PERSONNEL_SELECT_REQUIRED"),
+                    actionLabel,
+                    requiredPersonnel),
+                BodyFontSize, Color.white, TextAnchor.MiddleCenter, 40f);
+
+            AddLabel(panel.transform, TFTVCommonMethods.ConvertKeyToString("KEY_BASE_PERSONNEL_SELECT_WARNING"),
+                BodyFontSize, WarningColor, TextAnchor.MiddleCenter, 76f);
+
+            Transform listContent = CreateScrollArea(panel.transform);
+
+            HashSet<int> preselectedIds = new HashSet<int>(preselected.Select(person => person.Id));
+            List<Row> rows = new List<Row>();
+
+            Text counter = null;
+            Image confirmImage = null;
+            Button confirmButton = null;
+
+            foreach (PersonnelInfo person in eligible)
+            {
+                Row row = new Row
+                {
+                    Person = person,
+                    Weight = PersonnelData.GetActivationWeight(person.Character),
+                    Selected = preselectedIds.Contains(person.Id)
+                };
+
+                CreateRow(listContent, row, () => RefreshFooter(rows, requiredPersonnel, counter, confirmImage, confirmButton));
+                rows.Add(row);
+            }
+
+            counter = AddLabel(panel.transform, string.Empty, BodyFontSize, Color.white, TextAnchor.MiddleCenter, 40f);
+
+            GameObject buttonRow = new GameObject("Buttons", typeof(RectTransform), typeof(HorizontalLayoutGroup));
+            buttonRow.transform.SetParent(panel.transform, false);
+            HorizontalLayoutGroup buttonLayout = buttonRow.GetComponent<HorizontalLayoutGroup>();
+            buttonLayout.spacing = 16f;
+            buttonLayout.childAlignment = TextAnchor.MiddleCenter;
+            buttonLayout.childControlWidth = true;
+            buttonLayout.childControlHeight = true;
+            buttonLayout.childForceExpandWidth = true;
+            buttonLayout.childForceExpandHeight = false;
+            buttonRow.AddComponent<LayoutElement>().minHeight = ButtonHeight;
+
+            confirmButton = CreateButton(
+                buttonRow.transform,
+                TFTVCommonMethods.ConvertKeyToString("KEY_BASE_PERSONNEL_SELECT_CONFIRM"),
+                ConfirmColor,
+                () =>
+                {
+                    List<PersonnelInfo> chosen = rows.Where(r => r.Selected).Select(r => r.Person).ToList();
+                    if (chosen.Sum(person => PersonnelData.GetActivationWeight(person.Character)) < requiredPersonnel)
+                    {
+                        return;
+                    }
+
+                    Close();
+                    onConfirm(chosen);
+                },
+                out confirmImage);
+
+            CreateButton(
+                buttonRow.transform,
+                TFTVCommonMethods.ConvertKeyToString("KEY_BASE_PERSONNEL_SELECT_CANCEL"),
+                CancelColor,
+                Close,
+                out _);
+
+            RefreshFooter(rows, requiredPersonnel, counter, confirmImage, confirmButton);
+            LayoutRebuilder.ForceRebuildLayoutImmediate(panelRect);
+        }
+
+        private static void RefreshFooter(
+            List<Row> rows,
+            int requiredPersonnel,
+            Text counter,
+            Image confirmImage,
+            Button confirmButton)
+        {
+            int selectedWeight = rows.Where(row => row.Selected).Sum(row => row.Weight);
+            bool enough = selectedWeight >= requiredPersonnel;
+
+            if (counter != null)
+            {
+                counter.text = string.Format(
+                    CultureInfo.InvariantCulture,
+                    TFTVCommonMethods.ConvertKeyToString("KEY_BASE_PERSONNEL_SELECT_COUNTER"),
+                    selectedWeight,
+                    requiredPersonnel);
+                counter.color = enough ? Color.white : WarningColor;
+            }
+
+            if (confirmButton != null)
+            {
+                confirmButton.interactable = enough;
+            }
+
+            if (confirmImage != null)
+            {
+                confirmImage.color = enough ? ConfirmColor : DisabledColor;
+            }
+        }
+
+        private static Transform CreateScrollArea(Transform parent)
+        {
+            GameObject scrollView = new GameObject("ScrollView", typeof(RectTransform), typeof(ScrollRect));
+            scrollView.transform.SetParent(parent, false);
+            scrollView.AddComponent<LayoutElement>().flexibleHeight = 1f;
+
+            GameObject viewport = new GameObject("Viewport", typeof(RectTransform), typeof(Mask), typeof(Image));
+            viewport.transform.SetParent(scrollView.transform, false);
+            viewport.GetComponent<Mask>().showMaskGraphic = true;
+            viewport.GetComponent<Image>().color = new Color(0.04f, 0.05f, 0.08f, 0.9f);
+
+            RectTransform viewportRect = viewport.GetComponent<RectTransform>();
+            viewportRect.anchorMin = Vector2.zero;
+            viewportRect.anchorMax = Vector2.one;
+            viewportRect.offsetMin = Vector2.zero;
+            viewportRect.offsetMax = Vector2.zero;
+
+            GameObject content = new GameObject("Content", typeof(RectTransform), typeof(VerticalLayoutGroup), typeof(ContentSizeFitter));
+            content.transform.SetParent(viewport.transform, false);
+
+            RectTransform contentRect = content.GetComponent<RectTransform>();
+            contentRect.anchorMin = new Vector2(0, 1);
+            contentRect.anchorMax = new Vector2(1, 1);
+            contentRect.pivot = new Vector2(0.5f, 1);
+            contentRect.sizeDelta = Vector2.zero;
+
+            VerticalLayoutGroup contentLayout = content.GetComponent<VerticalLayoutGroup>();
+            contentLayout.spacing = 4f;
+            contentLayout.padding = new RectOffset(6, 6, 6, 6);
+            contentLayout.childControlWidth = true;
+            contentLayout.childControlHeight = true;
+            contentLayout.childForceExpandWidth = true;
+            contentLayout.childForceExpandHeight = false;
+
+            content.GetComponent<ContentSizeFitter>().verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+
+            ScrollRect scrollRect = scrollView.GetComponent<ScrollRect>();
+            scrollRect.viewport = viewportRect;
+            scrollRect.content = contentRect;
+            scrollRect.horizontal = false;
+            scrollRect.vertical = true;
+            scrollRect.movementType = ScrollRect.MovementType.Clamped;
+            scrollRect.scrollSensitivity = 30f;
+
+            return content.transform;
+        }
+
+        private static void CreateRow(Transform parent, Row row, Action onToggled)
+        {
+            GameObject go = new GameObject($"Personnel_{row.Person.Id}", typeof(RectTransform), typeof(Image), typeof(Button));
+            go.transform.SetParent(parent, false);
+            go.AddComponent<LayoutElement>().minHeight = RowHeight;
+
+            row.Background = go.GetComponent<Image>();
+            row.Background.color = row.Selected ? RowSelectedColor : RowNormalColor;
+
+            go.GetComponent<Button>().onClick.AddListener(() =>
+            {
+                try
+                {
+                    row.Selected = !row.Selected;
+                    row.Background.color = row.Selected ? RowSelectedColor : RowNormalColor;
+                    onToggled?.Invoke();
+                }
+                catch (Exception e)
+                {
+                    TFTVLogger.Error(e);
+                }
+            });
+
+            GameObject textGO = new GameObject("Text", typeof(RectTransform), typeof(Text));
+            textGO.transform.SetParent(go.transform, false);
+
+            RectTransform textRect = textGO.GetComponent<RectTransform>();
+            textRect.anchorMin = Vector2.zero;
+            textRect.anchorMax = Vector2.one;
+            textRect.offsetMin = new Vector2(16, 0);
+            textRect.offsetMax = new Vector2(-16, 0);
+
+            Text text = textGO.GetComponent<Text>();
+            text.font = ResolveFont();
+            text.text = DescribeRow(row);
+            text.fontSize = RowFontSize;
+            text.color = Color.white;
+            text.alignment = TextAnchor.MiddleLeft;
+            text.horizontalOverflow = HorizontalWrapMode.Overflow;
+            text.verticalOverflow = VerticalWrapMode.Truncate;
+        }
+
+        private static string DescribeRow(Row row)
+        {
+            string name = row.Person.Character?.DisplayName ?? $"Personnel {row.Person.Id}";
+            string assignment = DescribeAssignment(row.Person.Assignment);
+
+            string affinity = LeaderSelection.TryGetCurrentAffinity(row.Person.Character, out LeaderSelection.AffinityApproach approach, out int rank)
+                ? $"{LeaderSelection.GetApproachDisplayName(approach)} {rank}"
+                : "-";
+
+            string weight = row.Weight > 1
+                ? string.Format(
+                    CultureInfo.InvariantCulture,
+                    TFTVCommonMethods.ConvertKeyToString("KEY_BASE_PERSONNEL_SELECT_COUNTS_AS"),
+                    row.Weight)
+                : string.Empty;
+
+            return string.IsNullOrEmpty(weight)
+                ? $"{name}   |   {assignment}   |   {affinity}"
+                : $"{name}   |   {assignment}   |   {affinity}   |   {weight}";
+        }
+
+        private static string DescribeAssignment(PersonnelAssignment assignment)
+        {
+            switch (assignment)
+            {
+                case PersonnelAssignment.Research: return "Research";
+                case PersonnelAssignment.Manufacturing: return "Manufacturing";
+                default: return "Unassigned";
+            }
+        }
+
+        private static Text AddLabel(Transform parent, string caption, int fontSize, Color color, TextAnchor anchor, float minHeight)
+        {
+            GameObject go = new GameObject("Label", typeof(RectTransform), typeof(Text));
+            go.transform.SetParent(parent, false);
+            go.AddComponent<LayoutElement>().minHeight = minHeight;
+
+            Text text = go.GetComponent<Text>();
+            text.font = ResolveFont();
+            text.text = caption;
+            text.fontSize = fontSize;
+            text.color = color;
+            text.alignment = anchor;
+            text.horizontalOverflow = HorizontalWrapMode.Wrap;
+            text.verticalOverflow = VerticalWrapMode.Overflow;
+            return text;
+        }
+
+        private static Button CreateButton(Transform parent, string caption, Color color, Action onClick, out Image image)
+        {
+            GameObject go = new GameObject($"Btn_{caption}", typeof(RectTransform), typeof(Image), typeof(Button));
+            go.transform.SetParent(parent, false);
+            go.AddComponent<LayoutElement>().minHeight = ButtonHeight;
+
+            image = go.GetComponent<Image>();
+            image.color = color;
+
+            Button button = go.GetComponent<Button>();
+            button.onClick.AddListener(() =>
+            {
+                try { onClick?.Invoke(); } catch (Exception e) { TFTVLogger.Error(e); }
+            });
+
+            GameObject textGO = new GameObject("Text", typeof(RectTransform), typeof(Text));
+            textGO.transform.SetParent(go.transform, false);
+
+            RectTransform textRect = textGO.GetComponent<RectTransform>();
+            textRect.anchorMin = Vector2.zero;
+            textRect.anchorMax = Vector2.one;
+            textRect.offsetMin = Vector2.zero;
+            textRect.offsetMax = Vector2.zero;
+
+            Text text = textGO.GetComponent<Text>();
+            text.font = ResolveFont();
+            text.text = caption;
+            text.fontSize = BodyFontSize;
+            text.color = Color.white;
+            text.alignment = TextAnchor.MiddleCenter;
+
+            return button;
+        }
+
+        private static Font ResolveFont()
+        {
+            return PersonnelManagementUI.PuristaSemibold ?? Resources.GetBuiltinResource<Font>("Arial.ttf");
+        }
+    }
+}

--- a/TFTV/TFTVBaseRework/BaseActivationUI.cs
+++ b/TFTV/TFTVBaseRework/BaseActivationUI.cs
@@ -259,7 +259,12 @@ namespace TFTV.TFTVBaseRework
                             root,
                             TFTVCommonMethods.ConvertKeyToString("KEY_BASE_OUTPOST_OPTION"),
                             hasAircraftWithSoldiers && isExplored && PhoenixBaseVisitFlow.CanAffordOutpost(faction),
-                            () => ExecuteAndCloseOnSuccess(modal, () => PhoenixBaseVisitFlow.TrySetOutpostFromActivationUI(site, faction)));
+                            () => SelectPersonnelThenExecute(
+                                __instance,
+                                faction,
+                                PhoenixBaseVisitFlow.GetOutpostPersonnelCost(),
+                                TFTVCommonMethods.ConvertKeyToString("KEY_BASE_OUTPOST_OPTION"),
+                                chosen => ExecuteAndCloseOnSuccess(modal, () => PhoenixBaseVisitFlow.TrySetOutpostFromActivationUI(site, faction, chosen))));
                         ApplyCostRow(outpostBtn, faction, PhoenixBaseVisitFlow.GetOutpostCostPack(), PhoenixBaseVisitFlow.GetOutpostPersonnelCost());
                         SetButtonTooltip(outpostBtn,
                             $"{exploreFirstPrefix}{TFTVCommonMethods.ConvertKeyToString("KEY_BASE_OUTPOST_TOOLTIP")}");
@@ -274,7 +279,12 @@ namespace TFTV.TFTVBaseRework
                         root,
                         activateLabel,
                         hasAircraftWithSoldiers && isExplored && PhoenixBaseVisitFlow.CanAffordBaseQueue(faction, fromOutpost),
-                        () => ExecuteAndCloseOnSuccess(modal, () => PhoenixBaseVisitFlow.TryQueueFullBaseFromActivationUI(site, faction, fromOutpost)));
+                        () => SelectPersonnelThenExecute(
+                            __instance,
+                            faction,
+                            PhoenixBaseVisitFlow.GetBaseQueuePersonnelCost(fromOutpost),
+                            activateLabel,
+                            chosen => ExecuteAndCloseOnSuccess(modal, () => PhoenixBaseVisitFlow.TryQueueFullBaseFromActivationUI(site, faction, fromOutpost, chosen))));
                     ApplyCostRow(activateBaseBtn, faction, PhoenixBaseVisitFlow.GetBaseQueueCostPack(fromOutpost), PhoenixBaseVisitFlow.GetBaseQueuePersonnelCost(fromOutpost));
                     SetButtonTooltip(activateBaseBtn, fromOutpost
                         ? $"{exploreFirstPrefix}{TFTVCommonMethods.ConvertKeyToString("KEY_BASE_OUTPOST_UPGRADE_TOOLTIP")}"
@@ -533,6 +543,32 @@ namespace TFTV.TFTVBaseRework
                     bind.InsufficientResources?.gameObject.SetActive(false);
                 }
                 catch (Exception ex) { TFTVLogger.Error(ex); }
+            }
+
+            /// <summary>
+            /// Asks the player which personnel to spend before running the action. If the picker
+            /// cannot be shown, the action runs with no selection and the game picks for them.
+            /// </summary>
+            private static void SelectPersonnelThenExecute(
+                PXBaseActivationDataBind bind,
+                GeoPhoenixFaction faction,
+                int requiredPersonnel,
+                string actionLabel,
+                Action<List<PersonnelInfo>> execute)
+            {
+                try
+                {
+                    Transform anchor = bind?.Confirm?.transform;
+
+                    if (!BaseActivationPersonnelSelection.TryShow(anchor, faction, requiredPersonnel, actionLabel, execute))
+                    {
+                        execute(null);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    TFTVLogger.Error(ex);
+                }
             }
 
             private static void ExecuteAndCloseOnSuccess(UIModal modal, Func<bool> action)

--- a/TFTV/TFTVBaseRework/Data.cs
+++ b/TFTV/TFTVBaseRework/Data.cs
@@ -372,35 +372,50 @@ namespace TFTV.TFTVBaseRework
             return 1;
         }
 
-        internal static bool TryConsumePersonnelForBaseActivation(GeoPhoenixFaction faction, int requiredPersonnel)
+        /// <summary>
+        /// Personnel that may be spent on setting up an Outpost or activating a Base:
+        /// everyone who is not on field duty and not already in training.
+        /// </summary>
+        internal static List<PersonnelInfo> GetPersonnelEligibleForBaseActivation(GeoPhoenixFaction faction)
         {
-            if (!BaseReworkCheck.BaseReworkEnabled || faction == null || requiredPersonnel <= 0)
+            if (!BaseReworkCheck.BaseReworkEnabled || faction == null)
             {
-                return false;
+                return new List<PersonnelInfo>();
             }
 
-            List<PersonnelInfo> eligible = _assignments.Values
+            return _assignments.Values
                 .Where(person => person?.Character != null && person.Character.Faction == faction)
                 .Where(person => person.Assignment == PersonnelAssignment.Unassigned
                     || person.Assignment == PersonnelAssignment.Research
                     || person.Assignment == PersonnelAssignment.Manufacturing)
+                .OrderBy(person => GetBaseActivationPriority(person.Assignment))
+                .ThenByDescending(person => GetActivationWeight(person.Character))
+                .ThenBy(person => person.Id)
                 .ToList();
+        }
 
-            if (eligible.Sum(person => GetActivationWeight(person.Character)) < requiredPersonnel)
+        /// <summary>
+        /// The set the game would spend on its own, used to pre-fill the selection dialog and as the
+        /// fallback when no selection is made. Returns null when the requirement cannot be met.
+        /// </summary>
+        internal static List<PersonnelInfo> PickDefaultPersonnelForBaseActivation(GeoPhoenixFaction faction, int requiredPersonnel)
+        {
+            if (requiredPersonnel <= 0)
             {
-                return false;
+                return null;
+            }
+
+            List<PersonnelInfo> ordered = GetPersonnelEligibleForBaseActivation(faction);
+
+            if (ordered.Sum(person => GetActivationWeight(person.Character)) < requiredPersonnel)
+            {
+                return null;
             }
 
             // Fill by assignment priority (Unassigned, then Research, then Manufacturing).
             // Within a priority group, spend Psycho-Sociology administrators (weight 3) while their
             // full weight still fits the remaining requirement, and top up with regular personnel.
-            List<PersonnelInfo> ordered = eligible
-                .OrderBy(person => GetBaseActivationPriority(person.Assignment))
-                .ThenByDescending(person => GetActivationWeight(person.Character))
-                .ThenBy(person => person.Id)
-                .ToList();
-
-            List<PersonnelInfo> toConsume = new List<PersonnelInfo>();
+            List<PersonnelInfo> picked = new List<PersonnelInfo>();
             int remaining = requiredPersonnel;
 
             foreach (PersonnelInfo person in ordered)
@@ -416,7 +431,7 @@ namespace TFTV.TFTVBaseRework
                     continue;
                 }
 
-                toConsume.Add(person);
+                picked.Add(person);
                 remaining -= weight;
             }
 
@@ -424,28 +439,75 @@ namespace TFTV.TFTVBaseRework
             // overshoot with the highest-priority one rather than fail.
             if (remaining > 0)
             {
-                PersonnelInfo filler = ordered.FirstOrDefault(person => !toConsume.Contains(person));
+                PersonnelInfo filler = ordered.FirstOrDefault(person => !picked.Contains(person));
                 if (filler == null)
                 {
-                    return false;
+                    return null;
                 }
 
-                toConsume.Add(filler);
+                picked.Add(filler);
                 remaining -= GetActivationWeight(filler.Character);
             }
 
-            if (remaining > 0)
+            return remaining > 0 ? null : picked;
+        }
+
+        /// <summary>
+        /// Spends exactly the personnel the player picked. They are dismissed for good, as with the
+        /// automatic selection.
+        /// </summary>
+        internal static bool TryConsumeSelectedPersonnelForBaseActivation(
+            GeoPhoenixFaction faction,
+            IList<PersonnelInfo> selection,
+            int requiredPersonnel)
+        {
+            if (!BaseReworkCheck.BaseReworkEnabled || faction == null || requiredPersonnel <= 0 || selection == null)
             {
                 return false;
             }
 
+            HashSet<int> eligibleIds = new HashSet<int>(GetPersonnelEligibleForBaseActivation(faction).Select(person => person.Id));
+
+            List<PersonnelInfo> toConsume = selection
+                .Where(person => person?.Character != null && eligibleIds.Contains(person.Id))
+                .Distinct()
+                .ToList();
+
+            if (toConsume.Count != selection.Count
+                || toConsume.Sum(person => GetActivationWeight(person.Character)) < requiredPersonnel)
+            {
+                TFTVLogger.Always($"[PersonnelData] Rejected personnel selection for base activation: {toConsume.Count}/{selection.Count} still eligible, {requiredPersonnel} required.");
+                return false;
+            }
+
+            ConsumePersonnelForBaseActivation(faction, toConsume);
+            return true;
+        }
+
+        internal static bool TryConsumePersonnelForBaseActivation(GeoPhoenixFaction faction, int requiredPersonnel)
+        {
+            if (!BaseReworkCheck.BaseReworkEnabled || faction == null)
+            {
+                return false;
+            }
+
+            List<PersonnelInfo> toConsume = PickDefaultPersonnelForBaseActivation(faction, requiredPersonnel);
+            if (toConsume == null)
+            {
+                return false;
+            }
+
+            ConsumePersonnelForBaseActivation(faction, toConsume);
+            return true;
+        }
+
+        private static void ConsumePersonnelForBaseActivation(GeoPhoenixFaction faction, IEnumerable<PersonnelInfo> toConsume)
+        {
             foreach (PersonnelInfo person in toConsume)
             {
                 RemovePersonnel(faction, person);
                 faction.KillCharacter(person.Character, CharacterDeathReason.Dismissed);
             }
-
-            return true;
         }
 
         private static int GetBaseActivationPriority(PersonnelAssignment assignment)

--- a/TFTV/TFTVBaseRework/UI/AffinityBadgeTooltip.cs
+++ b/TFTV/TFTVBaseRework/UI/AffinityBadgeTooltip.cs
@@ -1,0 +1,213 @@
+using Base.UI;
+using PhoenixPoint.Tactical.Entities.Abilities;
+using System;
+using TFTV.TFTVIncidents;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+namespace TFTV.TFTVBaseRework
+{
+    /// <summary>
+    /// Hover tooltip for the Affinity icon on a personnel slot: names the Affinity and its rank,
+    /// then lists every benefit it grants, base duty included.
+    /// </summary>
+    internal sealed class AffinityBadgeTooltip : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler
+    {
+        internal LeaderSelection.AffinityApproach Approach;
+        internal int Rank;
+
+        private const string TooltipObjectName = "TFTV_AffinityBadgeTooltip";
+        private const float TooltipWidth = 700f;
+        private const float TooltipMargin = 8f;
+        private const int TooltipFontSize = 26;
+        private const int TooltipPadH = 18;
+        private const int TooltipPadV = 14;
+
+        private static RectTransform _tooltipRect;
+        private static Text _tooltipLabel;
+
+        public void OnPointerEnter(PointerEventData eventData)
+        {
+            Show();
+        }
+
+        public void OnPointerExit(PointerEventData eventData)
+        {
+            Hide();
+        }
+
+        private void OnDisable()
+        {
+            Hide();
+        }
+
+        private void Show()
+        {
+            try
+            {
+                RectTransform tooltip = EnsureTooltip(transform);
+                if (tooltip == null)
+                {
+                    return;
+                }
+
+                string content = BuildContent();
+                if (string.IsNullOrEmpty(content))
+                {
+                    Hide();
+                    return;
+                }
+
+                _tooltipLabel.text = content;
+                LayoutRebuilder.ForceRebuildLayoutImmediate(_tooltipLabel.rectTransform);
+                LayoutRebuilder.ForceRebuildLayoutImmediate(tooltip);
+
+                PositionNextTo(tooltip, transform as RectTransform);
+
+                tooltip.gameObject.SetActive(true);
+                tooltip.SetAsLastSibling();
+            }
+            catch (Exception e)
+            {
+                TFTVLogger.Error(e);
+            }
+        }
+
+        private static void Hide()
+        {
+            if (_tooltipRect != null && _tooltipRect.gameObject.activeSelf)
+            {
+                _tooltipRect.gameObject.SetActive(false);
+            }
+        }
+
+        private string BuildContent()
+        {
+            string header = null;
+
+            PassiveModifierAbilityDef ability = LeaderSelection.GetAffinityAbility(Approach, Rank);
+            if (ability?.ViewElementDef?.DisplayName1 != null)
+            {
+                header = ability.ViewElementDef.DisplayName1.Localize();
+            }
+
+            if (string.IsNullOrEmpty(header))
+            {
+                header = $"{LeaderSelection.GetApproachDisplayName(Approach)} {Rank}";
+            }
+
+            string benefitsKey = LeaderSelection.GetAllBenefitsLocalizationKey(Approach);
+            string benefits = string.IsNullOrEmpty(benefitsKey)
+                ? string.Empty
+                : new LocalizedTextBind() { LocalizationKey = benefitsKey }.Localize();
+
+            return string.IsNullOrEmpty(benefits) ? header : $"{header}\n\n{benefits}";
+        }
+
+        /// <summary>
+        /// Anchors the tooltip to the left of the icon and keeps it inside the canvas.
+        /// </summary>
+        private static void PositionNextTo(RectTransform tooltip, RectTransform iconRect)
+        {
+            if (tooltip == null || iconRect == null)
+            {
+                return;
+            }
+
+            Canvas canvas = tooltip.GetComponentInParent<Canvas>();
+            RectTransform canvasRect = canvas?.transform as RectTransform;
+            if (canvasRect == null)
+            {
+                return;
+            }
+
+            Camera cam = canvas.renderMode == RenderMode.ScreenSpaceOverlay ? null : canvas.worldCamera;
+
+            Vector3[] corners = new Vector3[4];
+            iconRect.GetWorldCorners(corners);
+            // corners[1] is the top-left corner of the icon.
+            Vector2 screenPoint = RectTransformUtility.WorldToScreenPoint(cam, corners[1]);
+
+            if (!RectTransformUtility.ScreenPointToLocalPointInRectangle(canvasRect, screenPoint, cam, out Vector2 localPoint))
+            {
+                return;
+            }
+
+            float halfWidth = canvasRect.rect.width * 0.5f;
+            float halfHeight = canvasRect.rect.height * 0.5f;
+            float tooltipWidth = tooltip.rect.width;
+            float tooltipHeight = tooltip.rect.height;
+
+            // Pivot is top-right, so the tooltip hangs down and to the left of the anchor point.
+            float x = Mathf.Clamp(localPoint.x, -halfWidth + tooltipWidth + TooltipMargin, halfWidth - TooltipMargin);
+            float y = Mathf.Clamp(localPoint.y, -halfHeight + tooltipHeight + TooltipMargin, halfHeight - TooltipMargin);
+
+            tooltip.anchoredPosition = new Vector2(x, y);
+        }
+
+        private static RectTransform EnsureTooltip(Transform reference)
+        {
+            if (_tooltipRect != null)
+            {
+                return _tooltipRect;
+            }
+
+            Canvas canvas = reference.GetComponentInParent<Canvas>();
+            if (canvas == null)
+            {
+                return null;
+            }
+
+            GameObject go = new GameObject(
+                TooltipObjectName,
+                typeof(RectTransform),
+                typeof(VerticalLayoutGroup),
+                typeof(ContentSizeFitter),
+                typeof(Image));
+            go.transform.SetParent(canvas.transform, false);
+            // The panel root drives a layout group; the tooltip places itself.
+            go.AddComponent<LayoutElement>().ignoreLayout = true;
+
+            _tooltipRect = go.GetComponent<RectTransform>();
+            _tooltipRect.anchorMin = new Vector2(0.5f, 0.5f);
+            _tooltipRect.anchorMax = new Vector2(0.5f, 0.5f);
+            _tooltipRect.pivot = new Vector2(1f, 1f);
+            _tooltipRect.sizeDelta = new Vector2(TooltipWidth, 0f);
+
+            Image bg = go.GetComponent<Image>();
+            bg.color = new Color(0.06f, 0.06f, 0.10f, 0.94f);
+            bg.raycastTarget = false;
+
+            VerticalLayoutGroup vlg = go.GetComponent<VerticalLayoutGroup>();
+            vlg.padding = new RectOffset(TooltipPadH, TooltipPadH, TooltipPadV, TooltipPadV);
+            vlg.childAlignment = TextAnchor.UpperLeft;
+            vlg.childControlWidth = true;
+            vlg.childControlHeight = true;
+            vlg.childForceExpandWidth = true;
+            vlg.childForceExpandHeight = false;
+
+            ContentSizeFitter csf = go.GetComponent<ContentSizeFitter>();
+            csf.horizontalFit = ContentSizeFitter.FitMode.Unconstrained;
+            csf.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+
+            GameObject textGO = new GameObject("Label", typeof(RectTransform), typeof(Text));
+            textGO.transform.SetParent(go.transform, false);
+
+            _tooltipLabel = textGO.GetComponent<Text>();
+            _tooltipLabel.font = PersonnelManagementUI.PuristaSemibold
+                ?? canvas.GetComponentInChildren<Text>(true)?.font
+                ?? Resources.GetBuiltinResource<Font>("Arial.ttf");
+            _tooltipLabel.fontSize = TooltipFontSize;
+            _tooltipLabel.color = Color.white;
+            _tooltipLabel.alignment = TextAnchor.UpperLeft;
+            _tooltipLabel.horizontalOverflow = HorizontalWrapMode.Wrap;
+            _tooltipLabel.verticalOverflow = VerticalWrapMode.Overflow;
+            _tooltipLabel.supportRichText = true;
+            _tooltipLabel.raycastTarget = false;
+
+            go.SetActive(false);
+            return _tooltipRect;
+        }
+    }
+}

--- a/TFTV/TFTVBaseRework/UI/Panel.cs
+++ b/TFTV/TFTVBaseRework/UI/Panel.cs
@@ -519,7 +519,9 @@ namespace TFTV.TFTVBaseRework
                 var badgeImg = badgeGO.AddComponent<Image>();
                 badgeImg.sprite = icon;
                 badgeImg.preserveAspect = true;
-                badgeImg.raycastTarget = false;
+                // Raycasts have to reach the badge for the hover tooltip. Clicks and drags still
+                // bubble up to the slot, which is where the selector and drag handler live.
+                badgeImg.raycastTarget = true;
 
                 var badgeRect = badgeGO.GetComponent<RectTransform>();
                 badgeRect.anchorMin = new Vector2(1, 1);
@@ -527,6 +529,10 @@ namespace TFTV.TFTVBaseRework
                 badgeRect.pivot = new Vector2(1, 1);
                 badgeRect.anchoredPosition = new Vector2(-6, -6);
                 badgeRect.sizeDelta = new Vector2(36, 36);
+
+                var tooltip = badgeGO.AddComponent<AffinityBadgeTooltip>();
+                tooltip.Approach = approach;
+                tooltip.Rank = rank;
             }
             catch (Exception e)
             {

--- a/TFTV/TFTVIncidents/IncidentResolutionUI.cs
+++ b/TFTV/TFTVIncidents/IncidentResolutionUI.cs
@@ -311,29 +311,10 @@ namespace TFTV.TFTVIncidents
 
                 private static string BuildContent(LeaderSelection.AffinityApproach approach)
                 {
-                    string key;
-                    switch (approach)
+                    string key = LeaderSelection.GetAllBenefitsLocalizationKey(approach);
+                    if (string.IsNullOrEmpty(key))
                     {
-                        case LeaderSelection.AffinityApproach.PsychoSociology:
-                            key = "KEY_AFFINITY_PSYCHO_SOCIOLOGY_ALL_BENEFITS";
-                            break;
-                        case LeaderSelection.AffinityApproach.Exploration:
-                            key = "KEY_AFFINITY_EXPLORATION_ALL_BENEFITS";
-                            break;
-                        case LeaderSelection.AffinityApproach.Occult:
-                            key = "KEY_AFFINITY_OCCULT_ALL_BENEFITS";
-                            break;
-                        case LeaderSelection.AffinityApproach.Biotech:
-                            key = "KEY_AFFINITY_BIOTECH_ALL_BENEFITS";
-                            break;
-                        case LeaderSelection.AffinityApproach.Machinery:
-                            key = "KEY_AFFINITY_MACHINERY_ALL_BENEFITS";
-                            break;
-                        case LeaderSelection.AffinityApproach.Compute:
-                            key = "KEY_AFFINITY_COMPUTE_ALL_BENEFITS";
-                            break;
-                        default:
-                            return approach.ToString();
+                        return approach.ToString();
                     }
 
                     return new LocalizedTextBind() { LocalizationKey = key }.Localize();

--- a/TFTV/TFTVIncidents/LeaderSelection.cs
+++ b/TFTV/TFTVIncidents/LeaderSelection.cs
@@ -556,6 +556,37 @@ namespace TFTV.TFTVIncidents
             }
         }
 
+        internal static string GetApproachDisplayName(AffinityApproach approach)
+        {
+            switch (approach)
+            {
+                case AffinityApproach.PsychoSociology: return "Psycho-Sociology";
+                case AffinityApproach.Exploration: return "Exploration";
+                case AffinityApproach.Occult: return "Occult";
+                case AffinityApproach.Biotech: return "Biotech";
+                case AffinityApproach.Machinery: return "Machinery";
+                case AffinityApproach.Compute: return "Compute";
+                default: return approach.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Localization key listing every benefit of the Affinity, Geoscape, Tactical and base duty alike.
+        /// </summary>
+        internal static string GetAllBenefitsLocalizationKey(AffinityApproach approach)
+        {
+            switch (approach)
+            {
+                case AffinityApproach.PsychoSociology: return "KEY_AFFINITY_PSYCHO_SOCIOLOGY_ALL_BENEFITS";
+                case AffinityApproach.Exploration: return "KEY_AFFINITY_EXPLORATION_ALL_BENEFITS";
+                case AffinityApproach.Occult: return "KEY_AFFINITY_OCCULT_ALL_BENEFITS";
+                case AffinityApproach.Biotech: return "KEY_AFFINITY_BIOTECH_ALL_BENEFITS";
+                case AffinityApproach.Machinery: return "KEY_AFFINITY_MACHINERY_ALL_BENEFITS";
+                case AffinityApproach.Compute: return "KEY_AFFINITY_COMPUTE_ALL_BENEFITS";
+                default: return null;
+            }
+        }
+
         internal static GeoCharacter SelectFallbackLeader(GeoVehicle vehicle)
         {
             IEnumerable<GeoCharacter> characters = vehicle?.GetAllCharacters() ?? Enumerable.Empty<GeoCharacter>();


### PR DESCRIPTION
Follow-up to the recent base rework balance changes. The tutorial panels and tooltips still described the old numbers, and two of the new rules had no UI to go with them.

## Texts

`Dist/Assets/Localization/TFTV_AircraftRework_Localization.csv`. Every number below was checked against the implementation rather than the design notes — `ResearchAndManufacturing.GetWorkerOutput`, `TrainingFacilityRework.GetMaxTargetLevel`, `PersonnelData.GetActivationWeight`, `PersonnelData.ApplyPendingRecruitAffinity`.

- **Worker output.** `TUTORIAL_PERSONNEL_TEXT0`, `KEY_RESEARCH_TOTAL_TT` and `KEY_PRODUCTION_TOTAL_TT` all claimed a Personnel on a worker slot generates 4. Corrected to 2, with the per-Affinity table: Biotech 6 Research, Machinery 6 Manufacturing, Compute / Occult / Psycho-Sociology 4 of either, Exploration 2 like everyone else.
- **Training caps.** Compute and Occult to Level 5, Exploration to Level 6.
- **Administration.** Psycho-Sociology counting as 3 Personnel toward an Outpost or Base activation, in `TUTORIAL_PERSONNEL_TEXT0`, `TUTORIAL_ADDITIONAL_BASES_TEXT0`, and the four site tooltips (`KEY_BASE_OUTPOST_TOOLTIP`, `KEY_BASE_OUTPOST_UPGRADE_TOOLTIP`, `KEY_BASE_ACTIVATE_OPTION_TOOLTIP`, `KEY_OUTPOST_ACTIVATED_DESCRIPTION`).
- **Recruit affinities.** A rank 2 leader gives one of the Personnel gained their Affinity at rank 1; a rank 3 leader adds a second recruit with a different random Affinity. Added to `TUTORIAL_PERSONNEL_TEXT0`, `TUTORIAL_INCIDENTS_TEXT0`, `TUTORIAL_INCIDENTS_TEXT1` (phrased there as a reason to care who leads) and `TUTORIAL_AFFINITIES_TEXT0`.
- **Affinity tooltips.** Each of the six `KEY_AFFINITY_*_ALL_BENEFITS` entries gained a "Base Duty Benefits" section listing only what that Affinity grants, and noting that unlike the Geoscape and Tactical benefits these do not scale with rank.
- No mention of Elite Training: the research is not implemented, so the text says Level 4 flat. The code path in `GetMaxTargetLevel` that raises the cap to 5 on `PX_EliteTraining_ResearchDef` is left in place but inert.

The `KEY_AFFINITY_DESC_<X>_<rank>` ability descriptions were deliberately left alone — `Affinities.RefreshTacticalAbilityDescriptionsFromSnapshot` overwrites `ViewElementDef.Description` at runtime, so edits there would not show.

## Affinity badge tooltip

New `TFTV/TFTVBaseRework/UI/AffinityBadgeTooltip.cs`. Hovering the badge in the assignments screen names the Affinity and rank (from the ability's own `DisplayName1`, e.g. "COMPUTE 2") and lists every benefit, base duty included. It clamps itself inside the canvas so badges near an edge do not push it off-screen.

The badge's `raycastTarget` had to go true for hover to reach it. The component only handles pointer enter/exit, so clicks and drags still bubble to the slot's `PersonnelSlotSelector` and `PersonnelSlotDragHandler`.

The benefits-key lookup moved out of `IncidentResolutionUI` into `LeaderSelection.GetAllBenefitsLocalizationKey`, so both tooltips read from one place.

## Choosing who is spent on a Base or Outpost

New `TFTV/TFTVBaseRework/BaseActivationPersonnelSelection.cs`. "Set up an Outpost", "Activate the Base" and "Upgrade to regular Base" now open a picker over the activation modal instead of acting immediately:

- Lists every eligible Personnel (Unassigned / Research / Manufacturing) with name, current assignment, Affinity, and "Administrator, counts as 3" for Psycho-Sociology.
- Pre-selected with exactly who the game would have taken, so confirming straight away reproduces the old behaviour.
- Warns that Personnel posted to a site stay there for good and cannot normally be recovered.
- Running "Selected: N / M" counter by activation weight; Confirm stays disabled until the requirement is met. Cancel leaves the activation modal open.

On the data side, the old auto-picker in `Data.cs` splits into `GetPersonnelEligibleForBaseActivation`, `PickDefaultPersonnelForBaseActivation` (the previous algorithm, now also used to pre-fill the dialog) and `TryConsumeSelectedPersonnelForBaseActivation`, which re-validates the picked set against the eligible pool and the requirement before spending it, so a stale selection cannot slip through. `TryConsumePersonnelForBaseActivation` keeps its old behaviour and is the fallback whenever no selection is supplied.

The selection threads through as an optional parameter (`TrySetOutpostFromActivationUI` / `TryQueueFullBaseFromActivationUI` → `TryPayAndConsumePersonnel`), so existing callers are unaffected.

`SetOutpost` and `EstablishBase` also drop their hardcoded `1`/`3`/`4` and cost-pack literals in favour of the existing `GetOutpostPersonnelCost` / `GetBaseQueuePersonnelCost` / `GetBaseQueueCostPack` helpers, which the cost rows in the UI were already using. Same values, one source now.

## Reviewer notes

- **Not verified in-game.** This is compile-verified only (`dotnet build`, 0 errors, the same 7 pre-existing warnings). The picker is hand-built uGUI, so the panel proportions and the tooltip placement are worth a look on a real activation.
- **One path left on automatic selection:** the `ActivateBaseAbilityView.PayResourcementCost` patch, which is the vanilla confirm route. With the rework on, that modal's Confirm button is cleared and hidden in favour of the custom buttons, so it should be unreachable. If a base ever activates without the picker appearing, that is the path to look at.
- The localization CSV was rewritten through a CSV parser; a round-trip check confirmed only the intended rows changed, and the file still parses as 237 rows × 12 columns with CRLF endings and no trailing newline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
