### PR TITLE
Base rework: fix research/manufacturing income and its topbar display

### DIFF
--- a/TFTV/TFTVBaseRework/Data.cs
+++ b/TFTV/TFTVBaseRework/Data.cs
@@ -671,14 +671,18 @@ namespace TFTV.TFTVBaseRework
                 return false;
             }
 
-            if (!ResearchManufacturingSlotsManager.IncrementUsedSlot(faction, slotType))
-            {
-                return false;
-            }
-
+            // Assign before reserving the slot: reserving refreshes the info bar, which recalculates
+            // income from these records and would not yet see this person.
             person.Assignment = slotType == FacilitySlotType.Research
                 ? PersonnelAssignment.Research
                 : PersonnelAssignment.Manufacturing;
+
+            if (!ResearchManufacturingSlotsManager.IncrementUsedSlot(faction, slotType))
+            {
+                person.Assignment = PersonnelAssignment.Unassigned;
+                return false;
+            }
+
             person.TrainingSpec = null;
 
             TFTVLogger.Always($"{LogPrefix} Auto-assigned {person.Character.DisplayName} to {person.Assignment}.");
@@ -795,9 +799,14 @@ namespace TFTV.TFTVBaseRework
 
             TFTVLogger.Always($"{LogPrefix} RemovePersonnel requested Name={name} RequestedId={requestedId} CharacterId={characterId} Assignment={person.Assignment}");
 
-            if (person.Assignment == PersonnelAssignment.Research || person.Assignment == PersonnelAssignment.Manufacturing)
+            // Clear the assignment before releasing the slot, so the income recalculation the release
+            // triggers no longer counts this person's output.
+            PersonnelAssignment vacatedAssignment = person.Assignment;
+            person.Assignment = PersonnelAssignment.Unassigned;
+
+            if (vacatedAssignment == PersonnelAssignment.Research || vacatedAssignment == PersonnelAssignment.Manufacturing)
             {
-                ReleaseWorkSlotIfNeeded(faction, person.Assignment);
+                ReleaseWorkSlotIfNeeded(faction, vacatedAssignment);
             }
 
             bool removed = _assignments.Remove(requestedId);
@@ -876,15 +885,18 @@ namespace TFTV.TFTVBaseRework
                 return false;
             }
 
-            bool slotAdded = ResearchManufacturingSlotsManager.IncrementUsedSlot(faction, slotType);
-            if (!slotAdded)
+            // Move the person first. Both slot counters refresh the info bar, which recalculates income
+            // from these records, so they have to see the new assignment or the figure comes out stale.
+            person.Assignment = desired;
+
+            if (!ResearchManufacturingSlotsManager.IncrementUsedSlot(faction, slotType))
             {
+                person.Assignment = previous;
                 TFTVLogger.Always($"{LogPrefix} No free {slotType} slots available (used >= provided).");
                 return false;
             }
 
             ReleaseWorkSlotIfNeeded(faction, previous);
-            person.Assignment = desired;
 
             GeoLevelController level = GameUtl.CurrentLevel().GetComponent<GeoLevelController>();
             UIModuleInfoBar infoBar = level.View.GeoscapeModules.ResourcesModule;
@@ -1403,13 +1415,16 @@ namespace TFTV.TFTVBaseRework
             }
 
             PersonnelAssignment previous = person.Assignment;
+
+            // Move to Training before releasing the work slot, so the income recalculation the release
+            // triggers already sees this person off research/manufacturing duty.
+            person.Assignment = PersonnelAssignment.Training;
+            person.TrainingSpec = spec;
+
             if (previous == PersonnelAssignment.Research || previous == PersonnelAssignment.Manufacturing)
             {
                 ReleaseWorkSlotIfNeeded(faction, previous);
             }
-
-            person.Assignment = PersonnelAssignment.Training;
-            person.TrainingSpec = spec;
 
             TryAutoAssignUnassignedPersonnel(faction, "AssignPersonnelToTraining");
             return true;
@@ -1423,12 +1438,15 @@ namespace TFTV.TFTVBaseRework
             PersonnelAssignment previous = person.Assignment;
             if (previous == PersonnelAssignment.Unassigned) return;
 
+            // Clear the assignment before releasing the slot: releasing refreshes the info bar, which
+            // recalculates income from these records and would otherwise still count this person.
+            person.Assignment = PersonnelAssignment.Unassigned;
+
             if (previous == PersonnelAssignment.Research || previous == PersonnelAssignment.Manufacturing)
             {
                 ReleaseWorkSlotIfNeeded(faction, previous);
             }
 
-            person.Assignment = PersonnelAssignment.Unassigned;
             TFTVLogger.Always($"{LogPrefix} Unassigned {person.Character.DisplayName} from {previous} to Unassigned.");
 
             try
@@ -1492,8 +1510,9 @@ namespace TFTV.TFTVBaseRework
                         break;
                     }
 
-                    ReleaseWorkSlotIfNeeded(faction, person.Assignment);
+                    PersonnelAssignment vacated = person.Assignment;
                     person.Assignment = PersonnelAssignment.Unassigned;
+                    ReleaseWorkSlotIfNeeded(faction, vacated);
                     over--;
 
                     TFTVLogger.Always($"{LogPrefix} Evicted {person.Character.DisplayName} from {targetAssignment} due to living capacity.");

--- a/TFTV/TFTVBaseRework/ResearchAndManufacturing.cs
+++ b/TFTV/TFTVBaseRework/ResearchAndManufacturing.cs
@@ -1,13 +1,19 @@
-﻿using PhoenixPoint.Common.Core;
+using HarmonyLib;
+using PhoenixPoint.Common.Core;
 using PhoenixPoint.Common.Entities;
 using PhoenixPoint.Geoscape.Entities;
+using PhoenixPoint.Geoscape.Entities.PhoenixBases;
 using PhoenixPoint.Geoscape.Entities.PhoenixBases.FacilityComponents;
+using PhoenixPoint.Geoscape.Entities.Sites;
 using PhoenixPoint.Geoscape.Levels;
 using PhoenixPoint.Geoscape.Levels.Factions;
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using TFTV.TFTVIncidents;
 using UnityEngine;
+using static TFTV.TFTVBaseRework.BaseActivation;
 
 namespace TFTV.TFTVBaseRework
 {
@@ -17,9 +23,8 @@ namespace TFTV.TFTVBaseRework
         internal const float AffinityWorkerOutputPerSlot = 4.0f;
         internal const float SpecialistWorkerOutputPerSlot = 6.0f;
 
-        private const int UnoccupiedResearchPerSlot = 1;
-        private const int UnoccupiedProductionPerSlot = 2;
-        private const string CentralizedAIResearchId = "NJ_CentralizedAI_ResearchDef";
+        private static readonly MethodInfo OnIncomeChangedMethod =
+            AccessTools.Method(typeof(GeoFaction), "OnIncomeChanged");
 
         internal static void ApplyProductionAdjustments(GeoFaction faction)
         {
@@ -29,29 +34,67 @@ namespace TFTV.TFTVBaseRework
             }
 
             GeoPhoenixFaction phoenixFaction = faction as GeoPhoenixFaction;
-            if (phoenixFaction == null)
+            if (phoenixFaction?.ResourceIncome == null)
             {
                 return;
             }
 
-            ResourcePack baseProductionOutput = GetProductionReasonOutput(phoenixFaction);
+            // Recompute the raw site production the same way GeoFaction.UpdateProduction does, rather
+            // than reading back whatever is currently stored. Reading the stored value would fold our
+            // own bonus back in every time this runs outside the UpdateProduction postfix.
+            ResourcePack sitePack = GetSiteProduction(phoenixFaction);
 
-            float baseResearch = baseProductionOutput.ByResourceType(ResourceType.Research).Value;
-            float baseProduction = baseProductionOutput.ByResourceType(ResourceType.Production).Value;
-            //   float baseSupplies = baseProductionOutput.ByResourceType(ResourceType.Supplies).Value;
-            //   float baseMutagen = baseProductionOutput.ByResourceType(ResourceType.Mutagen).Value;
-
-            // TFTVLogger.Always($"Base production output - Research: {baseResearch}, Production: {baseProduction}, Supplies: {baseSupplies}, Mutagen: {baseMutagen}");
+            float baseResearch = sitePack.ByResourceType(ResourceType.Research).Value;
+            float baseProduction = sitePack.ByResourceType(ResourceType.Production).Value;
 
             GetOutputBonuses(phoenixFaction, out float researchBonus, out float productionBonus);
 
-            phoenixFaction.ResourceIncome.SetOutput(OperationReason.Production, new ResourcePack(new ResourceUnit[]
+            float newResearch = Mathf.Max(0f, baseResearch + researchBonus);
+            float newProduction = Mathf.Max(0f, baseProduction + productionBonus);
+
+            // Keep every other resource the bases generate (food, mutagen, ...) exactly as the sites
+            // reported it. SetOutput replaces the whole pack, so anything omitted here is lost income.
+            List<ResourceUnit> units = sitePack.Values
+                .Where(unit => unit.Type != ResourceType.Research && unit.Type != ResourceType.Production)
+                .ToList();
+
+            units.Add(new ResourceUnit(ResourceType.Research, newResearch));
+            units.Add(new ResourceUnit(ResourceType.Production, newProduction));
+
+            float previousResearch = phoenixFaction.ResourceIncome.GetTotalResouce(ResourceType.Research).Value;
+            float previousProduction = phoenixFaction.ResourceIncome.GetTotalResouce(ResourceType.Production).Value;
+
+            phoenixFaction.ResourceIncome.SetOutput(OperationReason.Production, new ResourcePack(units));
+
+            // UpdateProduction raises IncomeChanged before this postfix runs, so the info bar would
+            // otherwise keep showing the unadjusted figure until something else refreshes it.
+            if (!Mathf.Approximately(previousResearch, newResearch) || !Mathf.Approximately(previousProduction, newProduction))
             {
-                new ResourceUnit(ResourceType.Research, Mathf.Max(0f, baseResearch + researchBonus)),
-                new ResourceUnit(ResourceType.Production, Mathf.Max(0f, baseProduction + productionBonus)),
-               // new ResourceUnit(ResourceType.Supplies, baseSupplies),
-               // new ResourceUnit(ResourceType.Mutagen, baseMutagen)
-            }));
+                try
+                {
+                    OnIncomeChangedMethod?.Invoke(phoenixFaction, null);
+                }
+                catch (Exception e)
+                {
+                    TFTVLogger.Error(e);
+                }
+            }
+        }
+
+        private static ResourcePack GetSiteProduction(GeoPhoenixFaction faction)
+        {
+            try
+            {
+                return new ResourcePack(faction.Sites
+                    .Select(site => site.SiteProduction)
+                    .Where(production => production != null)
+                    .SelectMany(production => production.Values));
+            }
+            catch (Exception e)
+            {
+                TFTVLogger.Error(e);
+                return new ResourcePack();
+            }
         }
 
         internal static void GetOutputBonuses(GeoPhoenixFaction faction, out float researchBonus, out float productionBonus)
@@ -65,69 +108,85 @@ namespace TFTV.TFTVBaseRework
             }
 
             PoolAssignmentSnapshot snapshot = BuildPoolAssignmentSnapshot(faction);
-            researchBonus = GetAssignedBonus(faction, PersonnelAssignment.Research, snapshot.ResearchAssigned, ResourceType.Research)
-                + GetIdleSlotBonus(faction, snapshot.ResearchCapacity, snapshot.ResearchAssigned, ResourceType.Research, UnoccupiedResearchPerSlot);
+
+            researchBonus = GetAssignedBonus(faction, PersonnelAssignment.Research, snapshot.ResearchCapacity, ResourceType.Research)
+                + GetIdleSlotBonus(faction, snapshot.ResearchCapacity, snapshot.ResearchAssigned, ResourceType.Research);
 
             if (TFTVVoidOmens.VoidOmensCheck[6])
             {
                 researchBonus *= 1.5f;
             }
 
-            productionBonus = GetAssignedBonus(faction, PersonnelAssignment.Manufacturing, snapshot.ManufacturingAssigned, ResourceType.Production)
-                + GetIdleSlotBonus(faction, snapshot.ManufacturingCapacity, snapshot.ManufacturingAssigned, ResourceType.Production, UnoccupiedProductionPerSlot);
+            productionBonus = GetAssignedBonus(faction, PersonnelAssignment.Manufacturing, snapshot.ManufacturingCapacity, ResourceType.Production)
+                + GetIdleSlotBonus(faction, snapshot.ManufacturingCapacity, snapshot.ManufacturingAssigned, ResourceType.Production);
         }
 
-        private static ResourcePack GetProductionReasonOutput(GeoPhoenixFaction faction)
-        {
-            if (faction?.ResourceIncome == null)
-            {
-                return new ResourcePack();
-            }
-
-            try
-            {
-
-                return new ResourcePack(new ResourceUnit[]
-                {
-                new ResourceUnit(ResourceType.Research, faction.ResourceIncome.GetTotalResouce(ResourceType.Research).Value),
-                new ResourceUnit(ResourceType.Production, faction.ResourceIncome.GetTotalResouce(ResourceType.Production).Value),
-                    //  new ResourceUnit(ResourceType.Supplies, faction.ResourceIncome.GetTotalResouce(ResourceType.Supplies).Value),
-                    //  new ResourceUnit(ResourceType.Mutagen, faction.ResourceIncome.GetTotalResouce(ResourceType.Mutagen).Value)
-
-                });
-
-            }
-            catch (Exception e)
-            {
-                TFTVLogger.Error(e);
-                throw;
-            }
-        }
-
+        /// <summary>
+        /// Capacity comes from the facilities, the assigned count from the personnel records. The
+        /// running slot counters are display state and drift from the records mid-assignment, so they
+        /// must not feed the income.
+        /// </summary>
         private static PoolAssignmentSnapshot BuildPoolAssignmentSnapshot(GeoPhoenixFaction faction)
         {
             Workers.FacilitySlotPools pools = Workers.ResearchManufacturingSlotsManager.RecalculateSlots(faction);
 
+            int researchCapacity = pools.Research.ProvidedSlots;
+            int manufacturingCapacity = pools.Manufacturing.ProvidedSlots;
+
             return new PoolAssignmentSnapshot
             {
-                ResearchAssigned = pools.Research.UsedSlots,
-                ResearchCapacity = pools.Research.ProvidedSlots,
-                ManufacturingAssigned = pools.Manufacturing.UsedSlots,
-                ManufacturingCapacity = pools.Manufacturing.ProvidedSlots
+                ResearchCapacity = researchCapacity,
+                ResearchAssigned = Math.Min(researchCapacity, CountAssigned(faction, PersonnelAssignment.Research)),
+                ManufacturingCapacity = manufacturingCapacity,
+                ManufacturingAssigned = Math.Min(manufacturingCapacity, CountAssigned(faction, PersonnelAssignment.Manufacturing))
             };
         }
 
-        private static float GetAssignedBonus(GeoPhoenixFaction faction, PersonnelAssignment assignment, int usedSlots, ResourceType resourceType)
+        /// <summary>
+        /// Slots actually being worked: the personnel assigned to this duty, capped at the slots the
+        /// facilities provide. Same source the income uses, so displays cannot disagree with it.
+        /// </summary>
+        internal static int GetOccupiedSlots(GeoPhoenixFaction faction, PersonnelAssignment assignment)
         {
-            if (usedSlots <= 0)
+            if (faction == null)
+            {
+                return 0;
+            }
+
+            Workers.FacilitySlotPools pools = Workers.ResearchManufacturingSlotsManager.GetOrCreatePools(faction);
+
+            int capacity = assignment == PersonnelAssignment.Research
+                ? pools.Research.ProvidedSlots
+                : pools.Manufacturing.ProvidedSlots;
+
+            return Math.Min(capacity, CountAssigned(faction, assignment));
+        }
+
+        private static int CountAssigned(GeoPhoenixFaction faction, PersonnelAssignment assignment)
+        {
+            return PersonnelData.Assignments.Values
+                .Count(person => person?.Character != null
+                    && person.Character.Faction == faction
+                    && person.Assignment == assignment);
+        }
+
+        /// <summary>
+        /// Output of the personnel working this assignment, capped at the number of slots the
+        /// facilities provide. When more are assigned than there are slots, the most productive ones
+        /// take the slots.
+        /// </summary>
+        private static float GetAssignedBonus(GeoPhoenixFaction faction, PersonnelAssignment assignment, int capacity, ResourceType resourceType)
+        {
+            if (capacity <= 0)
             {
                 return 0f;
             }
 
             return PersonnelData.Assignments.Values
                 .Where(person => person?.Character != null && person.Character.Faction == faction && person.Assignment == assignment)
-                .OrderBy(person => person.Id)
-                .Take(usedSlots)
+                .OrderByDescending(person => GetWorkerOutput(person.Character, resourceType))
+                .ThenBy(person => person.Id)
+                .Take(capacity)
                 .Sum(person => GetWorkerOutput(person.Character, resourceType));
         }
 
@@ -154,51 +213,116 @@ namespace TFTV.TFTVBaseRework
             }
         }
 
-        private static float GetIdleSlotBonus(GeoPhoenixFaction faction, int capacity, int assigned, ResourceType resourceType, int basePerSlot)
+        /// <summary>
+        /// Gives idle slots the facility upgrades that Workers.GeoFactionFacilityBuffCollection_GetValue_Patch
+        /// strips from every research and manufacturing facility. Without this, researched upgrades would do
+        /// nothing at all; an occupied slot does not get them because the personnel in it is the upgrade.
+        /// </summary>
+        private static float GetIdleSlotBonus(GeoPhoenixFaction faction, int capacity, int assigned, ResourceType resourceType)
         {
             int idleSlots = Math.Max(0, capacity - assigned);
-            if (idleSlots <= 0 || !HasFacilityBuff(faction, resourceType))
+            if (idleSlots <= 0 || capacity <= 0)
             {
                 return 0f;
             }
 
-            int perSlot = basePerSlot;
-            if (HasCentralizedAI(faction))
+            float strippedTotal = GetStrippedBuffTotal(faction, resourceType);
+            if (strippedTotal <= 0f)
             {
-                perSlot++;
+                return 0f;
             }
 
-            return idleSlots * perSlot;
+            // strippedTotal covers every providing facility; hand out only the idle share of it.
+            return strippedTotal * idleSlots / capacity;
         }
 
-        private static bool HasCentralizedAI(GeoPhoenixFaction faction)
+        /// <summary>
+        /// Sum, over every working research/manufacturing facility, of the buff value our GetValue patch
+        /// discards: vanilla would return baseValue * (multiplier + buffs + global) + added, the patch
+        /// returns baseValue * multiplier + added, so the difference is what researched upgrades are worth.
+        /// </summary>
+        private static float GetStrippedBuffTotal(GeoPhoenixFaction faction, ResourceType resourceType)
         {
-            return faction?.Research != null && faction.Research.HasCompleted(CentralizedAIResearchId);
-        }
-
-        private static bool HasFacilityBuff(GeoPhoenixFaction faction, ResourceType resourceType)
-        {
-            return faction?.FacilityBuffs?.FacilityBuffs != null
-                && faction.FacilityBuffs.FacilityBuffs.Any(buff => buff?.FacilityDef != null && FacilityProvidesOutput(buff.FacilityDef, resourceType));
-        }
-
-        private static bool FacilityProvidesOutput(PhoenixFacilityDef facilityDef, ResourceType resourceType)
-        {
-            if (facilityDef?.GeoFacilityComponentDefs == null)
+            GeoFactionFacilityBuffCollection buffs = faction?.FacilityBuffs;
+            if (buffs?.FacilityBuffs == null || faction.Bases == null)
             {
-                return false;
+                return 0f;
             }
 
-            foreach (GeoFacilityComponentDef component in facilityDef.GeoFacilityComponentDefs)
+            float total = 0f;
+
+            foreach (GeoPhoenixBase geoBase in faction.Bases)
             {
-                ResourceGeneratorFacilityComponentDef generator = component as ResourceGeneratorFacilityComponentDef;
-                if (generator != null && generator.BaseResourcesOutput.ByResourceType(resourceType).Value > 0f)
+                if (geoBase?.Layout?.Facilities == null)
                 {
-                    return true;
+                    continue;
+                }
+
+                // Outposts provide no slots, so they get no make-up bonus either.
+                if (geoBase.Site != null && geoBase.Site.SiteTags.Contains(PhoenixBaseReworkState.OutpostTag))
+                {
+                    continue;
+                }
+
+                foreach (GeoPhoenixFacility facility in geoBase.Layout.Facilities)
+                {
+                    if (facility == null || !facility.IsWorking || facility.Def?.GeoFacilityComponentDefs == null)
+                    {
+                        continue;
+                    }
+
+                    foreach (GeoFacilityComponentDef component in facility.Def.GeoFacilityComponentDefs)
+                    {
+                        if (!(component is ResourceGeneratorFacilityComponentDef generator))
+                        {
+                            continue;
+                        }
+
+                        float baseValue = generator.BaseResourcesOutput.ByResourceType(resourceType).Value;
+                        if (baseValue <= 0f)
+                        {
+                            continue;
+                        }
+
+                        total += GetStrippedBuffValue(buffs, facility.Def, baseValue);
+                    }
                 }
             }
 
-            return false;
+            return total;
+        }
+
+        private static float GetStrippedBuffValue(GeoFactionFacilityBuffCollection buffs, PhoenixFacilityDef facilityDef, float baseValue)
+        {
+            List<GeoFactionFacilityBuff> forFacility = buffs.FacilityBuffs
+                .Where(buff => buff != null && buff.FacilityDef == facilityDef)
+                .ToList();
+
+            // A Set buff overrides everything in vanilla, including the base value.
+            GeoFactionFacilityBuff set = forFacility
+                .FirstOrDefault(buff => buff.ModificationType == GeoFactionFacilityBuff.FacilityComponentModificationType.Set);
+            if (set != null)
+            {
+                return Mathf.Max(0f, set.Amount - baseValue);
+            }
+
+            float added = 0f;
+            float multiplier = buffs.GlobalProductionMultiplier;
+
+            foreach (GeoFactionFacilityBuff buff in forFacility)
+            {
+                switch (buff.ModificationType)
+                {
+                    case GeoFactionFacilityBuff.FacilityComponentModificationType.Add:
+                        added += buff.Amount;
+                        break;
+                    case GeoFactionFacilityBuff.FacilityComponentModificationType.Multiply:
+                        multiplier += buff.Amount;
+                        break;
+                }
+            }
+
+            return Mathf.Max(0f, baseValue * multiplier + added);
         }
 
         private struct PoolAssignmentSnapshot

--- a/TFTV/TFTVBaseRework/UI/Panel.cs
+++ b/TFTV/TFTVBaseRework/UI/Panel.cs
@@ -105,8 +105,12 @@ namespace TFTV.TFTVBaseRework
 
                 // Create 4 columns
                 CreateColumn(columnsContainer.transform, PersonnelAssignment.Unassigned, "Unassigned", null, level, phoenix, slotPrefab);
-                CreateColumn(columnsContainer.transform, PersonnelAssignment.Research, $"Research ({pools.Research.UsedSlots}/{pools.Research.ProvidedSlots})", pools.Research, level, phoenix, slotPrefab);
-                CreateColumn(columnsContainer.transform, PersonnelAssignment.Manufacturing, $"Manufacturing ({pools.Manufacturing.UsedSlots}/{pools.Manufacturing.ProvidedSlots})", pools.Manufacturing, level, phoenix, slotPrefab);
+                // Occupied counts come from the personnel records, matching the info bar and the income.
+                int researchUsed = ResearchAndManufacturing.GetOccupiedSlots(phoenix, PersonnelAssignment.Research);
+                int manufacturingUsed = ResearchAndManufacturing.GetOccupiedSlots(phoenix, PersonnelAssignment.Manufacturing);
+
+                CreateColumn(columnsContainer.transform, PersonnelAssignment.Research, $"Research ({researchUsed}/{pools.Research.ProvidedSlots})", pools.Research, level, phoenix, slotPrefab);
+                CreateColumn(columnsContainer.transform, PersonnelAssignment.Manufacturing, $"Manufacturing ({manufacturingUsed}/{pools.Manufacturing.ProvidedSlots})", pools.Manufacturing, level, phoenix, slotPrefab);
                 CreateColumn(columnsContainer.transform, PersonnelAssignment.Training, $"Deploy / Train ({trainUsed}/{trainProvided})", null, level, phoenix, slotPrefab);
             }
             catch (Exception e)

--- a/TFTV/TFTVBaseRework/Workers.cs
+++ b/TFTV/TFTVBaseRework/Workers.cs
@@ -92,8 +92,17 @@ namespace TFTV.TFTVBaseRework
 
                     ResearchAndManufacturing.GetOutputBonuses(phoenix, out float researchBonus, out float productionBonus);
 
-                    __instance.ProductionLabel.text = FormatSlotString(Mathf.RoundToInt(totalProduction), Mathf.RoundToInt(productionBonus), slotPools.Manufacturing);
-                    __instance.ResearchLabel.text = FormatSlotString(Mathf.RoundToInt(totalResearch), Mathf.RoundToInt(researchBonus), slotPools.Research);
+                    __instance.ProductionLabel.text = FormatSlotString(
+                        Mathf.RoundToInt(totalProduction),
+                        Mathf.RoundToInt(productionBonus),
+                        slotPools.Manufacturing.ProvidedSlots,
+                        ResearchAndManufacturing.GetOccupiedSlots(phoenix, PersonnelAssignment.Manufacturing));
+
+                    __instance.ResearchLabel.text = FormatSlotString(
+                        Mathf.RoundToInt(totalResearch),
+                        Mathf.RoundToInt(researchBonus),
+                        slotPools.Research.ProvidedSlots,
+                        ResearchAndManufacturing.GetOccupiedSlots(phoenix, PersonnelAssignment.Research));
 
                     // Override SoldiersLabel to show living space used vs capacity,
                     // since our living-space accounting differs from vanilla's Soldiers.Count().
@@ -110,10 +119,11 @@ namespace TFTV.TFTVBaseRework
                 }
             }
 
-            private static string FormatSlotString(int totalPerHour, int bonus, FacilitySlotPool pool)
+            // Slots used are counted from the personnel records, the same source the income figure uses,
+            // so the two halves of the label can never disagree.
+            private static string FormatSlotString(int totalPerHour, int bonus, int provided, int occupied)
             {
-                int provided = pool.ProvidedSlots;
-                int used = provided > 0 ? pool.UsedSlots : 0;
+                int used = provided > 0 ? occupied : 0;
 
                 if (bonus > 0)
                 {


### PR DESCRIPTION
Follow-up to #46. Investigating odd topbar behaviour when assigning personnel turned up four separate defects in how the faction's research and manufacturing income is calculated and displayed, plus the design change to the unoccupied lab/fab bonus.

Findings come from reading the mod against the decompiled game assembly, with the sequencing bug confirmed against a runtime `TFTV.log`.

## The topbar oddity: income computed before the assignment changed

`AssignPersonnelToWorkSlot`, `UnassignFromWork`, `AssignPersonnelToTraining`, `RemovePersonnel`, `TryAssignUnassignedWorkerToSlot` and the living-capacity eviction loop all updated the slot counters *before* setting `person.Assignment`. `IncrementUsedSlot`/`DecrementUsedSlot` call `TryUpdateInfoBar` → `UpdateProduction` → the postfix that recalculates income from the personnel records — which still held the old assignment. The final `UpdateResourceInfo` call only redraws labels, so the income figure stayed stale while the `(+N)` beside it was recomputed correctly, and the two disagreed by one worker's output.

Confirmed in the log — the info bar update is printed *before* the assignment change:

```
[Workers] Updating info bar with Research Used/Provided=3/11 …
[PersonnelData] Unassigned Luis Popescu from Research to Unassigned.
```

All six paths now move the person first, with a rollback if the slot cannot be reserved.

## Worker output no longer depends on the slot counters

`GetAssignedBonus` used `.OrderBy(p => p.Id).Take(usedSlots)` — the set from the personnel records, the count from a separately maintained `FacilitySlotPool.UsedSlots`. Whenever those drifted (during the window above, or when `SetProvidedSlots` clamps after a lab is lost) it counted the wrong people, and by lowest id, so a high-id Biotech could be silently dropped in favour of a plain worker producing 2 — visibly sitting in the Research column contributing nothing.

Capacity now comes from the facilities and the set from the records, ordered by output so the most productive personnel take the slots. The `used/provided` displays in the info bar and the assignments panel read the same helper (`GetOccupiedSlots`), so they cannot disagree with the income.

## Missing income-changed event

`GeoFaction.UpdateProduction` raises `IncomeChanged` *before* returning, and `UIModuleInfoBar` refreshes on that event — but the mod's postfix applies the bonus *after* `UpdateProduction` returns. So any recalculation the game triggered itself (a facility finishing, a base activating, power routing) redrew the topbar from the raw pre-bonus figure and never refreshed. The mod's own path escaped this only because `TryUpdateInfoBar` re-invokes `UpdateResourceInfo` afterwards. The postfix now re-raises the event when it changes the values.

Checked for recursion: `IncomeChanged` → `GeoscapeView.OnFactionIncomeChanged` → `FactionIncomeChanged` → `UIModuleInfoBar.OnIncomeChanged` → `UpdateResourceInfo`, whose postfix only reads. Nothing loops back into `UpdateProduction`.

## Base food and mutagen income was being deleted

Not part of the reported symptom, but found alongside it and more costly.

`ApplyProductionAdjustments` rebuilt the `OperationReason.Production` pack from just Research and Production and called `SetOutput`, and `FactionResourceOutput.SetOutput(reason, pack)` **replaces the entry's whole pack**. That entry holds all site production, and `PhoenixBaseStats.ResourceOutput` aggregates every `ResourceGeneratorFacilityComponent` — including `FoodProduction_PhoenixFacilityDef` — so the bases' Supplies output was dropped on every recalculation, leaving only the negative Maintenance food drain. The commented-out `baseSupplies`/`baseMutagen` lines show this was noticed; removing them deleted the income rather than preserving it.

The adjustment now recomputes the site pack the way `GeoFaction.UpdateProduction` does, overwrites only the two units it owns, and passes everything else through untouched. Recomputing from the sites also makes it idempotent, so calling it outside the postfix no longer folds the previous bonus back in.

Related: `GetProductionReasonOutput` did not read the Production entry at all — it called `GetTotalResouce`, which sums every `OperationReason`. Harmless for Research and Production since nothing else writes those types, but it is exactly why the Supplies line could not simply be carried through: `GetTotalResouce(Supplies)` includes the negative food drain from `OperationReason.Maintenance`, so writing it back would apply the drain twice. The method is gone.

## Unoccupied lab/fab bonus now reflects what the researches grant

`GeoFactionFacilityBuffCollection_GetValue_Patch` returns `baseValue * multiplier + addedValue` for research/manufacturing components, discarding everything vanilla adds: `Add` buffs, `Multiply` buffs, the `Set` short-circuit, and `GlobalProductionMultiplier`. The make-up bonus was then gated on `HasFacilityBuff`, a bare existence check, so:

- every lab-buff research was worth a flat +1 Research / +2 Manufacturing per idle slot;
- researching a second one added nothing;
- the buff's actual `Amount` and `ModificationType` were ignored;
- research rewards with `Facility == null` become a `GlobalProductionMultiplier`, invisible to the check *and* stripped by the patch, so they did nothing at all.

The bonus is now the exact value the patch discards — `baseValue * (multiply buffs + global) + add buffs`, with `Set` handled as vanilla does — summed over the working facilities and handed out to the idle share of the slots.

## Reviewer notes

- **Compile-verified only** (`dotnet build`, 0 errors, the same 7 pre-existing warnings). None of this has been exercised in game.
- **Worth confirming first:** build or check a Food Production facility and verify the Supplies income line now reflects it. That is the finding most worth checking against real behaviour rather than a reading of the code.
- **The idle-slot numbers now come entirely from the def values and want a balance pass.** They are no longer the flat 1/2 constants.
- **The hardcoded `NJ_CentralizedAI_ResearchDef` bump is gone.** It existed because the `GetValue` patch was swallowing that research's effect; if it grants a facility buff or a global modifier it is picked up automatically now, but if it works some other way its old +1 has disappeared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
