### PR TITLE
Portraits: angled framing, pulled back, and learned-ability icons

### DIFF
--- a/TFTV/TFTV.csproj
+++ b/TFTV/TFTV.csproj
@@ -213,6 +213,7 @@
     <Compile Include="TFTVIncidents\GeoUIAdjustments.cs" />
     <Compile Include="TFTVIncidents\IncidentOutcomeSummaryUI.cs" />
     <Compile Include="TFTVIncidents\IncidentResolutionUI.cs" />
+    <Compile Include="TFTVIncidents\LeaderAbilityIcons.cs" />
     <Compile Include="TFTVIncidents\LeaderSelection.cs" />
     <Compile Include="TFTVIncidents\MachineryRepairDefs.cs" />
     <Compile Include="TFTVIncidents\PortraitGenerator.cs" />

--- a/TFTV/TFTVIncidents/IncidentResolutionUI.cs
+++ b/TFTV/TFTVIncidents/IncidentResolutionUI.cs
@@ -413,6 +413,7 @@ namespace TFTV.TFTVIncidents
 
                 ResetSelectedLeaderContext(geoEvent, vehicle);
                 PortraitGenerator.ClearCache();
+                LeaderAbilityIcons.Clear();
 
                 List<GeoCharacter> crew = ResolveCrew(vehicle);
                 if (crew.Count == 0)
@@ -504,6 +505,7 @@ namespace TFTV.TFTVIncidents
                         SetSelectedRow(selectedRow);
                         SetSelectedLeader(selectedCharacter, geoEvent, vehicle);
                         PortraitGenerator.RequestLeaderPortrait(__instance, selectedCharacter);
+                        LeaderAbilityIcons.Show(__instance, selectedCharacter);
                         UpdateHeaderForSelectedOperative(header, selectedCharacter, geoEvent, vehicle);
                         UpdateChoiceButtonsForSelectedOperative(__instance, geoEvent, vehicle, selectedCharacter);
                         RefreshHeaderGainDisplay();
@@ -531,6 +533,7 @@ namespace TFTV.TFTVIncidents
                     SetSelectedRow(selectedRow);
                     SetSelectedLeader(selectedCharacter, geoEvent, vehicle);
                     PortraitGenerator.RequestLeaderPortrait(__instance, selectedCharacter);
+                    LeaderAbilityIcons.Show(__instance, selectedCharacter);
                     UpdateHeaderForSelectedOperative(header, selectedCharacter, geoEvent, vehicle);
                     UpdateChoiceButtonsForSelectedOperative(__instance, geoEvent, vehicle, selectedCharacter);
                     RefreshHeaderGainDisplay();

--- a/TFTV/TFTVIncidents/LeaderAbilityIcons.cs
+++ b/TFTV/TFTVIncidents/LeaderAbilityIcons.cs
@@ -1,0 +1,291 @@
+﻿using PhoenixPoint.Geoscape.Entities;
+using PhoenixPoint.Geoscape.View.ViewControllers.Roster;
+using PhoenixPoint.Geoscape.View.ViewModules;
+using PhoenixPoint.Tactical.Entities.Abilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+namespace TFTV.TFTVIncidents
+{
+    /// <summary>
+    /// Shows the selected incident operative's learned abilities as a strip of icons in the leader
+    /// picture slot, each hovering to the game's own ability tooltip.
+    ///
+    /// The learned set is <see cref="CharacterProgression.Abilities"/>, which is what the rest of the
+    /// mod treats as acquired - class and personal skills, perks and drills all land there, and
+    /// DrillSwapUI tests drill ownership against the same list.
+    /// </summary>
+    internal static class LeaderAbilityIcons
+    {
+        private const string ContainerName = "[TFTV]LeaderAbilityIcons";
+
+        // Sized to sit along the bottom of the leader picture without crowding the face.
+        private const int IconSize = 34;
+        private const int IconSpacing = 3;
+        private const int IconsPerRow = 6;
+        private const float BottomOffset = 6f;
+
+        private static GameObject _container;
+
+        /// <summary>
+        /// Rebuilds the icon strip for the given operative. Safe to call on every leader change.
+        /// </summary>
+        internal static void Show(UIModuleSiteEncounters module, GeoCharacter character)
+        {
+            try
+            {
+                if (module?.EncounterLeaderImage == null || character == null)
+                {
+                    return;
+                }
+
+                GameObject container = EnsureContainer(module);
+                if (container == null)
+                {
+                    return;
+                }
+
+                for (int i = container.transform.childCount - 1; i >= 0; i--)
+                {
+                    UnityEngine.Object.Destroy(container.transform.GetChild(i).gameObject);
+                }
+
+                List<TacticalAbilityDef> abilities = GetLearnedAbilities(character);
+                container.SetActive(abilities.Count > 0);
+
+                foreach (TacticalAbilityDef ability in abilities)
+                {
+                    CreateIcon(container.transform, ability, module.EncounterLeaderImage.canvas);
+                }
+            }
+            catch (Exception e)
+            {
+                TFTVLogger.Error(e);
+            }
+        }
+
+        /// <summary>
+        /// Drops the strip, for when the incident goes away.
+        /// </summary>
+        internal static void Clear()
+        {
+            try
+            {
+                AbilityIconTooltip.HideShared();
+
+                if (_container != null)
+                {
+                    UnityEngine.Object.Destroy(_container);
+                }
+            }
+            catch (Exception e)
+            {
+                TFTVLogger.Error(e);
+            }
+            finally
+            {
+                _container = null;
+            }
+        }
+
+        /// <summary>
+        /// Learned abilities that have an icon to show, in track order and without duplicates - an
+        /// ability can sit on more than one track, and the same one twice in a row reads as a bug.
+        /// </summary>
+        private static List<TacticalAbilityDef> GetLearnedAbilities(GeoCharacter character)
+        {
+            List<TacticalAbilityDef> abilities = new List<TacticalAbilityDef>();
+            if (character.Progression?.Abilities == null)
+            {
+                return abilities;
+            }
+
+            foreach (TacticalAbilityDef ability in character.Progression.Abilities)
+            {
+                if (ability?.ViewElementDef?.SmallIcon == null || abilities.Contains(ability))
+                {
+                    continue;
+                }
+
+                abilities.Add(ability);
+            }
+
+            return abilities;
+        }
+
+        private static GameObject EnsureContainer(UIModuleSiteEncounters module)
+        {
+            Transform parent = module.EncounterLeaderImage.transform;
+            Transform existing = parent.Find(ContainerName);
+            if (existing != null)
+            {
+                _container = existing.gameObject;
+                return _container;
+            }
+
+            GameObject container = new GameObject(ContainerName, typeof(RectTransform), typeof(GridLayoutGroup), typeof(ContentSizeFitter));
+            container.transform.SetParent(parent, false);
+
+            // Pinned along the bottom edge of the picture, growing upwards as rows are added.
+            RectTransform rect = container.GetComponent<RectTransform>();
+            rect.anchorMin = new Vector2(0.5f, 0f);
+            rect.anchorMax = new Vector2(0.5f, 0f);
+            rect.pivot = new Vector2(0.5f, 0f);
+            rect.anchoredPosition = new Vector2(0f, BottomOffset);
+
+            GridLayoutGroup grid = container.GetComponent<GridLayoutGroup>();
+            grid.cellSize = new Vector2(IconSize, IconSize);
+            grid.spacing = new Vector2(IconSpacing, IconSpacing);
+            grid.constraint = GridLayoutGroup.Constraint.FixedColumnCount;
+            grid.constraintCount = IconsPerRow;
+            grid.childAlignment = TextAnchor.LowerCenter;
+            grid.startAxis = GridLayoutGroup.Axis.Horizontal;
+
+            ContentSizeFitter fitter = container.GetComponent<ContentSizeFitter>();
+            fitter.horizontalFit = ContentSizeFitter.FitMode.PreferredSize;
+            fitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+
+            _container = container;
+            return container;
+        }
+
+        private static void CreateIcon(Transform parent, TacticalAbilityDef ability, Canvas canvas)
+        {
+            GameObject iconObject = new GameObject($"Ability_{ability.name}", typeof(RectTransform), typeof(Image));
+            iconObject.transform.SetParent(parent, false);
+
+            Image image = iconObject.GetComponent<Image>();
+            image.sprite = ability.ViewElementDef.SmallIcon;
+            image.preserveAspect = true;
+            image.raycastTarget = true;
+
+            iconObject.AddComponent<AbilityIconTooltip>().Initialize(ability, canvas);
+        }
+
+        /// <summary>
+        /// Hover behaviour for one icon: shows the roster's own ability tooltip, positioned beside the
+        /// icon and kept inside the canvas.
+        /// </summary>
+        private sealed class AbilityIconTooltip : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler
+        {
+            private const float Gap = 12f;
+            private static readonly Vector3[] CornerBuffer = new Vector3[4];
+            private static GeoRosterAbilityDetailTooltip _shared;
+
+            private TacticalAbilityDef _ability;
+            private Canvas _canvas;
+
+            internal void Initialize(TacticalAbilityDef ability, Canvas canvas)
+            {
+                _ability = ability;
+                _canvas = canvas;
+            }
+
+            public void OnPointerEnter(PointerEventData eventData)
+            {
+                try
+                {
+                    GeoRosterAbilityDetailTooltip tooltip = EnsureTooltip();
+                    if (tooltip == null || _ability == null)
+                    {
+                        return;
+                    }
+
+                    tooltip.Show(_ability, _ability.ViewElementDef, useMutagens: false, cost: 0);
+                    tooltip.transform.SetAsLastSibling();
+                    Position(tooltip);
+                }
+                catch (Exception e)
+                {
+                    TFTVLogger.Error(e);
+                }
+            }
+
+            public void OnPointerExit(PointerEventData eventData)
+            {
+                HideShared();
+            }
+
+            private void OnDisable()
+            {
+                HideShared();
+            }
+
+            internal static void HideShared()
+            {
+                if (_shared != null)
+                {
+                    _shared.Hide();
+                }
+            }
+
+            /// <summary>
+            /// Places the tooltip to the right of the icon, or to its left when that would run off the
+            /// canvas, and keeps it vertically inside.
+            /// </summary>
+            private void Position(GeoRosterAbilityDetailTooltip tooltip)
+            {
+                if (!(tooltip.transform is RectTransform tooltipRect)
+                    || _canvas == null
+                    || !(_canvas.transform is RectTransform canvasRect))
+                {
+                    return;
+                }
+
+                Camera camera = _canvas.renderMode == RenderMode.ScreenSpaceOverlay ? null : _canvas.worldCamera;
+
+                ((RectTransform)transform).GetWorldCorners(CornerBuffer);
+                Vector2 iconRightScreen = RectTransformUtility.WorldToScreenPoint(camera, CornerBuffer[2]);
+                Vector2 iconLeftScreen = RectTransformUtility.WorldToScreenPoint(camera, CornerBuffer[0]);
+
+                if (!RectTransformUtility.ScreenPointToLocalPointInRectangle(canvasRect, iconRightScreen, camera, out Vector2 rightLocal)
+                    || !RectTransformUtility.ScreenPointToLocalPointInRectangle(canvasRect, iconLeftScreen, camera, out Vector2 leftLocal))
+                {
+                    return;
+                }
+
+                Vector2 size = tooltipRect.rect.size * tooltipRect.localScale;
+                float x = rightLocal.x + Gap + size.x * tooltipRect.pivot.x;
+                if (x + size.x * (1f - tooltipRect.pivot.x) > canvasRect.rect.xMax)
+                {
+                    x = leftLocal.x - Gap - size.x * (1f - tooltipRect.pivot.x);
+                }
+
+                float y = Mathf.Clamp(
+                    rightLocal.y,
+                    canvasRect.rect.yMin + size.y * tooltipRect.pivot.y,
+                    canvasRect.rect.yMax - size.y * (1f - tooltipRect.pivot.y));
+
+                tooltipRect.anchoredPosition = new Vector2(x, y);
+            }
+
+            private GeoRosterAbilityDetailTooltip EnsureTooltip()
+            {
+                if (_shared != null)
+                {
+                    return _shared;
+                }
+
+                GeoRosterAbilityDetailTooltip template = Resources.FindObjectsOfTypeAll<GeoRosterAbilityDetailTooltip>()
+                    .FirstOrDefault(t => t != null);
+
+                if (template == null)
+                {
+                    return null;
+                }
+
+                Transform parent = _canvas != null ? _canvas.transform : template.transform.parent;
+                GameObject clone = UnityEngine.Object.Instantiate(template.gameObject, parent, worldPositionStays: false);
+                clone.name = "[TFTV]IncidentAbilityTooltip";
+                clone.SetActive(false);
+
+                _shared = clone.GetComponent<GeoRosterAbilityDetailTooltip>();
+                return _shared;
+            }
+        }
+    }
+}

--- a/TFTV/TFTVIncidents/PortraitGenerator.cs
+++ b/TFTV/TFTVIncidents/PortraitGenerator.cs
@@ -20,7 +20,8 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using TFTV.TFTVUI.Personnel;
+using TFTV.TFTVUI.Personnel;
+
 using UnityEngine;
 
 namespace TFTV.TFTVIncidents
@@ -54,10 +55,13 @@ namespace TFTV.TFTVIncidents
         private const int MaxPortraitResolution = 1024;
         private const int FallbackPortraitResolution = 512;
 
-        // Framing of the head close-up.
+        // Framing. The camera sits off to one side of the face rather than square in front of it, a
+        // little above eye level, and far enough back for the shoulders and armour to read.
         private const float CameraFoV = 40f;
-        private const float NoseDistance = 0.80f;
-        private const float HeadDistance = 0.88f;
+        private const float NoseDistance = 1.10f;
+        private const float HeadDistance = 1.20f;
+        private const float CameraYawDegrees = 28f;
+        private const float CameraHeight = 0.06f;
 
         // Generous: the first build of a session waits on addon assets being loaded from disk.
         private const float RebuildTimeoutSeconds = 20f;
@@ -292,6 +296,17 @@ namespace TFTV.TFTVIncidents
                 // clean when the UI displays it slightly scaled.
                 rendered.filterMode = FilterMode.Trilinear;
                 rendered.anisoLevel = 4;
+
+                // TEMPORARY - lets the new framing be checked directly. Remove once it is settled.
+                try
+                {
+                    System.IO.File.WriteAllBytes(System.IO.Path.Combine(Application.persistentDataPath,
+                        $"TFTV_Portrait_{character.Id}.png"), rendered.EncodeToPNG());
+                }
+                catch (Exception dumpError)
+                {
+                    TFTVLogger.Error(dumpError);
+                }
 
                 onDone?.Invoke(Sprite.Create(
                     rendered,
@@ -722,7 +737,13 @@ namespace TFTV.TFTVIncidents
                 camera.nearClipPlane = 0.01f;
                 camera.farClipPlane = 2.5f;
 
-                camera.transform.position = target.position + target.forward * distance;
+                // Swing the camera around the head for a three-quarter view. The yaw is taken about
+                // world up rather than the bone's, since rig bones do not carry a dependable up, and
+                // the look-at levels the shot so the portrait is never tilted.
+                Vector3 viewDirection = Quaternion.AngleAxis(CameraYawDegrees, Vector3.up) * target.forward;
+                camera.transform.position = target.position
+                    + viewDirection.normalized * distance
+                    + Vector3.up * CameraHeight;
                 camera.transform.LookAt(target.position);
 
                 camera.Render();


### PR DESCRIPTION
Brings in `023a0cc9`, the one portrait commit that never reached master. PR #45 merged up to `028e385a`; this was committed after that PR closed and has been sitting unmerged on the branch since, so master has none of it — including `TFTVIncidents/LeaderAbilityIcons.cs`, which is absent from master entirely.

Three changes to the incident leader slot, all authored in the earlier portrait session.

## Angled framing

The camera no longer faces the operative head on. It swings 28 degrees around the head for a three-quarter view and sits slightly above eye level. The yaw is taken about world up rather than the target bone's, because rig bones do not carry a dependable up, and the look-at levels the shot so the portrait is never tilted.

## Pulled back

Nose distance 0.80 → 1.10, head 0.88 → 1.20, so the whole figure including the armour reads smaller in the slot.

## Learned-ability icons

`LeaderAbilityIcons` draws the selected operative's learned abilities as a strip of icons along the bottom of the picture, each hovering to the roster's own `GeoRosterAbilityDetailTooltip`, following the pattern the Haven Recruits UI uses for its ability icons. The learned set is `Progression.Abilities`, which is what the rest of the mod treats as acquired — class and personal skills, perks and drills all land there, and `DrillSwapUI` tests drill ownership against the same list. Icons come from `ViewElementDef.SmallIcon`, duplicates are dropped, and the strip is rebuilt on every leader change and cleared with the incident.

`IncidentResolutionUI` gains three lines: `LeaderAbilityIcons.Clear()` alongside the existing `PortraitGenerator.ClearCache()`, and `LeaderAbilityIcons.Show(...)` next to each of the two `RequestLeaderPortrait` calls.

## Reviewer notes

- **There is temporary debug code to remove before this ships.** `PortraitGenerator.cs` writes every render to `TFTV_Portrait_{id}.png` under `Application.persistentDataPath` on each portrait. It is commented `TEMPORARY - lets the new framing be checked directly. Remove once it is settled.` It was left in deliberately to judge the new framing; if the framing is settled it should come out, and if it is not, this PR should wait.
- **Merges cleanly into current master.** Verified with a `git merge-tree` dry run against master at `bbeeb894`. The merged tree keeps both sides of the two files that master has since touched: the `GetAllBenefitsLocalizationKey` refactor in `IncidentResolutionUI.cs` from #46 sits alongside the `LeaderAbilityIcons` hooks, and `TFTV.csproj` carries all three new file entries (`LeaderAbilityIcons.cs`, `AffinityBadgeTooltip.cs`, `BaseActivationPersonnelSelection.cs`).
- **Not re-verified in game by me.** This is previously authored work being surfaced, not something I wrote or tested this session; the framing numbers and the icon strip were judged in the original portrait session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
