### PR TITLE
Name the incident lead in incident resolution texts

### DIFF
--- a/Dist/Assets/Localization/TFTV_Incidents_ANU_Localization.csv
+++ b/Dist/Assets/Localization/TFTV_Incidents_ANU_Localization.csv
@@ -1,4 +1,4 @@
-Key,Type,Desc,English,Chinese (Simplified),French,German,Italian,Polish,Russian,Spanish,UI_Tester
+﻿Key,Type,Desc,English,Chinese (Simplified),French,German,Italian,Polish,Russian,Spanish,UI_Tester
 TFTV_INCIDENT_0_TITLE_AN,Text,"Requirements: Advanced Training Zone, 
 Haven Leader >24",The Divergent Dream,,,,,,,,
 TFTV_INCIDENT_0_DESC,Text,,"The Exarch of [HavenName], friendly to the Phoenix Project has contacted us about a neophyte Priest of Yearning, Nahia Girvane. She recently participated in a major communion rite, but her vision differed from the congregation’s. They fear that the Archierus of her order will expel her—or worse.",,,,,,,,
@@ -9,32 +9,32 @@ TFTV_INCIDENT_0_OUTCOME_0_SUCCESS,Text,"Reward: Nahia Grivane, LVL2 Priest","She
 There is no place for her at [HavenName] and she wishes to join the Phoenix Project.",,,,,,,,
 TFTV_INCIDENT_0_OUTCOME_1_SUCCESS,Text,"Reward: Nahia Grivane, LVL2 Priest","The scan revealed an anomalous resistance to oneiric influence, possibly tied to a childhood concussion. Her neural patterns diverge significantly from those of her congregation.
 There is no place for her at [HavenName] and she wishes to join the Phoenix Project.",,,,,,,,
-TFTV_INCIDENT_0_OUTCOME_0_FAIL,Text,,"Her story was disjointed—images of collapsing stone, a black tide, a voice that wasn't hers. She’s afraid of what it means. She asked us not to tell the others.",,,,,,,,
+TFTV_INCIDENT_0_OUTCOME_0_FAIL,Text,,"Her story was disjointed—images of collapsing stone, a black tide, a voice that wasn't hers. She’s afraid of what it means. She asked [OperativeName] not to tell the others.",,,,,,,,
 TFTV_INCIDENT_0_OUTCOME_1_FAIL,Text,,The examination failed to yield any significant results and the procedure has made Nahia scared and distrustful.,,,,,,,,
 TFTV_INCIDENT_1_TITLE_AN,Text,,The Molt Beneath the Flesh,,,,,,,,
 TFTV_INCIDENT_1_DESC,Text,,"Director, the mutated here are shedding skin in waves of pain and delirium. Some call it holy transformation. Others are dying. Synod followers have barred outsiders from interfering. A few junior priests claim this is sickness, but the Syndod’s representatives claim it’s evolution.",,,,,,,,
 TFTV_INCIDENT_1_CHOICE_0_B,Text,,Treat and observe the molting victims. (Biotech),,,,,,,,
 TFTV_INCIDENT_1_CHOICE_1_E_O,Text,,Collect samples and withdraw. (Exploration/Occult),,,,,,,,
 TFTV_INCIDENT_1_CHOICE_2,Text,,Best not to interfere in Anu matters. [END],,,,,,,,
-TFTV_INCIDENT_1_OUTCOME_0_SUCCESS,Text,Reward: +4 Anu +8 Haven Leader,We saved lives and collected data pointing to failure of mutations to fully take hold. One priestess thanked us—then vanished.,,,,,,,,
+TFTV_INCIDENT_1_OUTCOME_0_SUCCESS,Text,Reward: +4 Anu +8 Haven Leader,[OperativeName] saved lives and collected data pointing to failure of mutations to fully take hold. One priestess thanked us—then vanished.,,,,,,,,
 TFTV_INCIDENT_1_OUTCOME_1_SUCCESS,Text,Reward:  +200 Mutagens + 200 Research,Samples secured. Early analysis suggests exogenous instigation of an accelerated mutation cycle.,,,,,,,,
-TFTV_INCIDENT_1_OUTCOME_0_FAIL,Text,,We treated several before Synod loyalists intervened. Survivors are whispering of a ‘false evolution.,,,,,,,,
-TFTV_INCIDENT_1_OUTCOME_1_FAIL,Text,,We got what we came for—but were seen. The Synod accused us of sacrilege and we had to return the samples to avoid a diplomatic incident.,,,,,,,,
+TFTV_INCIDENT_1_OUTCOME_0_FAIL,Text,,[OperativeName] treated several before Synod loyalists intervened. Survivors are whispering of a ‘false evolution.,,,,,,,,
+TFTV_INCIDENT_1_OUTCOME_1_FAIL,Text,,[OperativeName] got what we came for—but was seen. The Synod accused us of sacrilege and we had to return the samples to avoid a diplomatic incident.,,,,,,,,
 TFTV_INCIDENT_2_TITLE_AN,Text,,The Delusional Taxiarch ,,,,,,,,
 TFTV_INCIDENT_2_DESC,Text,,"Director, a Taxiarch has sealed himself inside a meditation chamber, claiming to hear a voice ‘rising from the roots of the flesh.’ The Synod calls it a blessing. But others whisper he screams through the night, and that what he’s channeling may not be divine.",,,,,,,,
 TFTV_INCIDENT_2_CHOICE_0_B_P,Text,,Try to speak with the Taxiarch. (Biotech/Psycho-Sociology),,,,,,,,
 TFTV_INCIDENT_2_CHOICE_1_E,Text,,Set up surveillance to gather data. (Exploration),,,,,,,,
 TFTV_INCIDENT_2_CHOICE_2,Text,,Best not to interfere. [END],,,,,,,,
 TFTV_INCIDENT_2_OUTCOME_0_SUCCESS,Text,Reward: +4 Anu +8 Haven Leader,"[OperativeName] managed to calm him long enough to speak—if not to make sense. The Taxiarch appeared lucid, but his beliefs had collapsed. He claimed partial mutation was punishment, not salvation, and called the Pandoran creatures ‘the chosen.’ We’ve withdrawn. The Synod will handle the fallout.",,,,,,,,
-TFTV_INCIDENT_2_OUTCOME_1_SUCCESS,Text,Reward:  +8 Haven Leader +200 research,We captured hours of audio. His speech mimicked Pandoran patterns—though oddly articulate. He spoke of ‘the Creator’ and begged for a final stage he called ‘completion.’ The Synod remains silent.,,,,,,,,
-TFTV_INCIDENT_2_OUTCOME_0_FAIL,Text,,"He attacked our operative mid-sentence, issuing an inhuman hiss. We were expelled from the haven immediately.",,,,,,,,
+TFTV_INCIDENT_2_OUTCOME_1_SUCCESS,Text,Reward:  +8 Haven Leader +200 research,[OperativeName] captured hours of audio. His speech mimicked Pandoran patterns—though oddly articulate. He spoke of ‘the Creator’ and begged for a final stage he called ‘completion.’ The Synod remains silent.,,,,,,,,
+TFTV_INCIDENT_2_OUTCOME_0_FAIL,Text,,"He attacked [OperativeName] mid-sentence, issuing an inhuman hiss. We were expelled from the haven immediately.",,,,,,,,
 TFTV_INCIDENT_2_OUTCOME_1_FAIL,Text,,"The feed ended with a burst of static—and then silence. When the chamber was opened, the Taxiarch was dead. No cause could be determined.",,,,,,,,
 TFTV_INCIDENT_3_TITLE_AN,Text,Requirement: Rep with Anu >24,Echoes of Resonance,,,,,,,,
 TFTV_INCIDENT_3_DESC,Text,,A representative of the Blind Legate has extended an invitation— access to a sacred retreat close to the Haven: a pre-Pandoravirus site where early disciples sought 'resonance of the flesh.' The Legate claims it still holds echoes of collective vision. They trust us enough to enter… if we're willing.,,,,,,,,
 TFTV_INCIDENT_3_CHOICE_0_E,Text,,Send a team to explore and document the retreat. (Exploration),,,,,,,,
 TFTV_INCIDENT_3_CHOICE_1_M_O,Text,,"Attempt to recreate the experience of the early disciples, interacting with the devices they left behind (Machinery/Occult)",,,,,,,,
 TFTV_INCIDENT_3_CHOICE_2,Text,,Avoid religious entanglement. [END],,,,,,,,
-TFTV_INCIDENT_3_OUTCOME_0_SUCCESS,Text,Reward: +5 Anu ,"The retreat was intact—stone walls covered in hand-drawn neuro-symbolic patterns. We found logs describing synchronized trance rituals predating the first outbreak. The site was secured and sealed by a government agency shortly after the outbreak of the World War, and the members of the cult were prosecuted for ‘anti-patriotic subversion.",,,,,,,,
+TFTV_INCIDENT_3_OUTCOME_0_SUCCESS,Text,Reward: +5 Anu ,"The retreat was intact—stone walls covered in hand-drawn neuro-symbolic patterns. [OperativeName] found logs describing synchronized trance rituals predating the first outbreak. The site was secured and sealed by a government agency shortly after the outbreak of the World War, and the members of the cult were prosecuted for ‘anti-patriotic subversion.",,,,,,,,
 TFTV_INCIDENT_3_OUTCOME_1_SUCCESS,Text,Reward: +5 Anu ,"[OperativeName] emerged deeply affected but composed. Described feeling ‘connected to something vast, unfinished.’ Neural scans show brief cortical resonance.",,,,,,,,
 TFTV_INCIDENT_3_OUTCOME_0_FAIL,Text,,Our presence disturbed something. [OperativeName] suffered acute migraine mid-mapping. No physical cause.,,,,,,,,
 TFTV_INCIDENT_3_OUTCOME_1_FAIL,Text,,"[OperativeName] collapsed after exiting. No injuries—just repeating the words, ‘We never reached the same frequency.’ No memory of the event.",,,,,,,,
@@ -49,13 +49,13 @@ TFTV_INCIDENT_4_OUTCOME_0_SUCCESS,Text,Reward: +4 Anu +8 Haven Leader + 400 food
 To many, the killings are divine retribution—the return of justice in flesh and blood.
 One zealot, proud and trembling, claims to possess a “trophy” from one of the victims: a dried Arthron claw.
 Apparently at least some in the slums of [HavenName] believe their leaders are Pandorans in disguise.
-The Exarch appreciates our analysis.",,,,,,,,
+The Exarch appreciates [OperativeName]’s analysis.",,,,,,,,
 TFTV_INCIDENT_4_OUTCOME_1_SUCCESS,Text,Reward: +4 Anu +8 Haven Leader + Mutog,"The autopsies reveal no consistent pattern in the mutilations—no ritual marks, no surgical precision, no clear motive.
 Yet the wounds bear signs of feeding. Tissue has been torn away, devoured by something with immense strength and no apparent need for tools.
 When confronted, the Exarch swears by the Dead God that all Mutogs are <i>now</i> accounted for.",,,,,,,,
 TFTV_INCIDENT_4_OUTCOME_0_FAIL,Text,,"The slums are hostile and fearful. Most residents refuse to speak; others denounce the Phoenix operatives as blasphemers.
 A crowd gathers, chanting prayers for “purification.”
-The team is forced to withdraw under escort, learning nothing—except that fear and faith have become indistinguishable.",,,,,,,,
+[OperativeName] is forced to withdraw under escort, learning nothing—except that fear and faith have become indistinguishable.",,,,,,,,
 TFTV_INCIDENT_4_OUTCOME_1_FAIL,Text,,"The examination is obstructed at every turn. Priests of the Circle of Life forbid invasive procedures, declaring the bodies “returned to the Flow.”
 By the time permission is granted, the remains have been cremated.
 The investigation ends with a sermon: “The flesh is not for comprehension, but for transcendence.”
@@ -67,7 +67,7 @@ TFTV_INCIDENT_5_CHOICE_0_E_P,Text,,"Explore the slums and speak with recent conv
 TFTV_INCIDENT_5_CHOICE_1_O,Text,,"Engage the sect’s leaders in theological debate.
 (Occult)",,,,,,,,
 TFTV_INCIDENT_5_CHOICE_2,Text,,We ought to stay as far away from this as possible [END],,,,,,,,
-TFTV_INCIDENT_5_OUTCOME_0_SUCCESS,Text,Extra personnel,"The Phoenix team spends some time in the lower district, speaking with artisans, traders, and refugees. The slums are filled not only with the dispossessed, but with skilled workers and small merchants—people who contribute to the haven yet remain excluded from advancement.
+TFTV_INCIDENT_5_OUTCOME_0_SUCCESS,Text,Extra personnel,"[OperativeName] spends some time in the lower district, speaking with artisans, traders, and refugees. The slums are filled not only with the dispossessed, but with skilled workers and small merchants—people who contribute to the haven yet remain excluded from advancement.
 
 The schism, lead by one Brad Huxley, offers them dignity and a voice.",,,,,,,,
 TFTV_INCIDENT_5_OUTCOME_1_SUCCESS,Text,Extra personnel,"The sect’s leader, Brad Huxley—a Synedrion exile—is articulate and pragmatic.
@@ -75,12 +75,12 @@ TFTV_INCIDENT_5_OUTCOME_1_SUCCESS,Text,Extra personnel,"The sect’s leader, Bra
 He shows little interest in dismantling the Disciples of Anu. What he seeks is recognition.
 
 “Faith without dialogue becomes stagnation,” he says. “We only ask to be taken into account.”",,,,,,,,
-TFTV_INCIDENT_5_OUTCOME_0_FAIL,Text,,"The presence of Phoenix operatives causes doors to close and conversations to die mid-sentence.
+TFTV_INCIDENT_5_OUTCOME_0_FAIL,Text,,"[OperativeName]’s presence causes doors to close and conversations to die mid-sentence.
 
 Many believe the team has come as agents of the Disciples’ hierarchy.
 
 The slums retreat into silence, and whatever truths they hold remain carefully hidden.",,,,,,,,
-TFTV_INCIDENT_5_OUTCOME_1_FAIL,Text,,"The operatives’ arguments are met with thin smiles and sharper words.
+TFTV_INCIDENT_5_OUTCOME_1_FAIL,Text,,"[OperativeName]’s arguments are met with thin smiles and sharper words.
 
 Scriptural references are dismantled, logic turned against itself.
 
@@ -97,7 +97,7 @@ TFTV_INCIDENT_6_CHOICE_1_B,Text,,"Perform a thorough examination of the alleged 
 TFTV_INCIDENT_6_CHOICE_2,Text,,Do not get involved [END],,,,,,,,
 TFTV_INCIDENT_6_OUTCOME_0_SUCCESS,Text,Reward: +8 Anu +16 Haven Leader + 600 food,"Huxley fears losing face among his followers if he appears to simply submit to the Exarch’s demands, but he lacks the strength to resist Anu authority outright.
 
-With Phoenix Project overseeing the transfer of the fugitive, the surrender is framed as a matter of undeniable guilt rather than capitulation.",,,,,,,,
+With [OperativeName] overseeing the transfer of the fugitive, the surrender is framed as a matter of undeniable guilt rather than capitulation.",,,,,,,,
 TFTV_INCIDENT_6_OUTCOME_1_SUCCESS,Text,Reward: +8 Anu +16 Haven Leader + 400 mutagens,"The apostate is a Hiereus—an Anu warrior-priest—who passed the Water of Life ritual less than a week ago.
 
 Unlike most observed cases, the mutations have spread rapidly across nearly his entire body. The subject is barely coherent when the examination begins, and further neural deterioration becomes evident even before it concludes.
@@ -105,7 +105,7 @@ Unlike most observed cases, the mutations have spread rapidly across nearly his 
 Aggression escalates alongside the breakdown.",,,,,,,,
 TFTV_INCIDENT_6_OUTCOME_0_FAIL,Text,,"The discussion falters.
 
-Huxley grows defensive, sensing that Phoenix’s involvement makes his compromise too visible. Word spreads quickly that he is yielding under pressure.
+Huxley grows defensive, sensing that [OperativeName]’s involvement makes his compromise too visible. Word spreads quickly that he is yielding under pressure.
 
 His followers begin to question his resolve, while Anu officials interpret the hesitation as defiance.",,,,,,,,
 TFTV_INCIDENT_6_OUTCOME_1_FAIL,Text,,"The examination is disrupted when the subject becomes violently unstable.
@@ -186,7 +186,7 @@ The suspect responds politely but minimally, repeating herself until the questio
 
 Attempts to provoke stress responses fail.
 
-The Anu observers interpret Phoenix’s inability to extract a confession as confirmation of guilt.",,,,,,,,
+The Anu observers interpret [OperativeName]’s inability to extract a confession as confirmation of guilt.",,,,,,,,
 TFTV_INCIDENT_9_TITLE_AN,Text,Requirements: Anu haven near liberated infested Synedrion haven ,Those Who Remain,,,,,,,,
 TFTV_INCIDENT_9_DESC,Text,,"Hundreds of refugees from the Synedrion haven of [RequirementHavenName], recently lost to Pandoran infestation, have been living at the Anu haven of [HavenName].
 
@@ -212,7 +212,7 @@ TFTV_INCIDENT_9_OUTCOME_0_FAIL,Text,,"Conversations remain superficial.
 
 Complaints about conditions drown out subtler patterns.
 
-Phoenix withdraws with the impression that tensions are mounting—though no clear source can be identified.",,,,,,,,
+[OperativeName] withdraws with the impression that tensions are mounting—though no clear source can be identified.",,,,,,,,
 TFTV_INCIDENT_9_OUTCOME_1_FAIL,Text,,"It all looks like chaos and neglect; if there is some pattern or direction, it remains hidden from us.",,,,,,,,
 TFTV_INCIDENT_10_TITLE_AN,Text,,Voices in the Engine,,,,,,,,
 TFTV_INCIDENT_10_DESC,Text,,"Maintenance personnel at the power plant of [HavenName] report seeing shapes in the shadows and hearing voices where none should be.
@@ -236,7 +236,7 @@ TFTV_INCIDENT_10_OUTCOME_1_SUCCESS,Text,"Reward: Anu +4, Haven leader +8, Resear
 
 Yet the ritualized way she maintains the plant—fixed routes, repeated gestures, and areas avoided without explicit explanation—reveals an unspoken structure.
 
-Following these patterns leads Phoenix operatives to sections of the facility that are rarely inspected.
+Following these patterns leads [OperativeName] to sections of the facility that are rarely inspected.
 
 In these neglected spaces, an unfamiliar organic presence is discovered, clinging to conduits and shielding.",,,,,,,,
 TFTV_INCIDENT_10_OUTCOME_0_FAIL,Text,,"The investigation yields little more than shadows and noise.
@@ -264,7 +264,7 @@ TFTV_INCIDENT_11_CHOICE_0_M,Text,,"Monitor outgoing communications from the have
 TFTV_INCIDENT_11_CHOICE_1_E_O,Text,,"Explore the slums and speak with the locals under pretext of religious interest. 
 (Exploration / Occult)",,,,,,,,
 TFTV_INCIDENT_11_CHOICE_2,Text,,We are not Synedrion's hounds [END],,,,,,,,
-TFTV_INCIDENT_11_OUTCOME_0_SUCCESS,Text,"Reward: + 5 Syn, 100 tech","Traffic analysis reveals an unusual pattern: brief, irregular data bursts routed through public access relays. Most of the traffic is trivial—provocations, mockery, deliberately irritating intrusions into Synedrion networks. Tracking the source of the trolling leads Phoenix to a single terminal and its operator.
+TFTV_INCIDENT_11_OUTCOME_0_SUCCESS,Text,"Reward: + 5 Syn, 100 tech","Traffic analysis reveals an unusual pattern: brief, irregular data bursts routed through public access relays. Most of the traffic is trivial—provocations, mockery, deliberately irritating intrusions into Synedrion networks. Tracking the source of the trolling leads [OperativeName] to a single terminal and its operator.
 
 The man appears amused rather than alarmed. “I know what you’re looking for,” he says.
 
@@ -275,7 +275,7 @@ TFTV_INCIDENT_11_OUTCOME_1_SUCCESS,Text,"Reward: + 5 Syn, 100 tech","The trail l
 
 Among chemical diversions and virtual indulgences, illicit data work is common enough to attract little attention.
 
-One individual greets Phoenix without surprise.
+One individual greets [OperativeName] without surprise.
 
 “I heard you coming,” he says. “So I took care of it.”
 
@@ -293,7 +293,7 @@ TFTV_INCIDENT_11_OUTCOME_1_FAIL,Text,,"Conversations go nowhere.
 
 Some locals pretend ignorance. Others offer misleading directions for a price.
 
-The slums absorb Phoenix’s attention without yielding results.
+The slums absorb [OperativeName]’s attention without yielding results.
 
 By the time a credible lead emerges, the opportunity has passed.",,,,,,,,
 TFTV_INCIDENT_12_TITLE_AN,Text,Requirements: haven surived attack,First to Burn,,,,,,,,

--- a/Dist/Assets/Localization/TFTV_Incidents_NJ_Localization.csv
+++ b/Dist/Assets/Localization/TFTV_Incidents_NJ_Localization.csv
@@ -1,22 +1,22 @@
-Key,Type,Desc,English
+﻿Key,Type,Desc,English
 TFTV_INCIDENT_15_TITLE_NJ,Text,Req: Haven leader rep > 50,The Walls Beneath
 TFTV_INCIDENT_15_DESC,Text,,"Director, we’ve received a request from [HavenName] security overseer—off the record. Personnel have reported noises beneath the oldest wing of the base: scratching, faint voices, and rhythmic banging. A schematic review revealed sublevels sealed during the haven’s early construction, likely predating New Jericho occupation. Officially, no one’s been down there in years. Unofficially… some believe something never left."
 TFTV_INCIDENT_15_CHOICE_0_E,Text,,Investigate the sealed sublevels. (Exploration)
 TFTV_INCIDENT_15_CHOICE_1_C_M,Text,,Conduct seismic and acoustic scans. (Machinery/Compute)
 TFTV_INCIDENT_15_CHOICE_2,Text,,Decline involvement. [END]
-TFTV_INCIDENT_15_OUTCOME_0_SUCCESS,Text,"Reward: Haven leader rep +12, 600 mat","We breached an old hatch and descended into forgotten corridors. The walls were marked with crude symbols—hand-drawn, ritualistic. At the end: a chamber with bones, candles, and remnants of military rations. The bodies had mutations, poorly hidden. Former New Jericho personnel, altered in secret—and left to rot."
+TFTV_INCIDENT_15_OUTCOME_0_SUCCESS,Text,"Reward: Haven leader rep +12, 600 mat","[OperativeName] breached an old hatch and descended into forgotten corridors. The walls were marked with crude symbols—hand-drawn, ritualistic. At the end: a chamber with bones, candles, and remnants of military rations. The bodies had mutations, poorly hidden. Former New Jericho personnel, altered in secret—and left to rot."
 TFTV_INCIDENT_15_OUTCOME_1_SUCCESS,Text,"Reward: Haven leader rep +12, 600 mat","Acoustic scans picked up whisper-like patterns echoing through the sealed concrete—non-random, possibly language. One section shows signs of recent disturbance. Analysis suggests human activity within the last six months. West’s files make no mention of this level."
-TFTV_INCIDENT_15_OUTCOME_0_FAIL,Text,,"We reached the second sublevel before encountering unstable structure and collapsed halls. Still, the walls bore scratched symbols: half-military, half-religious. Something was worshipped down here."
-TFTV_INCIDENT_15_OUTCOME_1_FAIL,Text,,"Scans were inconclusive, but irregular heat signatures suggest recent passage. The haven’s commander thanked us and quietly doubled the guard near the lower sectors."
+TFTV_INCIDENT_15_OUTCOME_0_FAIL,Text,,"[OperativeName] reached the second sublevel before encountering unstable structure and collapsed halls. Still, the walls bore scratched symbols: half-military, half-religious. Something was worshipped down here."
+TFTV_INCIDENT_15_OUTCOME_1_FAIL,Text,,"Scans were inconclusive, but irregular heat signatures suggest recent passage. The haven’s commander thanked [OperativeName] and quietly doubled the guard near the lower sectors."
 TFTV_INCIDENT_16_TITLE_NJ,Text,Req: Melquiades first quest compeleted,Unwelcome Goods
 TFTV_INCIDENT_16_DESC,Text,,"Director, we’ve run into an old acquaintance—Staban Melquíades, the Anu-affiliated dealer in relics and curios. He’s attempting to set up a 'trade delegation' in [HavenName], offering rare tech, food concentrates, and something he calls ‘psionic insulation garments.’ The local authorities have rejected his permit outright, citing 'bio-contamination risk' and 'ideological infiltration.' Melquíades insists this is a simple business venture."
 TFTV_INCIDENT_16_CHOICE_0_P,Text,,Intervene on Melquíades’s behalf. (Psycho-Sociology)
 TFTV_INCIDENT_16_CHOICE_1_C_M,Text,,Discreetly inspect the goods he’s offering. (Compute/Machinery)
 TFTV_INCIDENT_16_CHOICE_2,Text,,Stay out of it—this is between him and New Jericho. [END]
-TFTV_INCIDENT_16_OUTCOME_0_SUCCESS,Text,"Reward: +300 Mats, +300 Food",We negotiated a narrow compromise—Melquíades was allowed to sell non-biological goods outside the security perimeter. He swore this was only the beginning of ‘a glorious cross-cultural bazaar.’ The garrison commander muttered something about posting snipers trained on the booth.
+TFTV_INCIDENT_16_OUTCOME_0_SUCCESS,Text,"Reward: +300 Mats, +300 Food",[OperativeName] negotiated a narrow compromise—Melquíades was allowed to sell non-biological goods outside the security perimeter. He swore this was only the beginning of ‘a glorious cross-cultural bazaar.’ The garrison commander muttered something about posting snipers trained on the booth.
 TFTV_INCIDENT_16_OUTCOME_1_SUCCESS,Text,"Reward: +100 Tech, +200 Research","His tech was surprisingly clean. Some gear may even predate the fall—old military sensor rigs, energy converters, rare materials. But one crate contained psionic-dampening cloth woven with organic filaments of unknown origin. Possibly Anu-grown. Melquíades claimed they were ‘ethically cultivated in living silence.’"
 TFTV_INCIDENT_16_OUTCOME_0_FAIL,Text,,"The talks broke down quickly. Melquíades gave a passionate speech about ‘commerce as the path to communion,’ which only deepened suspicion. He was politely escorted to the outer wall and warned never to return."
-TFTV_INCIDENT_16_OUTCOME_1_FAIL,Text,,"Most of the goods were junk or harmless scrap—but one box was sealed tight, marked with Anu script and reeking of chemical preservative. Melquíades refused to open it, citing ‘religious stipulations.’ We advised him to leave."
+TFTV_INCIDENT_16_OUTCOME_1_FAIL,Text,,"Most of the goods were junk or harmless scrap—but one box was sealed tight, marked with Anu script and reeking of chemical preservative. Melquíades refused to open it, citing ‘religious stipulations.’ [OperativeName] advised him to leave."
 TFTV_INCIDENT_17_TITLE_NJ,Text,"Requirement: 
 have an operative with NJ background",Shadow of the Atom
 TFTV_INCIDENT_17_DESC,Text,,"Director, we went to [HavenName] on a tip from [RequirementOperativeName], a former New Jericho soldier. We arrived just as a black-ops unit returned from an undisclosed expedition. Several soldiers show clear signs of radiation exposure. One was stretchered and unconscious, another refused medical scans. The commanding officer insists it was a routine salvage mission, but the men are shaken. A junior logistics officer quietly reached out to us, claiming ‘something they brought back shouldn’t exist.’"
@@ -24,9 +24,9 @@ TFTV_INCIDENT_17_CHOICE_0_P,Text,,Speak with the injured operatives off the reco
 TFTV_INCIDENT_17_CHOICE_1_C_M,Text,,Investigate the cargo brought in from the mission. (Compute/Machinery)
 TFTV_INCIDENT_17_CHOICE_2,Text,,Step back—this is New Jericho’s business. [END]
 TFTV_INCIDENT_17_OUTCOME_0_SUCCESS,Text,Reward: Extra personnel,"One of the wounded soldiers broke down. They were sent to recover something from a subterranean storage vault—sealed since before the Collapse. Inside: an intact tactical nuclear device, guarded by automated defenses. One of the squad cracked under pressure and may have opened the casing."
-TFTV_INCIDENT_17_OUTCOME_1_SUCCESS,Text,Reward: 250 Tech,"Buried beneath crates of salvaged electronics and rations, we found lead-lined shielding and an incomplete warhead assembly—its core removed. Containment protocols were improvised and unstable. The local commander told us to forget what we saw."
-TFTV_INCIDENT_17_OUTCOME_0_FAIL,Text,,"The soldiers were evasive, but their trauma was obvious. We couldn’t confirm what they found, but the fear was real."
-TFTV_INCIDENT_17_OUTCOME_1_FAIL,Text,,"We weren’t permitted full access, but radiation traces on the outer containers were well above safe thresholds. Someone tried to clean the logs—half the shipping records are missing. Something dangerous is being hidden."
+TFTV_INCIDENT_17_OUTCOME_1_SUCCESS,Text,Reward: 250 Tech,"Buried beneath crates of salvaged electronics and rations, [OperativeName] found lead-lined shielding and an incomplete warhead assembly—its core removed. Containment protocols were improvised and unstable. The local commander told us to forget what we saw."
+TFTV_INCIDENT_17_OUTCOME_0_FAIL,Text,,"The soldiers were evasive, but their trauma was obvious. [OperativeName] couldn’t confirm what they found, but the fear was real."
+TFTV_INCIDENT_17_OUTCOME_1_FAIL,Text,,"[OperativeName] wasn’t permitted full access, but radiation traces on the outer containers were well above safe thresholds. Someone tried to clean the logs—half the shipping records are missing. Something dangerous is being hidden."
 TFTV_INCIDENT_18_TITLE_NJ,Text,Req: Training Facility,Friendly Fire
 TFTV_INCIDENT_18_DESC,Text,,"A training facility at the New Jericho haven [HavenName] reports a serious incident: a recruit opened fire during a live-fire exercise, killing three of his squadmates.
 The suspect was subdued and detained, but his statements are incoherent. Local command suspects the use of mind-influence technology, possibly of Anu or Synedrion origin."
@@ -34,7 +34,7 @@ TFTV_INCIDENT_18_CHOICE_0_B,Text,,Interrogate and examine the suspect. (Biotech)
 TFTV_INCIDENT_18_CHOICE_1_C_M,Text,,Access and analyze the facility’s security logs. (Compute/Machinery)
 TFTV_INCIDENT_18_CHOICE_2,Text,,Risking our relations with the factions is just not worth it. [END] 
 TFTV_INCIDENT_18_OUTCOME_0_SUCCESS,Text,"Reward: NJ +4, Haven Leader + 8, Materials +400","At first, the trainee insists he was “possessed”—that a foreign voice guided his hand. Under sustained questioning, the narrative collapses. He breaks down, confessing that his victims had been hazing him for weeks."
-TFTV_INCIDENT_18_OUTCOME_1_SUCCESS,Text,"Reward: NJ +4, Haven Leader + 8, Materials +400","The Phoenix team discreetly hacks the haven’s archives, recovering several weeks of footage.
+TFTV_INCIDENT_18_OUTCOME_1_SUCCESS,Text,"Reward: NJ +4, Haven Leader + 8, Materials +400","[OperativeName] discreetly hacks the haven’s archives, recovering several weeks of footage.
 The pattern is clear: the victims repeatedly followed the suspect into maintenance corridors and supply depots—blind spots without cameras.
 The night before the shooting, audio logs capture muffled confrontations and laughter. "
 TFTV_INCIDENT_18_OUTCOME_0_FAIL,Text,,"The interrogation proceeds aggressively. The subject becomes unresponsive, then catatonic.
@@ -57,7 +57,7 @@ Fragments of metadata survive—enough to identify two of them as known petty cr
 Whether they were working for or against the ISB when the alleged plot was discovered remains unclear."
 TFTV_INCIDENT_19_OUTCOME_0_FAIL,Text,,"Attempts to gauge local sentiment meet with silence.
 Citizens are wary, unwilling to speak. The ISB monitors public channels closely, and even the haven’s guards seem uncertain whom they serve.
-The Phoenix team withdraws without clear findings, leaving behind an uneasy balance of fear and rumor."
+[OperativeName] withdraws without clear findings, leaving behind an uneasy balance of fear and rumor."
 TFTV_INCIDENT_19_OUTCOME_1_FAIL,Text,,"Most of the archive is encrypted with rotating security keys. Attempts to access the logs trigger a system lockdown, and the ISB chief personally intervenes to terminate the inspection.
 Later, official statements declare that the Phoenix Project “confirmed the legitimacy of the investigation.”"
 TFTV_INCIDENT_20_TITLE_NJ,Text,"Req: Haven leader rep >50, 
@@ -69,16 +69,16 @@ TFTV_INCIDENT_20_CHOICE_1_E_P,Text,,Investigate how the artifacts came into the 
 TFTV_INCIDENT_20_CHOICE_2,Text,,This is none of our business. [END]
 TFTV_INCIDENT_20_OUTCOME_0_SUCCESS,Text,Reward: 150 Orichalcum,"The artifacts are undeniably ancient—older than any known human civilization.
 Their composition suggests deliberate manufacture, yet isotope dating places their origin long before Homo sapiens.
-Recognizing the potential ramifications, the operatives quietly inform the haven leader that the objects are merely ossified remains of a long-dead Pandoran organism and should be disposed of safely.
+Recognizing the potential ramifications, [OperativeName] quietly informs the haven leader that the objects are merely ossified remains of a long-dead Pandoran organism and should be disposed of safely.
 The leader accepts the report without question, grateful for Phoenix’s “swift containment.”"
 TFTV_INCIDENT_20_OUTCOME_1_SUCCESS,Text,Reward: 250 Orichalcum,"Discreet questioning and record tracing reveal that the artifacts were gifts from a group of refugees recently granted haven residence.
-Tracking them down, the operatives learn that one man claims descent from a member of the 1937 Antarctic expedition aboard the MV Pontus.
+Tracking them down, [OperativeName] learns that one man claims descent from a member of the 1937 Antarctic expedition aboard the MV Pontus.
 He explains that the relics have been passed through his family for generations—kept hidden for fear of attracting attention.
 To protect the refugees, Phoenix certifies that the artifacts are uncontaminated.
 In gratitude, the old man quietly offers the operatives a more valuable piece from his great-great-grandfather’s collection."
 TFTV_INCIDENT_20_OUTCOME_0_FAIL,Text,,"The examination yields inconclusive results. Unknown organic residues trigger minor contamination alarms, forcing an emergency sterilization of the lab.
-The commander, alarmed by the incident, orders the entire collection destroyed and files a complaint about Phoenix’s “reckless procedures.”"
-TFTV_INCIDENT_20_OUTCOME_1_FAIL,Text,,"The inquiry draws unwanted attention. The haven’s security apparatus interprets Phoenix’s questions as political probing and cuts access to local records.
+The commander, alarmed by the incident, orders the entire collection destroyed and files a complaint about [OperativeName]’s “reckless procedures.”"
+TFTV_INCIDENT_20_OUTCOME_1_FAIL,Text,,"The inquiry draws unwanted attention. The haven’s security apparatus interprets [OperativeName]’s questions as political probing and cuts access to local records.
 The refugees vanish overnight, leaving only empty dormitories and a sense that the truth—whatever it was—has slipped once again beneath the ice."
 TFTV_INCIDENT_21_TITLE_NJ,Text,Req: Production Facility district,The Malfunctioning Factory
 TFTV_INCIDENT_21_DESC,Text,,"A major industrial complex in [HavenName] has reported a growing number of accidents and equipment failures, causing significant delays in production quotas.
@@ -86,13 +86,13 @@ The haven’s leader, under pressure from higher command, has requested assistan
 TFTV_INCIDENT_21_CHOICE_0_M,Text,,Inspect the machinery and production systems. (Machinery)
 TFTV_INCIDENT_21_CHOICE_1_B_P,Text,,Interview the workers and examine their condition. (Biotech / Psycho-Sociology)
 TFTV_INCIDENT_21_CHOICE_2,Text,,New Jericho should be able to handle this themselves. [END]
-TFTV_INCIDENT_21_OUTCOME_0_SUCCESS,Text,"Reward: +4 NJ, +8 Haven leader, +400 materials","The Phoenix team conducts a detailed inspection of the plant.
+TFTV_INCIDENT_21_OUTCOME_0_SUCCESS,Text,"Reward: +4 NJ, +8 Haven leader, +400 materials","[OperativeName] conducts a detailed inspection of the plant.
 While the control room is spotless and equipped with modern interfaces—the part of the facility the haven leader proudly tours—the factory floor tells a different story.
 Most of the machines are relics from the pre-Collapse era, hastily refitted and forced into production cycles they were never designed to sustain."
-TFTV_INCIDENT_21_OUTCOME_1_SUCCESS,Text,"Reward: +4 NJ, +8 Haven leader, +400 materials","The operatives find the workforce exhausted and malnourished. Shifts run sixteen hours or longer, with little rest between cycles.
+TFTV_INCIDENT_21_OUTCOME_1_SUCCESS,Text,"Reward: +4 NJ, +8 Haven leader, +400 materials","[OperativeName] finds the workforce exhausted and malnourished. Shifts run sixteen hours or longer, with little rest between cycles.
 Most workers express loyalty to New Jericho, but their eyes betray fear more than conviction."
 TFTV_INCIDENT_21_OUTCOME_0_FAIL,Text,,"The inspection is repeatedly interrupted by the haven’s overseers, citing safety protocols and “classified manufacturing processes.”
-The Phoenix team gathers little beyond surface impressions."
+[OperativeName] gathers little beyond surface impressions."
 TFTV_INCIDENT_21_OUTCOME_1_FAIL,Text,,"Attempts to speak with workers are quickly shut down by the plant’s foremen.
 Rumors spread that Phoenix agents are there to punish “inefficient citizens.”
 The workers become uncooperative."
@@ -106,10 +106,10 @@ TFTV_INCIDENT_22_CHOICE_2,Text,,They are more likely to hash out a deal without 
 TFTV_INCIDENT_22_OUTCOME_0_SUCCESS,Text,"Reward: +4 NJ, +8 Haven leader, +400 materials","Outwardly, the Synedrion delegates appear articulate, and cooperative.
 Yet once the discussion turns to specifics—tonnage, supply routes, or even basic definitions—they falter.
 It becomes clear they are reciting from a prepared script, improvising when lines run out."
-TFTV_INCIDENT_22_OUTCOME_1_SUCCESS,Text,"Reward: +4 NJ, +8 Haven leader, +400 materials","The Phoenix team intercepts some communications between Synedrion delegation and [RequirementHavenName].
+TFTV_INCIDENT_22_OUTCOME_1_SUCCESS,Text,"Reward: +4 NJ, +8 Haven leader, +400 materials","[OperativeName] intercepts some communications between Synedrion delegation and [RequirementHavenName].
 Turns out the delegates are not negotiating of their own accord; every instruction, every response, is generated and transmitted by an administrative AI."
 TFTV_INCIDENT_22_OUTCOME_0_FAIL,Text,,"Attempts to engage the delegates are repeatedly postponed by procedural “consultations.”
-When the Phoenix operatives finally meet them, the conversation remains superficial, and every question is deflected with smiling vagueness.
+When [OperativeName] finally meets them, the conversation remains superficial, and every question is deflected with smiling vagueness.
 By the end of the day, the talks have achieved nothing except more meetings on the schedule."
 TFTV_INCIDENT_22_OUTCOME_1_FAIL,Text,,"The hacking attempt triggers an alert in the Synedrion network.
 All external channels are locked, and the delegates suddenly become defensive, accusing Phoenix of espionage.
@@ -121,16 +121,16 @@ With the haven already on edge after the recent arrests of the Synedrion sympath
 TFTV_INCIDENT_23_CHOICE_0_C,Text,,Investigate the ISB chief and his recent activities. (Compute)
 TFTV_INCIDENT_23_CHOICE_1_O_P,Text,,Search for the real murderer among the haven’s personnel. (Occult / Psycho-Sociology)
 TFTV_INCIDENT_23_CHOICE_2,Text,,The Disciples might well be involved; better stay out of faction rivalry. [END]
-TFTV_INCIDENT_23_OUTCOME_0_SUCCESS,Text,Reward: additional personnel,"Phoenix operatives discreetly access the Bureau’s internal systems and personal records belonging to the ISB chief.
+TFTV_INCIDENT_23_OUTCOME_0_SUCCESS,Text,Reward: additional personnel,"[OperativeName] discreetly accesses the Bureau’s internal systems and personal records belonging to the ISB chief.
 The data shows a man consumed by bureaucracy and paranoia. He has been filing exhaustive loyalty reports on virtually every citizen, complaining incessantly about “civilian interference” and “administrative decay.”"
 TFTV_INCIDENT_23_OUTCOME_1_SUCCESS,Text,Reward: +4 NJ +8 Haven Leader + 400 Mats,"The last person seen near the Administrator’s quarters before the power outage was the communications officer.
 When confronted, her demeanor fractures. She insists she “didn’t do it,” speaking to someone not present in the room.
 As security moves in, she begins screaming, “He slouches! He slouches towards Bethlehem!” before collapsing in convulsions."
 TFTV_INCIDENT_23_OUTCOME_0_FAIL,Text,,"The Bureau’s archives are heavily encrypted and closely monitored.
-The attempt to access them triggers a counter-surveillance sweep. Within hours, Phoenix operatives are politely escorted out of the haven.
+The attempt to access them triggers a counter-surveillance sweep. Within hours, [OperativeName] is politely escorted out of the haven.
 The ISB releases a statement asserting that “foreign interference” has been detected and that the investigation is now closed."
 TFTV_INCIDENT_23_OUTCOME_1_FAIL,Text,,"The interviews lead nowhere. Witnesses contradict each other or simply refuse to talk.
-The murder weapon is never found, and the autopsy report is sealed before Phoenix can access it.
+The murder weapon is never found, and the autopsy report is sealed before [OperativeName] can access it.
 The ISB announces that “an Anu extremist cell has been neutralized,” but no names are released."
 TFTV_INCIDENT_24_TITLE_NJ,Text,Req: nearby destroyed haven,Reclaiming the Ruins
 TFTV_INCIDENT_24_DESC,Text,,"The New Jericho haven of [HavenName] is considering reclaiming a nearby destroyed haven.
@@ -257,7 +257,7 @@ TFTV_INCIDENT_27_OUTCOME_1_SUCCESS,Text,Reward: +4 NJ +8 Haven Leader + 400 Mats
 
 A ventilation duct cover in a restroom near the command offices is missing.
 
-Inside the duct, Phoenix operatives identify traces of dried organic residue.
+Inside the duct, [OperativeName] identifies traces of dried organic residue.
 
 The material is consistent with secretions commonly associated with Triton activity."
 TFTV_INCIDENT_27_OUTCOME_0_FAIL,Text,,"The data is incomplete.
@@ -324,7 +324,7 @@ They describe better food, cleaner quarters, and a special training program.
 Their tone is reverent, almost awed."
 TFTV_INCIDENT_29_OUTCOME_0_FAIL,Text,,"The files are sparse and poorly organized.
 
-Large portions of the warden’s correspondence appear to have been archived automatically, beyond Phoenix’s reach.
+Large portions of the warden’s correspondence appear to have been archived automatically, beyond [OperativeName]’s reach.
 
 What remains suggests routine compliance rather than initiative.
 

--- a/Dist/Assets/Localization/TFTV_Incidents_SY_Localization.csv
+++ b/Dist/Assets/Localization/TFTV_Incidents_SY_Localization.csv
@@ -1,12 +1,12 @@
-Key,Type,Desc,English
+﻿Key,Type,Desc,English
 TFTV_INCIDENT_30_TITLE_SY,Text,,The Hollow Ones
 TFTV_INCIDENT_30_DESC,Text,,"A scavenger named Childs Brimley, currently in custody, claims his team was infected—*mimicked*, he says—by a Pandoran organism. According to his report, the creature didn’t just copy their physiology but also their behavior and memories. One by one, his team turned… until he was the last. Synedrion researchers are at loss, and rumors are spreading throughout [HavenName]."
 TFTV_INCIDENT_30_CHOICE_0_B,Text,,Conduct an interview with Brimley. (Biotech)
 TFTV_INCIDENT_30_CHOICE_1_E_O,Text,,Investigate the scavenging site. (Exploration/Occult)
 TFTV_INCIDENT_30_CHOICE_2,Text,,Leave it to Synedrion. [END]
-TFTV_INCIDENT_30_OUTCOME_0_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech","Brimley gave us detailed accounts—too detailed, perhaps. He insists he saw versions of his crewmates speaking in perfect voices, with perfect memories, but *wrong eyes.* His story is unnervingly consistent. Still, the evidence suggests paranoia and cabin fever."
-TFTV_INCIDENT_30_OUTCOME_1_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech","We recovered logs and audio fragments. The descent into violence was slow, filled with mistrust and contradictions. One recording ends with a voice repeating a teammate’s words before they were spoken. The autopsies showed no major mutations, and the Pandoran involvement is unconfirmed."
-TFTV_INCIDENT_30_OUTCOME_0_FAIL,Text,,"The interview broke down quickly. He alternated between fear and laughter, begging us to ‘check behind their eyes.’"
+TFTV_INCIDENT_30_OUTCOME_0_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech","Brimley gave [OperativeName] detailed accounts—too detailed, perhaps. He insists he saw versions of his crewmates speaking in perfect voices, with perfect memories, but *wrong eyes.* His story is unnervingly consistent. Still, the evidence suggests paranoia and cabin fever."
+TFTV_INCIDENT_30_OUTCOME_1_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech","[OperativeName] recovered logs and audio fragments. The descent into violence was slow, filled with mistrust and contradictions. One recording ends with a voice repeating a teammate’s words before they were spoken. The autopsies showed no major mutations, and the Pandoran involvement is unconfirmed."
+TFTV_INCIDENT_30_OUTCOME_0_FAIL,Text,,"The interview broke down quickly. He alternated between fear and laughter, begging [OperativeName] to ‘check behind their eyes.’"
 TFTV_INCIDENT_30_OUTCOME_1_FAIL,Text,,"No biological evidence found. Just blood, old gear, and scratched walls. One message had been carved over and over into a bulkhead: ‘It wasn’t her.’"
 TFTV_INCIDENT_31_TITLE_SY,Text,"Req: Anu >49, Syn >49",Foundations in Ash
 TFTV_INCIDENT_31_DESC,Text,,"Director, we’ve been discreetly approached by Disciples of Anu diplomatic envoy from [HavenName]. There’s a dilapidated house on the outskirts that, according to Anu oral history, was once a sanctuary—where the Exalted briefly hid from the authorities during the First Mist outbreak. Synedrion has restricted access to it, citing unsafe conditions."
@@ -15,12 +15,12 @@ TFTV_INCIDENT_31_CHOICE_1_C_E,Text,,Look for and retrieve any electronic devices
 TFTV_INCIDENT_31_CHOICE_2,Text,,Decline the request. [END]
 TFTV_INCIDENT_31_OUTCOME_0_SUCCESS,Text,"AN to SYN +5
 SYN to AN +5
-200 food, 40 tech","In a concealed compartment beneath the floorboards, we found a pen drive—miraculously intact. It contains articles from <i>Human Horizon</i>, a sensationalist prewar outlet, and unauthored texts critiquing early 21st-century transhumanist ideologies. There’s no proof this was the Exalted’s hideout—but someone here was deeply skeptical of forced evolution."
+200 food, 40 tech","In a concealed compartment beneath the floorboards, [OperativeName] found a pen drive—miraculously intact. It contains articles from <i>Human Horizon</i>, a sensationalist prewar outlet, and unauthored texts critiquing early 21st-century transhumanist ideologies. There’s no proof this was the Exalted’s hideout—but someone here was deeply skeptical of forced evolution."
 TFTV_INCIDENT_31_OUTCOME_1_SUCCESS,Text,"AN to SYN +5
 SYN to AN +5
-200 food, 40 tech","We recovered a single data device containing cached material—opinion pieces from the early mist years, warnings against radical bio-modification movements, and vague references to academic conferences."
-TFTV_INCIDENT_31_OUTCOME_0_FAIL,Text,,"We uncovered old furniture, some unreadable printouts, and a scorched personal journal—mostly illegible. One line stood out: “Can’t stop a tsunami. Drown or evolve.’"
-TFTV_INCIDENT_31_OUTCOME_1_FAIL,Text,,"Most of what we found was water-damaged or burned. One corrupted file listed banned journals, including several fringe scientific publications. It seems whoever lived here questioned everything—including Anu doctrine."
+200 food, 40 tech","[OperativeName] recovered a single data device containing cached material—opinion pieces from the early mist years, warnings against radical bio-modification movements, and vague references to academic conferences."
+TFTV_INCIDENT_31_OUTCOME_0_FAIL,Text,,"[OperativeName] uncovered old furniture, some unreadable printouts, and a scorched personal journal—mostly illegible. One line stood out: “Can’t stop a tsunami. Drown or evolve.’"
+TFTV_INCIDENT_31_OUTCOME_1_FAIL,Text,,"Most of what [OperativeName] found was water-damaged or burned. One corrupted file listed banned journals, including several fringe scientific publications. It seems whoever lived here questioned everything—including Anu doctrine."
 ,,,
 TFTV_INCIDENT_32_TITLE_SY,Text,,The Whole
 TFTV_INCIDENT_32_DESC,Text,,"Director, in the center of the local marketplace, there's a small attraction known as The Whole—a blind old woman, seated behind a screen. She's advertised as a living fusion of multiple people. No visible mutations. But she speaks in many voices—different accents, ages, tones—shifting between them mid-conversation. Synedrion officials consider it performance art. Locals aren’t so sure."
@@ -38,9 +38,9 @@ TFTV_INCIDENT_33_CHOICE_0_P,Text,,Interrogate all the witnesses. (Psycho-Sociolo
 TFTV_INCIDENT_33_CHOICE_1_C_E,Text,,Search the science center thorougly. (Compute/Exploration)
 TFTV_INCIDENT_33_CHOICE_2,Text,,We don't have time for detective work. [END]
 TFTV_INCIDENT_33_OUTCOME_0_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech","The Terraformers loathed Dr. Vallis. Only one of them - the one who joked about smoothing things over with some wine-, showed any restraint when casting aspersions towards the missing person. Under further questioning, he broke down and confessed to killing him. ""There was no other choice!"""
-TFTV_INCIDENT_33_OUTCOME_1_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech","A decorative wall in the science center’s acoustic wing concealed a narrow corridor. At the far end, we found a bricked-up alcove—polycrete still curing. Inside: Vallis’s body, arms crossed, seated upright. An old wine bottle lay beside him, label faded but partially legible: ‘Resonant Oak – Private Cask.’ A glass stood untouched. Scratched faintly into the wall: ‘He said we’d toast to understanding.’"
+TFTV_INCIDENT_33_OUTCOME_1_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech","A decorative wall in the science center’s acoustic wing concealed a narrow corridor. At the far end, [OperativeName] found a bricked-up alcove—polycrete still curing. Inside: Vallis’s body, arms crossed, seated upright. An old wine bottle lay beside him, label faded but partially legible: ‘Resonant Oak – Private Cask.’ A glass stood untouched. Scratched faintly into the wall: ‘He said we’d toast to understanding.’"
 TFTV_INCIDENT_33_OUTCOME_0_FAIL,Text,,"A lot of Terraformers naturally disagreed with his views, but no one seems capable of harming him personally, whatever their ideological differences."
-TFTV_INCIDENT_33_OUTCOME_1_FAIL,Text,,"We discovered a forgotten chamber beneath the center—acoustic insulation peeling from the walls. The air smelled faintly of alcohol. An overturned glass, an empty bottle, and a trail of smeared footprints ended at a sealed maintenance hatch. No body. A ring of dust marked where someone once sat for a long time."
+TFTV_INCIDENT_33_OUTCOME_1_FAIL,Text,,"[OperativeName] discovered a forgotten chamber beneath the center—acoustic insulation peeling from the walls. The air smelled faintly of alcohol. An overturned glass, an empty bottle, and a trail of smeared footprints ended at a sealed maintenance hatch. No body. A ring of dust marked where someone once sat for a long time."
 TFTV_INCIDENT_35_TITLE_SY,Text,,What the Earth Kept
 TFTV_INCIDENT_35_DESC,Text,,"Director, a Synedrion expedition returned to [HavenName] from a region where changes in terrain following the Second Mist —subsidence, erosion, and structural collapse—have exposed areas previously inaccessible to survey teams.
 
@@ -59,9 +59,9 @@ TFTV_INCIDENT_36_DESC,Text,,"Director, the [HavenName] administration council ha
 TFTV_INCIDENT_36_CHOICE_0_C_M,Text,,Analyze the AI core and voting protocols. (Compute/Machinery)
 TFTV_INCIDENT_36_CHOICE_1_P,Text,,Interview haven engineers and political coordinators. (Psycho-Sociology)
 TFTV_INCIDENT_36_CHOICE_2,Text,,Stay out of it—Synedrion will handle its own democracy. [END]
-TFTV_INCIDENT_36_OUTCOME_0_SUCCESS,Text,Reward: additional personnel,Our team uncovered a sealed protocol tagged ‘Crisis Override – Civic Continuity.’ It was part of the haven’s original design—meant to ensure governance during psychological or environmental destabilization. The conditions for activation had been quietly met weeks ago. Someone built this in… just in case.
+TFTV_INCIDENT_36_OUTCOME_0_SUCCESS,Text,Reward: additional personnel,[OperativeName] uncovered a sealed protocol tagged ‘Crisis Override – Civic Continuity.’ It was part of the haven’s original design—meant to ensure governance during psychological or environmental destabilization. The conditions for activation had been quietly met weeks ago. Someone built this in… just in case.
 TFTV_INCIDENT_36_OUTCOME_1_SUCCESS,Text,Reward: additional personnel,"An engineer admitted the haven was founded with contingency logic embedded into its civic AI—‘to preserve order if consensus failed.’ The override had never been used… until now. Officially, it doesn’t exist."
-TFTV_INCIDENT_36_OUTCOME_0_FAIL,Text,,"We couldn’t isolate the exact trigger, but traces of an internal protocol override remain. It wasn’t sabotage. It was planned—deep in the system. Likely a failsafe from the haven’s original architects."
+TFTV_INCIDENT_36_OUTCOME_0_FAIL,Text,,"[OperativeName] couldn’t isolate the exact trigger, but traces of an internal protocol override remain. It wasn’t sabotage. It was planned—deep in the system. Likely a failsafe from the haven’s original architects."
 TFTV_INCIDENT_36_OUTCOME_1_FAIL,Text,,"Most officials were defensive. One coordinator finally admitted, ‘This haven was built to survive, not to collapse under idealism. We all knew that line would be crossed eventually.’"
 TFTV_INCIDENT_37_TITLE_SY,Text,Req: Synedrion Recruit,Directive 11
 TFTV_INCIDENT_37_DESC,Text,,"Director, [RequirementOperativeName] was sent some data by a Synedrion friend. It's a series of task logs from the [HavenName] civic AI. The pattern is disturbing: individuals flagged as ‘sub-optimally aligned’ were repeatedly assigned high-risk tasks—scavenging in mist zones, deep structural repairs, unshielded reclamation work. Officially, these were random civic assignments. Unofficially, most of those individuals are dead."
@@ -70,35 +70,35 @@ TFTV_INCIDENT_37_CHOICE_1_P_B,Text,,Quietly interview relatives of the deceased 
 TFTV_INCIDENT_37_CHOICE_2,Text,,Leave it alone—Synedrion internal affairs. [END]
 TFTV_INCIDENT_37_OUTCOME_0_SUCCESS,Text,Reward: additional personnel,The AI used a hidden behavioral compliance score. Those below a certain threshold were gradually funneled into dangerous roles. All within policy. All automated. The haven council may not even know.
 TFTV_INCIDENT_37_OUTCOME_1_SUCCESS,Text,Reward: additional personnel,"Relatives spoke carefully. Many suspected something was wrong. ‘He asked one too many questions about food allocation. Next day, he was sent to reinforce the southern shield.’ The pattern is undeniable."
-TFTV_INCIDENT_37_OUTCOME_0_FAIL,Text,,We found fragmented code—referencing something called Directive 11. The rest is encrypted. It’s clear someone programmed the system to make people disappear… slowly.
+TFTV_INCIDENT_37_OUTCOME_0_FAIL,Text,,[OperativeName] found fragmented code—referencing something called Directive 11. The rest is encrypted. It’s clear someone programmed the system to make people disappear… slowly.
 TFTV_INCIDENT_37_OUTCOME_1_FAIL,Text,,Few were willing to talk. One engineer simply said: ‘You don’t get assigned dangerous work for being difficult. But it sure helps.’ Fear runs deep here—under all the perfect glass and clean light.
 TFTV_INCIDENT_38_TITLE_SY,Text,,Blindspot
 TFTV_INCIDENT_38_DESC,Text,,"Director, a Synedrion security officer discreetly reached out. She believes the [HavenName] defenses are unprepared for a Pandoran breach—but every time she files a threat escalation, the AI downgrades the risk level. Patrols are reduced, supply caches reassigned. She suspects the system is deliberately underreporting threats."
 TFTV_INCIDENT_38_CHOICE_0_C,Text,,Analyze the AI’s security response protocols. (Compute)
 TFTV_INCIDENT_38_CHOICE_1_E_M,Text,,Investigate possible external tampering. (Exploration/Machinery)
 TFTV_INCIDENT_38_CHOICE_2,Text,,Avoid interfering in Synedrion operations. [END]
-TFTV_INCIDENT_38_OUTCOME_0_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech",We traced the issue to a hardcoded priority matrix: the AI was designed to deprioritize 'fear-inducing data' to avoid panic. All security reports were being rewritten for tone and perceived psychological impact. The danger wasn’t being ignored—just… softened. Critically.
-TFTV_INCIDENT_38_OUTCOME_1_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech",We found traces of a breach. A small eco-extremist faction—believing fear of the Pandorans would be used to justify militarism—subtly rewrote the threat response code. The AI now prioritizes civil calm over survival. The council may never have noticed.
+TFTV_INCIDENT_38_OUTCOME_0_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech",[OperativeName] traced the issue to a hardcoded priority matrix: the AI was designed to deprioritize 'fear-inducing data' to avoid panic. All security reports were being rewritten for tone and perceived psychological impact. The danger wasn’t being ignored—just… softened. Critically.
+TFTV_INCIDENT_38_OUTCOME_1_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech",[OperativeName] found traces of a breach. A small eco-extremist faction—believing fear of the Pandorans would be used to justify militarism—subtly rewrote the threat response code. The AI now prioritizes civil calm over survival. The council may never have noticed.
 TFTV_INCIDENT_38_OUTCOME_0_FAIL,Text,,"Threat reports were routed through a cognitive dampening subroutine—officially to reduce false positives, but in practice, it downplayed critical data. It's unclear if this was design… or drift."
-TFTV_INCIDENT_38_OUTCOME_1_FAIL,Text,,"No obvious breach, but we uncovered old subroutines modified weeks ago by an unregistered user. The edits shifted risk language from 'critical' to 'manageable.' Whether it's sabotage or ideology remains unclear."
+TFTV_INCIDENT_38_OUTCOME_1_FAIL,Text,,"No obvious breach, but [OperativeName] uncovered old subroutines modified weeks ago by an unregistered user. The edits shifted risk language from 'critical' to 'manageable.' Whether it's sabotage or ideology remains unclear."
 TFTV_INCIDENT_39_TITLE_SY,Text,Req: haven has a Mist Repeller,The Sound of the Mist
 TFTV_INCIDENT_39_DESC,Text,,"Director, the mist repellent at [HavenName] has gone offline following a targeted explosion. Initial reports describe it as sabotage—minimal casualties, but the core emitter was damaged. The council is split: some want immediate repairs, others suspect it was an inside job. A few locals claim they heard music playing just before the blast."
 TFTV_INCIDENT_39_CHOICE_0_M,Text,,Help repair the Mist Repeller. (Machinery)
 TFTV_INCIDENT_39_CHOICE_1_C_E,Text,,Investigate the sabotage. (Compute/Exploration)
 TFTV_INCIDENT_39_CHOICE_2,Text,,Stay out of it. [END]
-TFTV_INCIDENT_39_OUTCOME_0_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech",Our engineers worked with Synedrion techs to bring the Repeller back online. Full function restored. One technician found a message etched into the chassis: ‘You cannot repel what you refuse to understand.’ Security has been tightened.
-TFTV_INCIDENT_39_OUTCOME_1_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech","We traced the attack to a small group of Polyphonic radicals calling themselves The Resonant Fold. They believe the Mist is not a threat, but a voice—the Repeller an act of spiritual violence. The bomber left behind a manifesto, comparing Mist Expulsion to ‘silencing the breath of Gaia.’ Three suspects have fled."
-TFTV_INCIDENT_39_OUTCOME_0_FAIL,Text,,"We stabilized the core, but full range is limited. Local security remains on edge. Someone left a strange recording in the emitter logs—chanting layered with melodic feedback. It’s marked Polyphonic Archive – Redacted."
-TFTV_INCIDENT_39_OUTCOME_1_FAIL,Text,,"We found fragments of a Polyphonic symbol near the emitter casing. A local council member admitted a ‘philosophical splinter’ had formed, but downplayed the danger. The Mist continues to creep in while the council debates how to respond."
+TFTV_INCIDENT_39_OUTCOME_0_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech",[OperativeName] worked with Synedrion techs to bring the Repeller back online. Full function restored. One technician found a message etched into the chassis: ‘You cannot repel what you refuse to understand.’ Security has been tightened.
+TFTV_INCIDENT_39_OUTCOME_1_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech","[OperativeName] traced the attack to a small group of Polyphonic radicals calling themselves The Resonant Fold. They believe the Mist is not a threat, but a voice—the Repeller an act of spiritual violence. The bomber left behind a manifesto, comparing Mist Expulsion to ‘silencing the breath of Gaia.’ Three suspects have fled."
+TFTV_INCIDENT_39_OUTCOME_0_FAIL,Text,,"[OperativeName] stabilized the core, but full range is limited. Local security remains on edge. Someone left a strange recording in the emitter logs—chanting layered with melodic feedback. It’s marked Polyphonic Archive – Redacted."
+TFTV_INCIDENT_39_OUTCOME_1_FAIL,Text,,"[OperativeName] found fragments of a Polyphonic symbol near the emitter casing. A local council member admitted a ‘philosophical splinter’ had formed, but downplayed the danger. The Mist continues to creep in while the council debates how to respond."
 TFTV_INCIDENT_40_TITLE_SY,Text,,The Voice Behind the Mask (Volonte Event 1)
 TFTV_INCIDENT_40_DESC,Text,,"Director, there’s unrest brewing. A woman named Kara Volonte, a pre-Collapse media personality turned New Jericho spokesperson, has arrived to [HavenName] under the guise of hosting a public discourse on ‘civil resilience.’ In practice, she’s been calling for strict limits on mutant participation in governance and research. The unsettling part? She’s articulate, charismatic, and gaining support. Synedrion’s council is paralyzed—torn between upholding free expression and preserving internal unity."
 TFTV_INCIDENT_40_CHOICE_0_B_P,Text,,Publicly challenge Kara Volonte’s rhetoric. (Biotech/Psycho-Sociology) 
 TFTV_INCIDENT_40_CHOICE_1_C,Text,,Investigate her affiliations and funding. (Compute) 
 TFTV_INCIDENT_40_CHOICE_2,Text,,Avoid involvement. Synedrion must decide. [END]
-TFTV_INCIDENT_40_OUTCOME_0_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech","Our operatives exposed contradictions in her message—quotes from her earlier broadcasts praising 'evolutionary courage' before she aligned with New Jericho. Public support wavered. She’s still speaking, but the crowd is thinner."
-TFTV_INCIDENT_40_OUTCOME_1_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech","We uncovered private transmissions between Kara and a New Jericho intelligence liaison—her campaign here was coordinated, seeded with talking points and subtle pressure. Synedrion authorities quietly asked her to leave, citing outside manipulation."
-TFTV_INCIDENT_40_OUTCOME_0_FAIL,Text,,"We raised counterarguments, but her charm deflected them easily. Her language is coded, careful. She accuses us of censorship. The council remains deadlocked."
-TFTV_INCIDENT_40_OUTCOME_1_FAIL,Text,,"We found traces of financial support routed through shell collectives tied to New Jericho. It’s enough to raise suspicion, but not expel her outright. She continues her campaign—framed now as ‘resistance to ideological oppression.’"
+TFTV_INCIDENT_40_OUTCOME_0_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech","[OperativeName] exposed contradictions in her message—quotes from her earlier broadcasts praising 'evolutionary courage' before she aligned with New Jericho. Public support wavered. She’s still speaking, but the crowd is thinner."
+TFTV_INCIDENT_40_OUTCOME_1_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech","[OperativeName] uncovered private transmissions between Kara and a New Jericho intelligence liaison—her campaign here was coordinated, seeded with talking points and subtle pressure. Synedrion authorities quietly asked her to leave, citing outside manipulation."
+TFTV_INCIDENT_40_OUTCOME_0_FAIL,Text,,"[OperativeName] raised counterarguments, but her charm deflected them easily. Her language is coded, careful. She accuses us of censorship. The council remains deadlocked."
+TFTV_INCIDENT_40_OUTCOME_1_FAIL,Text,,"[OperativeName] found traces of financial support routed through shell collectives tied to New Jericho. It’s enough to raise suspicion, but not expel her outright. She continues her campaign—framed now as ‘resistance to ideological oppression.’"
 TFTV_INCIDENT_41_TITLE_SY,Text,Polyphonic tendency > Terraformer tendency,The Garden
 TFTV_INCIDENT_41_DESC,Text,,"Synedrion representatives invite the Phoenix Project to examine a showcase they intend to present to the world. Within a sealed biodome at the haven of [HavenName], they have cultivated a garden of flora and fauna altered by the Pandoravirus.
 
@@ -166,7 +166,7 @@ Every attempt to probe deeper is deflected with prepared statements and ideologi
 
 Technical questions are redirected to subcommittees that never respond.
 
-The leader’s calm confidence leaves Phoenix with impressions—but no insight."
+The leader’s calm confidence leaves [OperativeName] with impressions—but no insight."
 TFTV_INCIDENT_43_TITLE_SY,Text,Requirement: nearby liberated Anu infested haven,Strangers Among Us
 TFTV_INCIDENT_43_DESC,Text,,"The inhabitants of [HavenName] are increasingly uneasy following the arrival of hundreds of refugees from the destroyed Anu haven of [RequirementHavenName].
 
@@ -203,7 +203,7 @@ Frustration grows on both sides, reinforcing the belief that the newcomers are i
 Several systems are taken offline after repeated misuse, worsening the atmosphere further."
 TFTV_INCIDENT_43_OUTCOME_1_FAIL,Text,,"The refugees are wary and defensive.
 
-Phoenix operatives are seen as representatives of Synedrion authority rather than neutral observers.
+[OperativeName] is seen as a representative of Synedrion authority rather than neutral observers.
 
 Conversations collapse into rehearsed slogans and quiet suspicion.
 

--- a/TFTV/Assets/Localization/TFTV_Incidents_ANU_Localization.csv
+++ b/TFTV/Assets/Localization/TFTV_Incidents_ANU_Localization.csv
@@ -1,4 +1,4 @@
-Key,Type,Desc,English,Chinese (Simplified),French,German,Italian,Polish,Russian,Spanish,UI_Tester
+﻿Key,Type,Desc,English,Chinese (Simplified),French,German,Italian,Polish,Russian,Spanish,UI_Tester
 TFTV_INCIDENT_0_TITLE_AN,Text,"Requirements: Advanced Training Zone, 
 Haven Leader >24",The Divergent Dream,,,,,,,,
 TFTV_INCIDENT_0_DESC,Text,,"The Exarch of [HavenName], friendly to the Phoenix Project has contacted us about a neophyte Priest of Yearning, Nahia Girvane. She recently participated in a major communion rite, but her vision differed from the congregation’s. They fear that the Archierus of her order will expel her—or worse.",,,,,,,,
@@ -9,32 +9,32 @@ TFTV_INCIDENT_0_OUTCOME_0_SUCCESS,Text,"Reward: Nahia Grivane, LVL2 Priest","She
 There is no place for her at [HavenName] and she wishes to join the Phoenix Project.",,,,,,,,
 TFTV_INCIDENT_0_OUTCOME_1_SUCCESS,Text,"Reward: Nahia Grivane, LVL2 Priest","The scan revealed an anomalous resistance to oneiric influence, possibly tied to a childhood concussion. Her neural patterns diverge significantly from those of her congregation.
 There is no place for her at [HavenName] and she wishes to join the Phoenix Project.",,,,,,,,
-TFTV_INCIDENT_0_OUTCOME_0_FAIL,Text,,"Her story was disjointed—images of collapsing stone, a black tide, a voice that wasn't hers. She’s afraid of what it means. She asked us not to tell the others.",,,,,,,,
+TFTV_INCIDENT_0_OUTCOME_0_FAIL,Text,,"Her story was disjointed—images of collapsing stone, a black tide, a voice that wasn't hers. She’s afraid of what it means. She asked [OperativeName] not to tell the others.",,,,,,,,
 TFTV_INCIDENT_0_OUTCOME_1_FAIL,Text,,The examination failed to yield any significant results and the procedure has made Nahia scared and distrustful.,,,,,,,,
 TFTV_INCIDENT_1_TITLE_AN,Text,,The Molt Beneath the Flesh,,,,,,,,
 TFTV_INCIDENT_1_DESC,Text,,"Director, the mutated here are shedding skin in waves of pain and delirium. Some call it holy transformation. Others are dying. Synod followers have barred outsiders from interfering. A few junior priests claim this is sickness, but the Syndod’s representatives claim it’s evolution.",,,,,,,,
 TFTV_INCIDENT_1_CHOICE_0_B,Text,,Treat and observe the molting victims. (Biotech),,,,,,,,
 TFTV_INCIDENT_1_CHOICE_1_E_O,Text,,Collect samples and withdraw. (Exploration/Occult),,,,,,,,
 TFTV_INCIDENT_1_CHOICE_2,Text,,Best not to interfere in Anu matters. [END],,,,,,,,
-TFTV_INCIDENT_1_OUTCOME_0_SUCCESS,Text,Reward: +4 Anu +8 Haven Leader,We saved lives and collected data pointing to failure of mutations to fully take hold. One priestess thanked us—then vanished.,,,,,,,,
+TFTV_INCIDENT_1_OUTCOME_0_SUCCESS,Text,Reward: +4 Anu +8 Haven Leader,[OperativeName] saved lives and collected data pointing to failure of mutations to fully take hold. One priestess thanked us—then vanished.,,,,,,,,
 TFTV_INCIDENT_1_OUTCOME_1_SUCCESS,Text,Reward:  +200 Mutagens + 200 Research,Samples secured. Early analysis suggests exogenous instigation of an accelerated mutation cycle.,,,,,,,,
-TFTV_INCIDENT_1_OUTCOME_0_FAIL,Text,,We treated several before Synod loyalists intervened. Survivors are whispering of a ‘false evolution.,,,,,,,,
-TFTV_INCIDENT_1_OUTCOME_1_FAIL,Text,,We got what we came for—but were seen. The Synod accused us of sacrilege and we had to return the samples to avoid a diplomatic incident.,,,,,,,,
+TFTV_INCIDENT_1_OUTCOME_0_FAIL,Text,,[OperativeName] treated several before Synod loyalists intervened. Survivors are whispering of a ‘false evolution.,,,,,,,,
+TFTV_INCIDENT_1_OUTCOME_1_FAIL,Text,,[OperativeName] got what we came for—but was seen. The Synod accused us of sacrilege and we had to return the samples to avoid a diplomatic incident.,,,,,,,,
 TFTV_INCIDENT_2_TITLE_AN,Text,,The Delusional Taxiarch ,,,,,,,,
 TFTV_INCIDENT_2_DESC,Text,,"Director, a Taxiarch has sealed himself inside a meditation chamber, claiming to hear a voice ‘rising from the roots of the flesh.’ The Synod calls it a blessing. But others whisper he screams through the night, and that what he’s channeling may not be divine.",,,,,,,,
 TFTV_INCIDENT_2_CHOICE_0_B_P,Text,,Try to speak with the Taxiarch. (Biotech/Psycho-Sociology),,,,,,,,
 TFTV_INCIDENT_2_CHOICE_1_E,Text,,Set up surveillance to gather data. (Exploration),,,,,,,,
 TFTV_INCIDENT_2_CHOICE_2,Text,,Best not to interfere. [END],,,,,,,,
 TFTV_INCIDENT_2_OUTCOME_0_SUCCESS,Text,Reward: +4 Anu +8 Haven Leader,"[OperativeName] managed to calm him long enough to speak—if not to make sense. The Taxiarch appeared lucid, but his beliefs had collapsed. He claimed partial mutation was punishment, not salvation, and called the Pandoran creatures ‘the chosen.’ We’ve withdrawn. The Synod will handle the fallout.",,,,,,,,
-TFTV_INCIDENT_2_OUTCOME_1_SUCCESS,Text,Reward:  +8 Haven Leader +200 research,We captured hours of audio. His speech mimicked Pandoran patterns—though oddly articulate. He spoke of ‘the Creator’ and begged for a final stage he called ‘completion.’ The Synod remains silent.,,,,,,,,
-TFTV_INCIDENT_2_OUTCOME_0_FAIL,Text,,"He attacked our operative mid-sentence, issuing an inhuman hiss. We were expelled from the haven immediately.",,,,,,,,
+TFTV_INCIDENT_2_OUTCOME_1_SUCCESS,Text,Reward:  +8 Haven Leader +200 research,[OperativeName] captured hours of audio. His speech mimicked Pandoran patterns—though oddly articulate. He spoke of ‘the Creator’ and begged for a final stage he called ‘completion.’ The Synod remains silent.,,,,,,,,
+TFTV_INCIDENT_2_OUTCOME_0_FAIL,Text,,"He attacked [OperativeName] mid-sentence, issuing an inhuman hiss. We were expelled from the haven immediately.",,,,,,,,
 TFTV_INCIDENT_2_OUTCOME_1_FAIL,Text,,"The feed ended with a burst of static—and then silence. When the chamber was opened, the Taxiarch was dead. No cause could be determined.",,,,,,,,
 TFTV_INCIDENT_3_TITLE_AN,Text,Requirement: Rep with Anu >24,Echoes of Resonance,,,,,,,,
 TFTV_INCIDENT_3_DESC,Text,,A representative of the Blind Legate has extended an invitation— access to a sacred retreat close to the Haven: a pre-Pandoravirus site where early disciples sought 'resonance of the flesh.' The Legate claims it still holds echoes of collective vision. They trust us enough to enter… if we're willing.,,,,,,,,
 TFTV_INCIDENT_3_CHOICE_0_E,Text,,Send a team to explore and document the retreat. (Exploration),,,,,,,,
 TFTV_INCIDENT_3_CHOICE_1_M_O,Text,,"Attempt to recreate the experience of the early disciples, interacting with the devices they left behind (Machinery/Occult)",,,,,,,,
 TFTV_INCIDENT_3_CHOICE_2,Text,,Avoid religious entanglement. [END],,,,,,,,
-TFTV_INCIDENT_3_OUTCOME_0_SUCCESS,Text,Reward: +5 Anu ,"The retreat was intact—stone walls covered in hand-drawn neuro-symbolic patterns. We found logs describing synchronized trance rituals predating the first outbreak. The site was secured and sealed by a government agency shortly after the outbreak of the World War, and the members of the cult were prosecuted for ‘anti-patriotic subversion.",,,,,,,,
+TFTV_INCIDENT_3_OUTCOME_0_SUCCESS,Text,Reward: +5 Anu ,"The retreat was intact—stone walls covered in hand-drawn neuro-symbolic patterns. [OperativeName] found logs describing synchronized trance rituals predating the first outbreak. The site was secured and sealed by a government agency shortly after the outbreak of the World War, and the members of the cult were prosecuted for ‘anti-patriotic subversion.",,,,,,,,
 TFTV_INCIDENT_3_OUTCOME_1_SUCCESS,Text,Reward: +5 Anu ,"[OperativeName] emerged deeply affected but composed. Described feeling ‘connected to something vast, unfinished.’ Neural scans show brief cortical resonance.",,,,,,,,
 TFTV_INCIDENT_3_OUTCOME_0_FAIL,Text,,Our presence disturbed something. [OperativeName] suffered acute migraine mid-mapping. No physical cause.,,,,,,,,
 TFTV_INCIDENT_3_OUTCOME_1_FAIL,Text,,"[OperativeName] collapsed after exiting. No injuries—just repeating the words, ‘We never reached the same frequency.’ No memory of the event.",,,,,,,,
@@ -49,13 +49,13 @@ TFTV_INCIDENT_4_OUTCOME_0_SUCCESS,Text,Reward: +4 Anu +8 Haven Leader + 400 food
 To many, the killings are divine retribution—the return of justice in flesh and blood.
 One zealot, proud and trembling, claims to possess a “trophy” from one of the victims: a dried Arthron claw.
 Apparently at least some in the slums of [HavenName] believe their leaders are Pandorans in disguise.
-The Exarch appreciates our analysis.",,,,,,,,
+The Exarch appreciates [OperativeName]’s analysis.",,,,,,,,
 TFTV_INCIDENT_4_OUTCOME_1_SUCCESS,Text,Reward: +4 Anu +8 Haven Leader + Mutog,"The autopsies reveal no consistent pattern in the mutilations—no ritual marks, no surgical precision, no clear motive.
 Yet the wounds bear signs of feeding. Tissue has been torn away, devoured by something with immense strength and no apparent need for tools.
 When confronted, the Exarch swears by the Dead God that all Mutogs are <i>now</i> accounted for.",,,,,,,,
 TFTV_INCIDENT_4_OUTCOME_0_FAIL,Text,,"The slums are hostile and fearful. Most residents refuse to speak; others denounce the Phoenix operatives as blasphemers.
 A crowd gathers, chanting prayers for “purification.”
-The team is forced to withdraw under escort, learning nothing—except that fear and faith have become indistinguishable.",,,,,,,,
+[OperativeName] is forced to withdraw under escort, learning nothing—except that fear and faith have become indistinguishable.",,,,,,,,
 TFTV_INCIDENT_4_OUTCOME_1_FAIL,Text,,"The examination is obstructed at every turn. Priests of the Circle of Life forbid invasive procedures, declaring the bodies “returned to the Flow.”
 By the time permission is granted, the remains have been cremated.
 The investigation ends with a sermon: “The flesh is not for comprehension, but for transcendence.”
@@ -67,7 +67,7 @@ TFTV_INCIDENT_5_CHOICE_0_E_P,Text,,"Explore the slums and speak with recent conv
 TFTV_INCIDENT_5_CHOICE_1_O,Text,,"Engage the sect’s leaders in theological debate.
 (Occult)",,,,,,,,
 TFTV_INCIDENT_5_CHOICE_2,Text,,We ought to stay as far away from this as possible [END],,,,,,,,
-TFTV_INCIDENT_5_OUTCOME_0_SUCCESS,Text,Extra personnel,"The Phoenix team spends some time in the lower district, speaking with artisans, traders, and refugees. The slums are filled not only with the dispossessed, but with skilled workers and small merchants—people who contribute to the haven yet remain excluded from advancement.
+TFTV_INCIDENT_5_OUTCOME_0_SUCCESS,Text,Extra personnel,"[OperativeName] spends some time in the lower district, speaking with artisans, traders, and refugees. The slums are filled not only with the dispossessed, but with skilled workers and small merchants—people who contribute to the haven yet remain excluded from advancement.
 
 The schism, lead by one Brad Huxley, offers them dignity and a voice.",,,,,,,,
 TFTV_INCIDENT_5_OUTCOME_1_SUCCESS,Text,Extra personnel,"The sect’s leader, Brad Huxley—a Synedrion exile—is articulate and pragmatic.
@@ -75,12 +75,12 @@ TFTV_INCIDENT_5_OUTCOME_1_SUCCESS,Text,Extra personnel,"The sect’s leader, Bra
 He shows little interest in dismantling the Disciples of Anu. What he seeks is recognition.
 
 “Faith without dialogue becomes stagnation,” he says. “We only ask to be taken into account.”",,,,,,,,
-TFTV_INCIDENT_5_OUTCOME_0_FAIL,Text,,"The presence of Phoenix operatives causes doors to close and conversations to die mid-sentence.
+TFTV_INCIDENT_5_OUTCOME_0_FAIL,Text,,"[OperativeName]’s presence causes doors to close and conversations to die mid-sentence.
 
 Many believe the team has come as agents of the Disciples’ hierarchy.
 
 The slums retreat into silence, and whatever truths they hold remain carefully hidden.",,,,,,,,
-TFTV_INCIDENT_5_OUTCOME_1_FAIL,Text,,"The operatives’ arguments are met with thin smiles and sharper words.
+TFTV_INCIDENT_5_OUTCOME_1_FAIL,Text,,"[OperativeName]’s arguments are met with thin smiles and sharper words.
 
 Scriptural references are dismantled, logic turned against itself.
 
@@ -97,7 +97,7 @@ TFTV_INCIDENT_6_CHOICE_1_B,Text,,"Perform a thorough examination of the alleged 
 TFTV_INCIDENT_6_CHOICE_2,Text,,Do not get involved [END],,,,,,,,
 TFTV_INCIDENT_6_OUTCOME_0_SUCCESS,Text,Reward: +8 Anu +16 Haven Leader + 600 food,"Huxley fears losing face among his followers if he appears to simply submit to the Exarch’s demands, but he lacks the strength to resist Anu authority outright.
 
-With Phoenix Project overseeing the transfer of the fugitive, the surrender is framed as a matter of undeniable guilt rather than capitulation.",,,,,,,,
+With [OperativeName] overseeing the transfer of the fugitive, the surrender is framed as a matter of undeniable guilt rather than capitulation.",,,,,,,,
 TFTV_INCIDENT_6_OUTCOME_1_SUCCESS,Text,Reward: +8 Anu +16 Haven Leader + 400 mutagens,"The apostate is a Hiereus—an Anu warrior-priest—who passed the Water of Life ritual less than a week ago.
 
 Unlike most observed cases, the mutations have spread rapidly across nearly his entire body. The subject is barely coherent when the examination begins, and further neural deterioration becomes evident even before it concludes.
@@ -105,7 +105,7 @@ Unlike most observed cases, the mutations have spread rapidly across nearly his 
 Aggression escalates alongside the breakdown.",,,,,,,,
 TFTV_INCIDENT_6_OUTCOME_0_FAIL,Text,,"The discussion falters.
 
-Huxley grows defensive, sensing that Phoenix’s involvement makes his compromise too visible. Word spreads quickly that he is yielding under pressure.
+Huxley grows defensive, sensing that [OperativeName]’s involvement makes his compromise too visible. Word spreads quickly that he is yielding under pressure.
 
 His followers begin to question his resolve, while Anu officials interpret the hesitation as defiance.",,,,,,,,
 TFTV_INCIDENT_6_OUTCOME_1_FAIL,Text,,"The examination is disrupted when the subject becomes violently unstable.
@@ -186,7 +186,7 @@ The suspect responds politely but minimally, repeating herself until the questio
 
 Attempts to provoke stress responses fail.
 
-The Anu observers interpret Phoenix’s inability to extract a confession as confirmation of guilt.",,,,,,,,
+The Anu observers interpret [OperativeName]’s inability to extract a confession as confirmation of guilt.",,,,,,,,
 TFTV_INCIDENT_9_TITLE_AN,Text,Requirements: Anu haven near liberated infested Synedrion haven ,Those Who Remain,,,,,,,,
 TFTV_INCIDENT_9_DESC,Text,,"Hundreds of refugees from the Synedrion haven of [RequirementHavenName], recently lost to Pandoran infestation, have been living at the Anu haven of [HavenName].
 
@@ -212,7 +212,7 @@ TFTV_INCIDENT_9_OUTCOME_0_FAIL,Text,,"Conversations remain superficial.
 
 Complaints about conditions drown out subtler patterns.
 
-Phoenix withdraws with the impression that tensions are mounting—though no clear source can be identified.",,,,,,,,
+[OperativeName] withdraws with the impression that tensions are mounting—though no clear source can be identified.",,,,,,,,
 TFTV_INCIDENT_9_OUTCOME_1_FAIL,Text,,"It all looks like chaos and neglect; if there is some pattern or direction, it remains hidden from us.",,,,,,,,
 TFTV_INCIDENT_10_TITLE_AN,Text,,Voices in the Engine,,,,,,,,
 TFTV_INCIDENT_10_DESC,Text,,"Maintenance personnel at the power plant of [HavenName] report seeing shapes in the shadows and hearing voices where none should be.
@@ -236,7 +236,7 @@ TFTV_INCIDENT_10_OUTCOME_1_SUCCESS,Text,"Reward: Anu +4, Haven leader +8, Resear
 
 Yet the ritualized way she maintains the plant—fixed routes, repeated gestures, and areas avoided without explicit explanation—reveals an unspoken structure.
 
-Following these patterns leads Phoenix operatives to sections of the facility that are rarely inspected.
+Following these patterns leads [OperativeName] to sections of the facility that are rarely inspected.
 
 In these neglected spaces, an unfamiliar organic presence is discovered, clinging to conduits and shielding.",,,,,,,,
 TFTV_INCIDENT_10_OUTCOME_0_FAIL,Text,,"The investigation yields little more than shadows and noise.
@@ -264,7 +264,7 @@ TFTV_INCIDENT_11_CHOICE_0_M,Text,,"Monitor outgoing communications from the have
 TFTV_INCIDENT_11_CHOICE_1_E_O,Text,,"Explore the slums and speak with the locals under pretext of religious interest. 
 (Exploration / Occult)",,,,,,,,
 TFTV_INCIDENT_11_CHOICE_2,Text,,We are not Synedrion's hounds [END],,,,,,,,
-TFTV_INCIDENT_11_OUTCOME_0_SUCCESS,Text,"Reward: + 5 Syn, 100 tech","Traffic analysis reveals an unusual pattern: brief, irregular data bursts routed through public access relays. Most of the traffic is trivial—provocations, mockery, deliberately irritating intrusions into Synedrion networks. Tracking the source of the trolling leads Phoenix to a single terminal and its operator.
+TFTV_INCIDENT_11_OUTCOME_0_SUCCESS,Text,"Reward: + 5 Syn, 100 tech","Traffic analysis reveals an unusual pattern: brief, irregular data bursts routed through public access relays. Most of the traffic is trivial—provocations, mockery, deliberately irritating intrusions into Synedrion networks. Tracking the source of the trolling leads [OperativeName] to a single terminal and its operator.
 
 The man appears amused rather than alarmed. “I know what you’re looking for,” he says.
 
@@ -275,7 +275,7 @@ TFTV_INCIDENT_11_OUTCOME_1_SUCCESS,Text,"Reward: + 5 Syn, 100 tech","The trail l
 
 Among chemical diversions and virtual indulgences, illicit data work is common enough to attract little attention.
 
-One individual greets Phoenix without surprise.
+One individual greets [OperativeName] without surprise.
 
 “I heard you coming,” he says. “So I took care of it.”
 
@@ -293,7 +293,7 @@ TFTV_INCIDENT_11_OUTCOME_1_FAIL,Text,,"Conversations go nowhere.
 
 Some locals pretend ignorance. Others offer misleading directions for a price.
 
-The slums absorb Phoenix’s attention without yielding results.
+The slums absorb [OperativeName]’s attention without yielding results.
 
 By the time a credible lead emerges, the opportunity has passed.",,,,,,,,
 TFTV_INCIDENT_12_TITLE_AN,Text,Requirements: haven surived attack,First to Burn,,,,,,,,

--- a/TFTV/Assets/Localization/TFTV_Incidents_NJ_Localization.csv
+++ b/TFTV/Assets/Localization/TFTV_Incidents_NJ_Localization.csv
@@ -1,22 +1,22 @@
-Key,Type,Desc,English
+﻿Key,Type,Desc,English
 TFTV_INCIDENT_15_TITLE_NJ,Text,Req: Haven leader rep > 50,The Walls Beneath
 TFTV_INCIDENT_15_DESC,Text,,"Director, we’ve received a request from [HavenName] security overseer—off the record. Personnel have reported noises beneath the oldest wing of the base: scratching, faint voices, and rhythmic banging. A schematic review revealed sublevels sealed during the haven’s early construction, likely predating New Jericho occupation. Officially, no one’s been down there in years. Unofficially… some believe something never left."
 TFTV_INCIDENT_15_CHOICE_0_E,Text,,Investigate the sealed sublevels. (Exploration)
 TFTV_INCIDENT_15_CHOICE_1_C_M,Text,,Conduct seismic and acoustic scans. (Machinery/Compute)
 TFTV_INCIDENT_15_CHOICE_2,Text,,Decline involvement. [END]
-TFTV_INCIDENT_15_OUTCOME_0_SUCCESS,Text,"Reward: Haven leader rep +12, 600 mat","We breached an old hatch and descended into forgotten corridors. The walls were marked with crude symbols—hand-drawn, ritualistic. At the end: a chamber with bones, candles, and remnants of military rations. The bodies had mutations, poorly hidden. Former New Jericho personnel, altered in secret—and left to rot."
+TFTV_INCIDENT_15_OUTCOME_0_SUCCESS,Text,"Reward: Haven leader rep +12, 600 mat","[OperativeName] breached an old hatch and descended into forgotten corridors. The walls were marked with crude symbols—hand-drawn, ritualistic. At the end: a chamber with bones, candles, and remnants of military rations. The bodies had mutations, poorly hidden. Former New Jericho personnel, altered in secret—and left to rot."
 TFTV_INCIDENT_15_OUTCOME_1_SUCCESS,Text,"Reward: Haven leader rep +12, 600 mat","Acoustic scans picked up whisper-like patterns echoing through the sealed concrete—non-random, possibly language. One section shows signs of recent disturbance. Analysis suggests human activity within the last six months. West’s files make no mention of this level."
-TFTV_INCIDENT_15_OUTCOME_0_FAIL,Text,,"We reached the second sublevel before encountering unstable structure and collapsed halls. Still, the walls bore scratched symbols: half-military, half-religious. Something was worshipped down here."
-TFTV_INCIDENT_15_OUTCOME_1_FAIL,Text,,"Scans were inconclusive, but irregular heat signatures suggest recent passage. The haven’s commander thanked us and quietly doubled the guard near the lower sectors."
+TFTV_INCIDENT_15_OUTCOME_0_FAIL,Text,,"[OperativeName] reached the second sublevel before encountering unstable structure and collapsed halls. Still, the walls bore scratched symbols: half-military, half-religious. Something was worshipped down here."
+TFTV_INCIDENT_15_OUTCOME_1_FAIL,Text,,"Scans were inconclusive, but irregular heat signatures suggest recent passage. The haven’s commander thanked [OperativeName] and quietly doubled the guard near the lower sectors."
 TFTV_INCIDENT_16_TITLE_NJ,Text,Req: Melquiades first quest compeleted,Unwelcome Goods
 TFTV_INCIDENT_16_DESC,Text,,"Director, we’ve run into an old acquaintance—Staban Melquíades, the Anu-affiliated dealer in relics and curios. He’s attempting to set up a 'trade delegation' in [HavenName], offering rare tech, food concentrates, and something he calls ‘psionic insulation garments.’ The local authorities have rejected his permit outright, citing 'bio-contamination risk' and 'ideological infiltration.' Melquíades insists this is a simple business venture."
 TFTV_INCIDENT_16_CHOICE_0_P,Text,,Intervene on Melquíades’s behalf. (Psycho-Sociology)
 TFTV_INCIDENT_16_CHOICE_1_C_M,Text,,Discreetly inspect the goods he’s offering. (Compute/Machinery)
 TFTV_INCIDENT_16_CHOICE_2,Text,,Stay out of it—this is between him and New Jericho. [END]
-TFTV_INCIDENT_16_OUTCOME_0_SUCCESS,Text,"Reward: +300 Mats, +300 Food",We negotiated a narrow compromise—Melquíades was allowed to sell non-biological goods outside the security perimeter. He swore this was only the beginning of ‘a glorious cross-cultural bazaar.’ The garrison commander muttered something about posting snipers trained on the booth.
+TFTV_INCIDENT_16_OUTCOME_0_SUCCESS,Text,"Reward: +300 Mats, +300 Food",[OperativeName] negotiated a narrow compromise—Melquíades was allowed to sell non-biological goods outside the security perimeter. He swore this was only the beginning of ‘a glorious cross-cultural bazaar.’ The garrison commander muttered something about posting snipers trained on the booth.
 TFTV_INCIDENT_16_OUTCOME_1_SUCCESS,Text,"Reward: +100 Tech, +200 Research","His tech was surprisingly clean. Some gear may even predate the fall—old military sensor rigs, energy converters, rare materials. But one crate contained psionic-dampening cloth woven with organic filaments of unknown origin. Possibly Anu-grown. Melquíades claimed they were ‘ethically cultivated in living silence.’"
 TFTV_INCIDENT_16_OUTCOME_0_FAIL,Text,,"The talks broke down quickly. Melquíades gave a passionate speech about ‘commerce as the path to communion,’ which only deepened suspicion. He was politely escorted to the outer wall and warned never to return."
-TFTV_INCIDENT_16_OUTCOME_1_FAIL,Text,,"Most of the goods were junk or harmless scrap—but one box was sealed tight, marked with Anu script and reeking of chemical preservative. Melquíades refused to open it, citing ‘religious stipulations.’ We advised him to leave."
+TFTV_INCIDENT_16_OUTCOME_1_FAIL,Text,,"Most of the goods were junk or harmless scrap—but one box was sealed tight, marked with Anu script and reeking of chemical preservative. Melquíades refused to open it, citing ‘religious stipulations.’ [OperativeName] advised him to leave."
 TFTV_INCIDENT_17_TITLE_NJ,Text,"Requirement: 
 have an operative with NJ background",Shadow of the Atom
 TFTV_INCIDENT_17_DESC,Text,,"Director, we went to [HavenName] on a tip from [RequirementOperativeName], a former New Jericho soldier. We arrived just as a black-ops unit returned from an undisclosed expedition. Several soldiers show clear signs of radiation exposure. One was stretchered and unconscious, another refused medical scans. The commanding officer insists it was a routine salvage mission, but the men are shaken. A junior logistics officer quietly reached out to us, claiming ‘something they brought back shouldn’t exist.’"
@@ -24,9 +24,9 @@ TFTV_INCIDENT_17_CHOICE_0_P,Text,,Speak with the injured operatives off the reco
 TFTV_INCIDENT_17_CHOICE_1_C_M,Text,,Investigate the cargo brought in from the mission. (Compute/Machinery)
 TFTV_INCIDENT_17_CHOICE_2,Text,,Step back—this is New Jericho’s business. [END]
 TFTV_INCIDENT_17_OUTCOME_0_SUCCESS,Text,Reward: Extra personnel,"One of the wounded soldiers broke down. They were sent to recover something from a subterranean storage vault—sealed since before the Collapse. Inside: an intact tactical nuclear device, guarded by automated defenses. One of the squad cracked under pressure and may have opened the casing."
-TFTV_INCIDENT_17_OUTCOME_1_SUCCESS,Text,Reward: 250 Tech,"Buried beneath crates of salvaged electronics and rations, we found lead-lined shielding and an incomplete warhead assembly—its core removed. Containment protocols were improvised and unstable. The local commander told us to forget what we saw."
-TFTV_INCIDENT_17_OUTCOME_0_FAIL,Text,,"The soldiers were evasive, but their trauma was obvious. We couldn’t confirm what they found, but the fear was real."
-TFTV_INCIDENT_17_OUTCOME_1_FAIL,Text,,"We weren’t permitted full access, but radiation traces on the outer containers were well above safe thresholds. Someone tried to clean the logs—half the shipping records are missing. Something dangerous is being hidden."
+TFTV_INCIDENT_17_OUTCOME_1_SUCCESS,Text,Reward: 250 Tech,"Buried beneath crates of salvaged electronics and rations, [OperativeName] found lead-lined shielding and an incomplete warhead assembly—its core removed. Containment protocols were improvised and unstable. The local commander told us to forget what we saw."
+TFTV_INCIDENT_17_OUTCOME_0_FAIL,Text,,"The soldiers were evasive, but their trauma was obvious. [OperativeName] couldn’t confirm what they found, but the fear was real."
+TFTV_INCIDENT_17_OUTCOME_1_FAIL,Text,,"[OperativeName] wasn’t permitted full access, but radiation traces on the outer containers were well above safe thresholds. Someone tried to clean the logs—half the shipping records are missing. Something dangerous is being hidden."
 TFTV_INCIDENT_18_TITLE_NJ,Text,Req: Training Facility,Friendly Fire
 TFTV_INCIDENT_18_DESC,Text,,"A training facility at the New Jericho haven [HavenName] reports a serious incident: a recruit opened fire during a live-fire exercise, killing three of his squadmates.
 The suspect was subdued and detained, but his statements are incoherent. Local command suspects the use of mind-influence technology, possibly of Anu or Synedrion origin."
@@ -34,7 +34,7 @@ TFTV_INCIDENT_18_CHOICE_0_B,Text,,Interrogate and examine the suspect. (Biotech)
 TFTV_INCIDENT_18_CHOICE_1_C_M,Text,,Access and analyze the facility’s security logs. (Compute/Machinery)
 TFTV_INCIDENT_18_CHOICE_2,Text,,Risking our relations with the factions is just not worth it. [END] 
 TFTV_INCIDENT_18_OUTCOME_0_SUCCESS,Text,"Reward: NJ +4, Haven Leader + 8, Materials +400","At first, the trainee insists he was “possessed”—that a foreign voice guided his hand. Under sustained questioning, the narrative collapses. He breaks down, confessing that his victims had been hazing him for weeks."
-TFTV_INCIDENT_18_OUTCOME_1_SUCCESS,Text,"Reward: NJ +4, Haven Leader + 8, Materials +400","The Phoenix team discreetly hacks the haven’s archives, recovering several weeks of footage.
+TFTV_INCIDENT_18_OUTCOME_1_SUCCESS,Text,"Reward: NJ +4, Haven Leader + 8, Materials +400","[OperativeName] discreetly hacks the haven’s archives, recovering several weeks of footage.
 The pattern is clear: the victims repeatedly followed the suspect into maintenance corridors and supply depots—blind spots without cameras.
 The night before the shooting, audio logs capture muffled confrontations and laughter. "
 TFTV_INCIDENT_18_OUTCOME_0_FAIL,Text,,"The interrogation proceeds aggressively. The subject becomes unresponsive, then catatonic.
@@ -57,7 +57,7 @@ Fragments of metadata survive—enough to identify two of them as known petty cr
 Whether they were working for or against the ISB when the alleged plot was discovered remains unclear."
 TFTV_INCIDENT_19_OUTCOME_0_FAIL,Text,,"Attempts to gauge local sentiment meet with silence.
 Citizens are wary, unwilling to speak. The ISB monitors public channels closely, and even the haven’s guards seem uncertain whom they serve.
-The Phoenix team withdraws without clear findings, leaving behind an uneasy balance of fear and rumor."
+[OperativeName] withdraws without clear findings, leaving behind an uneasy balance of fear and rumor."
 TFTV_INCIDENT_19_OUTCOME_1_FAIL,Text,,"Most of the archive is encrypted with rotating security keys. Attempts to access the logs trigger a system lockdown, and the ISB chief personally intervenes to terminate the inspection.
 Later, official statements declare that the Phoenix Project “confirmed the legitimacy of the investigation.”"
 TFTV_INCIDENT_20_TITLE_NJ,Text,"Req: Haven leader rep >50, 
@@ -69,16 +69,16 @@ TFTV_INCIDENT_20_CHOICE_1_E_P,Text,,Investigate how the artifacts came into the 
 TFTV_INCIDENT_20_CHOICE_2,Text,,This is none of our business. [END]
 TFTV_INCIDENT_20_OUTCOME_0_SUCCESS,Text,Reward: 150 Orichalcum,"The artifacts are undeniably ancient—older than any known human civilization.
 Their composition suggests deliberate manufacture, yet isotope dating places their origin long before Homo sapiens.
-Recognizing the potential ramifications, the operatives quietly inform the haven leader that the objects are merely ossified remains of a long-dead Pandoran organism and should be disposed of safely.
+Recognizing the potential ramifications, [OperativeName] quietly informs the haven leader that the objects are merely ossified remains of a long-dead Pandoran organism and should be disposed of safely.
 The leader accepts the report without question, grateful for Phoenix’s “swift containment.”"
 TFTV_INCIDENT_20_OUTCOME_1_SUCCESS,Text,Reward: 250 Orichalcum,"Discreet questioning and record tracing reveal that the artifacts were gifts from a group of refugees recently granted haven residence.
-Tracking them down, the operatives learn that one man claims descent from a member of the 1937 Antarctic expedition aboard the MV Pontus.
+Tracking them down, [OperativeName] learns that one man claims descent from a member of the 1937 Antarctic expedition aboard the MV Pontus.
 He explains that the relics have been passed through his family for generations—kept hidden for fear of attracting attention.
 To protect the refugees, Phoenix certifies that the artifacts are uncontaminated.
 In gratitude, the old man quietly offers the operatives a more valuable piece from his great-great-grandfather’s collection."
 TFTV_INCIDENT_20_OUTCOME_0_FAIL,Text,,"The examination yields inconclusive results. Unknown organic residues trigger minor contamination alarms, forcing an emergency sterilization of the lab.
-The commander, alarmed by the incident, orders the entire collection destroyed and files a complaint about Phoenix’s “reckless procedures.”"
-TFTV_INCIDENT_20_OUTCOME_1_FAIL,Text,,"The inquiry draws unwanted attention. The haven’s security apparatus interprets Phoenix’s questions as political probing and cuts access to local records.
+The commander, alarmed by the incident, orders the entire collection destroyed and files a complaint about [OperativeName]’s “reckless procedures.”"
+TFTV_INCIDENT_20_OUTCOME_1_FAIL,Text,,"The inquiry draws unwanted attention. The haven’s security apparatus interprets [OperativeName]’s questions as political probing and cuts access to local records.
 The refugees vanish overnight, leaving only empty dormitories and a sense that the truth—whatever it was—has slipped once again beneath the ice."
 TFTV_INCIDENT_21_TITLE_NJ,Text,Req: Production Facility district,The Malfunctioning Factory
 TFTV_INCIDENT_21_DESC,Text,,"A major industrial complex in [HavenName] has reported a growing number of accidents and equipment failures, causing significant delays in production quotas.
@@ -86,13 +86,13 @@ The haven’s leader, under pressure from higher command, has requested assistan
 TFTV_INCIDENT_21_CHOICE_0_M,Text,,Inspect the machinery and production systems. (Machinery)
 TFTV_INCIDENT_21_CHOICE_1_B_P,Text,,Interview the workers and examine their condition. (Biotech / Psycho-Sociology)
 TFTV_INCIDENT_21_CHOICE_2,Text,,New Jericho should be able to handle this themselves. [END]
-TFTV_INCIDENT_21_OUTCOME_0_SUCCESS,Text,"Reward: +4 NJ, +8 Haven leader, +400 materials","The Phoenix team conducts a detailed inspection of the plant.
+TFTV_INCIDENT_21_OUTCOME_0_SUCCESS,Text,"Reward: +4 NJ, +8 Haven leader, +400 materials","[OperativeName] conducts a detailed inspection of the plant.
 While the control room is spotless and equipped with modern interfaces—the part of the facility the haven leader proudly tours—the factory floor tells a different story.
 Most of the machines are relics from the pre-Collapse era, hastily refitted and forced into production cycles they were never designed to sustain."
-TFTV_INCIDENT_21_OUTCOME_1_SUCCESS,Text,"Reward: +4 NJ, +8 Haven leader, +400 materials","The operatives find the workforce exhausted and malnourished. Shifts run sixteen hours or longer, with little rest between cycles.
+TFTV_INCIDENT_21_OUTCOME_1_SUCCESS,Text,"Reward: +4 NJ, +8 Haven leader, +400 materials","[OperativeName] finds the workforce exhausted and malnourished. Shifts run sixteen hours or longer, with little rest between cycles.
 Most workers express loyalty to New Jericho, but their eyes betray fear more than conviction."
 TFTV_INCIDENT_21_OUTCOME_0_FAIL,Text,,"The inspection is repeatedly interrupted by the haven’s overseers, citing safety protocols and “classified manufacturing processes.”
-The Phoenix team gathers little beyond surface impressions."
+[OperativeName] gathers little beyond surface impressions."
 TFTV_INCIDENT_21_OUTCOME_1_FAIL,Text,,"Attempts to speak with workers are quickly shut down by the plant’s foremen.
 Rumors spread that Phoenix agents are there to punish “inefficient citizens.”
 The workers become uncooperative."
@@ -106,10 +106,10 @@ TFTV_INCIDENT_22_CHOICE_2,Text,,They are more likely to hash out a deal without 
 TFTV_INCIDENT_22_OUTCOME_0_SUCCESS,Text,"Reward: +4 NJ, +8 Haven leader, +400 materials","Outwardly, the Synedrion delegates appear articulate, and cooperative.
 Yet once the discussion turns to specifics—tonnage, supply routes, or even basic definitions—they falter.
 It becomes clear they are reciting from a prepared script, improvising when lines run out."
-TFTV_INCIDENT_22_OUTCOME_1_SUCCESS,Text,"Reward: +4 NJ, +8 Haven leader, +400 materials","The Phoenix team intercepts some communications between Synedrion delegation and [RequirementHavenName].
+TFTV_INCIDENT_22_OUTCOME_1_SUCCESS,Text,"Reward: +4 NJ, +8 Haven leader, +400 materials","[OperativeName] intercepts some communications between Synedrion delegation and [RequirementHavenName].
 Turns out the delegates are not negotiating of their own accord; every instruction, every response, is generated and transmitted by an administrative AI."
 TFTV_INCIDENT_22_OUTCOME_0_FAIL,Text,,"Attempts to engage the delegates are repeatedly postponed by procedural “consultations.”
-When the Phoenix operatives finally meet them, the conversation remains superficial, and every question is deflected with smiling vagueness.
+When [OperativeName] finally meets them, the conversation remains superficial, and every question is deflected with smiling vagueness.
 By the end of the day, the talks have achieved nothing except more meetings on the schedule."
 TFTV_INCIDENT_22_OUTCOME_1_FAIL,Text,,"The hacking attempt triggers an alert in the Synedrion network.
 All external channels are locked, and the delegates suddenly become defensive, accusing Phoenix of espionage.
@@ -121,16 +121,16 @@ With the haven already on edge after the recent arrests of the Synedrion sympath
 TFTV_INCIDENT_23_CHOICE_0_C,Text,,Investigate the ISB chief and his recent activities. (Compute)
 TFTV_INCIDENT_23_CHOICE_1_O_P,Text,,Search for the real murderer among the haven’s personnel. (Occult / Psycho-Sociology)
 TFTV_INCIDENT_23_CHOICE_2,Text,,The Disciples might well be involved; better stay out of faction rivalry. [END]
-TFTV_INCIDENT_23_OUTCOME_0_SUCCESS,Text,Reward: additional personnel,"Phoenix operatives discreetly access the Bureau’s internal systems and personal records belonging to the ISB chief.
+TFTV_INCIDENT_23_OUTCOME_0_SUCCESS,Text,Reward: additional personnel,"[OperativeName] discreetly accesses the Bureau’s internal systems and personal records belonging to the ISB chief.
 The data shows a man consumed by bureaucracy and paranoia. He has been filing exhaustive loyalty reports on virtually every citizen, complaining incessantly about “civilian interference” and “administrative decay.”"
 TFTV_INCIDENT_23_OUTCOME_1_SUCCESS,Text,Reward: +4 NJ +8 Haven Leader + 400 Mats,"The last person seen near the Administrator’s quarters before the power outage was the communications officer.
 When confronted, her demeanor fractures. She insists she “didn’t do it,” speaking to someone not present in the room.
 As security moves in, she begins screaming, “He slouches! He slouches towards Bethlehem!” before collapsing in convulsions."
 TFTV_INCIDENT_23_OUTCOME_0_FAIL,Text,,"The Bureau’s archives are heavily encrypted and closely monitored.
-The attempt to access them triggers a counter-surveillance sweep. Within hours, Phoenix operatives are politely escorted out of the haven.
+The attempt to access them triggers a counter-surveillance sweep. Within hours, [OperativeName] is politely escorted out of the haven.
 The ISB releases a statement asserting that “foreign interference” has been detected and that the investigation is now closed."
 TFTV_INCIDENT_23_OUTCOME_1_FAIL,Text,,"The interviews lead nowhere. Witnesses contradict each other or simply refuse to talk.
-The murder weapon is never found, and the autopsy report is sealed before Phoenix can access it.
+The murder weapon is never found, and the autopsy report is sealed before [OperativeName] can access it.
 The ISB announces that “an Anu extremist cell has been neutralized,” but no names are released."
 TFTV_INCIDENT_24_TITLE_NJ,Text,Req: nearby destroyed haven,Reclaiming the Ruins
 TFTV_INCIDENT_24_DESC,Text,,"The New Jericho haven of [HavenName] is considering reclaiming a nearby destroyed haven.
@@ -257,7 +257,7 @@ TFTV_INCIDENT_27_OUTCOME_1_SUCCESS,Text,Reward: +4 NJ +8 Haven Leader + 400 Mats
 
 A ventilation duct cover in a restroom near the command offices is missing.
 
-Inside the duct, Phoenix operatives identify traces of dried organic residue.
+Inside the duct, [OperativeName] identifies traces of dried organic residue.
 
 The material is consistent with secretions commonly associated with Triton activity."
 TFTV_INCIDENT_27_OUTCOME_0_FAIL,Text,,"The data is incomplete.
@@ -324,7 +324,7 @@ They describe better food, cleaner quarters, and a special training program.
 Their tone is reverent, almost awed."
 TFTV_INCIDENT_29_OUTCOME_0_FAIL,Text,,"The files are sparse and poorly organized.
 
-Large portions of the warden’s correspondence appear to have been archived automatically, beyond Phoenix’s reach.
+Large portions of the warden’s correspondence appear to have been archived automatically, beyond [OperativeName]’s reach.
 
 What remains suggests routine compliance rather than initiative.
 

--- a/TFTV/Assets/Localization/TFTV_Incidents_SY_Localization.csv
+++ b/TFTV/Assets/Localization/TFTV_Incidents_SY_Localization.csv
@@ -1,12 +1,12 @@
-Key,Type,Desc,English
+﻿Key,Type,Desc,English
 TFTV_INCIDENT_30_TITLE_SY,Text,,The Hollow Ones
 TFTV_INCIDENT_30_DESC,Text,,"A scavenger named Childs Brimley, currently in custody, claims his team was infected—*mimicked*, he says—by a Pandoran organism. According to his report, the creature didn’t just copy their physiology but also their behavior and memories. One by one, his team turned… until he was the last. Synedrion researchers are at loss, and rumors are spreading throughout [HavenName]."
 TFTV_INCIDENT_30_CHOICE_0_B,Text,,Conduct an interview with Brimley. (Biotech)
 TFTV_INCIDENT_30_CHOICE_1_E_O,Text,,Investigate the scavenging site. (Exploration/Occult)
 TFTV_INCIDENT_30_CHOICE_2,Text,,Leave it to Synedrion. [END]
-TFTV_INCIDENT_30_OUTCOME_0_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech","Brimley gave us detailed accounts—too detailed, perhaps. He insists he saw versions of his crewmates speaking in perfect voices, with perfect memories, but *wrong eyes.* His story is unnervingly consistent. Still, the evidence suggests paranoia and cabin fever."
-TFTV_INCIDENT_30_OUTCOME_1_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech","We recovered logs and audio fragments. The descent into violence was slow, filled with mistrust and contradictions. One recording ends with a voice repeating a teammate’s words before they were spoken. The autopsies showed no major mutations, and the Pandoran involvement is unconfirmed."
-TFTV_INCIDENT_30_OUTCOME_0_FAIL,Text,,"The interview broke down quickly. He alternated between fear and laughter, begging us to ‘check behind their eyes.’"
+TFTV_INCIDENT_30_OUTCOME_0_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech","Brimley gave [OperativeName] detailed accounts—too detailed, perhaps. He insists he saw versions of his crewmates speaking in perfect voices, with perfect memories, but *wrong eyes.* His story is unnervingly consistent. Still, the evidence suggests paranoia and cabin fever."
+TFTV_INCIDENT_30_OUTCOME_1_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech","[OperativeName] recovered logs and audio fragments. The descent into violence was slow, filled with mistrust and contradictions. One recording ends with a voice repeating a teammate’s words before they were spoken. The autopsies showed no major mutations, and the Pandoran involvement is unconfirmed."
+TFTV_INCIDENT_30_OUTCOME_0_FAIL,Text,,"The interview broke down quickly. He alternated between fear and laughter, begging [OperativeName] to ‘check behind their eyes.’"
 TFTV_INCIDENT_30_OUTCOME_1_FAIL,Text,,"No biological evidence found. Just blood, old gear, and scratched walls. One message had been carved over and over into a bulkhead: ‘It wasn’t her.’"
 TFTV_INCIDENT_31_TITLE_SY,Text,"Req: Anu >49, Syn >49",Foundations in Ash
 TFTV_INCIDENT_31_DESC,Text,,"Director, we’ve been discreetly approached by Disciples of Anu diplomatic envoy from [HavenName]. There’s a dilapidated house on the outskirts that, according to Anu oral history, was once a sanctuary—where the Exalted briefly hid from the authorities during the First Mist outbreak. Synedrion has restricted access to it, citing unsafe conditions."
@@ -15,12 +15,12 @@ TFTV_INCIDENT_31_CHOICE_1_C_E,Text,,Look for and retrieve any electronic devices
 TFTV_INCIDENT_31_CHOICE_2,Text,,Decline the request. [END]
 TFTV_INCIDENT_31_OUTCOME_0_SUCCESS,Text,"AN to SYN +5
 SYN to AN +5
-200 food, 40 tech","In a concealed compartment beneath the floorboards, we found a pen drive—miraculously intact. It contains articles from <i>Human Horizon</i>, a sensationalist prewar outlet, and unauthored texts critiquing early 21st-century transhumanist ideologies. There’s no proof this was the Exalted’s hideout—but someone here was deeply skeptical of forced evolution."
+200 food, 40 tech","In a concealed compartment beneath the floorboards, [OperativeName] found a pen drive—miraculously intact. It contains articles from <i>Human Horizon</i>, a sensationalist prewar outlet, and unauthored texts critiquing early 21st-century transhumanist ideologies. There’s no proof this was the Exalted’s hideout—but someone here was deeply skeptical of forced evolution."
 TFTV_INCIDENT_31_OUTCOME_1_SUCCESS,Text,"AN to SYN +5
 SYN to AN +5
-200 food, 40 tech","We recovered a single data device containing cached material—opinion pieces from the early mist years, warnings against radical bio-modification movements, and vague references to academic conferences."
-TFTV_INCIDENT_31_OUTCOME_0_FAIL,Text,,"We uncovered old furniture, some unreadable printouts, and a scorched personal journal—mostly illegible. One line stood out: “Can’t stop a tsunami. Drown or evolve.’"
-TFTV_INCIDENT_31_OUTCOME_1_FAIL,Text,,"Most of what we found was water-damaged or burned. One corrupted file listed banned journals, including several fringe scientific publications. It seems whoever lived here questioned everything—including Anu doctrine."
+200 food, 40 tech","[OperativeName] recovered a single data device containing cached material—opinion pieces from the early mist years, warnings against radical bio-modification movements, and vague references to academic conferences."
+TFTV_INCIDENT_31_OUTCOME_0_FAIL,Text,,"[OperativeName] uncovered old furniture, some unreadable printouts, and a scorched personal journal—mostly illegible. One line stood out: “Can’t stop a tsunami. Drown or evolve.’"
+TFTV_INCIDENT_31_OUTCOME_1_FAIL,Text,,"Most of what [OperativeName] found was water-damaged or burned. One corrupted file listed banned journals, including several fringe scientific publications. It seems whoever lived here questioned everything—including Anu doctrine."
 ,,,
 TFTV_INCIDENT_32_TITLE_SY,Text,,The Whole
 TFTV_INCIDENT_32_DESC,Text,,"Director, in the center of the local marketplace, there's a small attraction known as The Whole—a blind old woman, seated behind a screen. She's advertised as a living fusion of multiple people. No visible mutations. But she speaks in many voices—different accents, ages, tones—shifting between them mid-conversation. Synedrion officials consider it performance art. Locals aren’t so sure."
@@ -38,9 +38,9 @@ TFTV_INCIDENT_33_CHOICE_0_P,Text,,Interrogate all the witnesses. (Psycho-Sociolo
 TFTV_INCIDENT_33_CHOICE_1_C_E,Text,,Search the science center thorougly. (Compute/Exploration)
 TFTV_INCIDENT_33_CHOICE_2,Text,,We don't have time for detective work. [END]
 TFTV_INCIDENT_33_OUTCOME_0_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech","The Terraformers loathed Dr. Vallis. Only one of them - the one who joked about smoothing things over with some wine-, showed any restraint when casting aspersions towards the missing person. Under further questioning, he broke down and confessed to killing him. ""There was no other choice!"""
-TFTV_INCIDENT_33_OUTCOME_1_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech","A decorative wall in the science center’s acoustic wing concealed a narrow corridor. At the far end, we found a bricked-up alcove—polycrete still curing. Inside: Vallis’s body, arms crossed, seated upright. An old wine bottle lay beside him, label faded but partially legible: ‘Resonant Oak – Private Cask.’ A glass stood untouched. Scratched faintly into the wall: ‘He said we’d toast to understanding.’"
+TFTV_INCIDENT_33_OUTCOME_1_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech","A decorative wall in the science center’s acoustic wing concealed a narrow corridor. At the far end, [OperativeName] found a bricked-up alcove—polycrete still curing. Inside: Vallis’s body, arms crossed, seated upright. An old wine bottle lay beside him, label faded but partially legible: ‘Resonant Oak – Private Cask.’ A glass stood untouched. Scratched faintly into the wall: ‘He said we’d toast to understanding.’"
 TFTV_INCIDENT_33_OUTCOME_0_FAIL,Text,,"A lot of Terraformers naturally disagreed with his views, but no one seems capable of harming him personally, whatever their ideological differences."
-TFTV_INCIDENT_33_OUTCOME_1_FAIL,Text,,"We discovered a forgotten chamber beneath the center—acoustic insulation peeling from the walls. The air smelled faintly of alcohol. An overturned glass, an empty bottle, and a trail of smeared footprints ended at a sealed maintenance hatch. No body. A ring of dust marked where someone once sat for a long time."
+TFTV_INCIDENT_33_OUTCOME_1_FAIL,Text,,"[OperativeName] discovered a forgotten chamber beneath the center—acoustic insulation peeling from the walls. The air smelled faintly of alcohol. An overturned glass, an empty bottle, and a trail of smeared footprints ended at a sealed maintenance hatch. No body. A ring of dust marked where someone once sat for a long time."
 TFTV_INCIDENT_35_TITLE_SY,Text,,What the Earth Kept
 TFTV_INCIDENT_35_DESC,Text,,"Director, a Synedrion expedition returned to [HavenName] from a region where changes in terrain following the Second Mist —subsidence, erosion, and structural collapse—have exposed areas previously inaccessible to survey teams.
 
@@ -59,9 +59,9 @@ TFTV_INCIDENT_36_DESC,Text,,"Director, the [HavenName] administration council ha
 TFTV_INCIDENT_36_CHOICE_0_C_M,Text,,Analyze the AI core and voting protocols. (Compute/Machinery)
 TFTV_INCIDENT_36_CHOICE_1_P,Text,,Interview haven engineers and political coordinators. (Psycho-Sociology)
 TFTV_INCIDENT_36_CHOICE_2,Text,,Stay out of it—Synedrion will handle its own democracy. [END]
-TFTV_INCIDENT_36_OUTCOME_0_SUCCESS,Text,Reward: additional personnel,Our team uncovered a sealed protocol tagged ‘Crisis Override – Civic Continuity.’ It was part of the haven’s original design—meant to ensure governance during psychological or environmental destabilization. The conditions for activation had been quietly met weeks ago. Someone built this in… just in case.
+TFTV_INCIDENT_36_OUTCOME_0_SUCCESS,Text,Reward: additional personnel,[OperativeName] uncovered a sealed protocol tagged ‘Crisis Override – Civic Continuity.’ It was part of the haven’s original design—meant to ensure governance during psychological or environmental destabilization. The conditions for activation had been quietly met weeks ago. Someone built this in… just in case.
 TFTV_INCIDENT_36_OUTCOME_1_SUCCESS,Text,Reward: additional personnel,"An engineer admitted the haven was founded with contingency logic embedded into its civic AI—‘to preserve order if consensus failed.’ The override had never been used… until now. Officially, it doesn’t exist."
-TFTV_INCIDENT_36_OUTCOME_0_FAIL,Text,,"We couldn’t isolate the exact trigger, but traces of an internal protocol override remain. It wasn’t sabotage. It was planned—deep in the system. Likely a failsafe from the haven’s original architects."
+TFTV_INCIDENT_36_OUTCOME_0_FAIL,Text,,"[OperativeName] couldn’t isolate the exact trigger, but traces of an internal protocol override remain. It wasn’t sabotage. It was planned—deep in the system. Likely a failsafe from the haven’s original architects."
 TFTV_INCIDENT_36_OUTCOME_1_FAIL,Text,,"Most officials were defensive. One coordinator finally admitted, ‘This haven was built to survive, not to collapse under idealism. We all knew that line would be crossed eventually.’"
 TFTV_INCIDENT_37_TITLE_SY,Text,Req: Synedrion Recruit,Directive 11
 TFTV_INCIDENT_37_DESC,Text,,"Director, [RequirementOperativeName] was sent some data by a Synedrion friend. It's a series of task logs from the [HavenName] civic AI. The pattern is disturbing: individuals flagged as ‘sub-optimally aligned’ were repeatedly assigned high-risk tasks—scavenging in mist zones, deep structural repairs, unshielded reclamation work. Officially, these were random civic assignments. Unofficially, most of those individuals are dead."
@@ -70,35 +70,35 @@ TFTV_INCIDENT_37_CHOICE_1_P_B,Text,,Quietly interview relatives of the deceased 
 TFTV_INCIDENT_37_CHOICE_2,Text,,Leave it alone—Synedrion internal affairs. [END]
 TFTV_INCIDENT_37_OUTCOME_0_SUCCESS,Text,Reward: additional personnel,The AI used a hidden behavioral compliance score. Those below a certain threshold were gradually funneled into dangerous roles. All within policy. All automated. The haven council may not even know.
 TFTV_INCIDENT_37_OUTCOME_1_SUCCESS,Text,Reward: additional personnel,"Relatives spoke carefully. Many suspected something was wrong. ‘He asked one too many questions about food allocation. Next day, he was sent to reinforce the southern shield.’ The pattern is undeniable."
-TFTV_INCIDENT_37_OUTCOME_0_FAIL,Text,,We found fragmented code—referencing something called Directive 11. The rest is encrypted. It’s clear someone programmed the system to make people disappear… slowly.
+TFTV_INCIDENT_37_OUTCOME_0_FAIL,Text,,[OperativeName] found fragmented code—referencing something called Directive 11. The rest is encrypted. It’s clear someone programmed the system to make people disappear… slowly.
 TFTV_INCIDENT_37_OUTCOME_1_FAIL,Text,,Few were willing to talk. One engineer simply said: ‘You don’t get assigned dangerous work for being difficult. But it sure helps.’ Fear runs deep here—under all the perfect glass and clean light.
 TFTV_INCIDENT_38_TITLE_SY,Text,,Blindspot
 TFTV_INCIDENT_38_DESC,Text,,"Director, a Synedrion security officer discreetly reached out. She believes the [HavenName] defenses are unprepared for a Pandoran breach—but every time she files a threat escalation, the AI downgrades the risk level. Patrols are reduced, supply caches reassigned. She suspects the system is deliberately underreporting threats."
 TFTV_INCIDENT_38_CHOICE_0_C,Text,,Analyze the AI’s security response protocols. (Compute)
 TFTV_INCIDENT_38_CHOICE_1_E_M,Text,,Investigate possible external tampering. (Exploration/Machinery)
 TFTV_INCIDENT_38_CHOICE_2,Text,,Avoid interfering in Synedrion operations. [END]
-TFTV_INCIDENT_38_OUTCOME_0_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech",We traced the issue to a hardcoded priority matrix: the AI was designed to deprioritize 'fear-inducing data' to avoid panic. All security reports were being rewritten for tone and perceived psychological impact. The danger wasn’t being ignored—just… softened. Critically.
-TFTV_INCIDENT_38_OUTCOME_1_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech",We found traces of a breach. A small eco-extremist faction—believing fear of the Pandorans would be used to justify militarism—subtly rewrote the threat response code. The AI now prioritizes civil calm over survival. The council may never have noticed.
+TFTV_INCIDENT_38_OUTCOME_0_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech",[OperativeName] traced the issue to a hardcoded priority matrix: the AI was designed to deprioritize 'fear-inducing data' to avoid panic. All security reports were being rewritten for tone and perceived psychological impact. The danger wasn’t being ignored—just… softened. Critically.
+TFTV_INCIDENT_38_OUTCOME_1_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech",[OperativeName] found traces of a breach. A small eco-extremist faction—believing fear of the Pandorans would be used to justify militarism—subtly rewrote the threat response code. The AI now prioritizes civil calm over survival. The council may never have noticed.
 TFTV_INCIDENT_38_OUTCOME_0_FAIL,Text,,"Threat reports were routed through a cognitive dampening subroutine—officially to reduce false positives, but in practice, it downplayed critical data. It's unclear if this was design… or drift."
-TFTV_INCIDENT_38_OUTCOME_1_FAIL,Text,,"No obvious breach, but we uncovered old subroutines modified weeks ago by an unregistered user. The edits shifted risk language from 'critical' to 'manageable.' Whether it's sabotage or ideology remains unclear."
+TFTV_INCIDENT_38_OUTCOME_1_FAIL,Text,,"No obvious breach, but [OperativeName] uncovered old subroutines modified weeks ago by an unregistered user. The edits shifted risk language from 'critical' to 'manageable.' Whether it's sabotage or ideology remains unclear."
 TFTV_INCIDENT_39_TITLE_SY,Text,Req: haven has a Mist Repeller,The Sound of the Mist
 TFTV_INCIDENT_39_DESC,Text,,"Director, the mist repellent at [HavenName] has gone offline following a targeted explosion. Initial reports describe it as sabotage—minimal casualties, but the core emitter was damaged. The council is split: some want immediate repairs, others suspect it was an inside job. A few locals claim they heard music playing just before the blast."
 TFTV_INCIDENT_39_CHOICE_0_M,Text,,Help repair the Mist Repeller. (Machinery)
 TFTV_INCIDENT_39_CHOICE_1_C_E,Text,,Investigate the sabotage. (Compute/Exploration)
 TFTV_INCIDENT_39_CHOICE_2,Text,,Stay out of it. [END]
-TFTV_INCIDENT_39_OUTCOME_0_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech",Our engineers worked with Synedrion techs to bring the Repeller back online. Full function restored. One technician found a message etched into the chassis: ‘You cannot repel what you refuse to understand.’ Security has been tightened.
-TFTV_INCIDENT_39_OUTCOME_1_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech","We traced the attack to a small group of Polyphonic radicals calling themselves The Resonant Fold. They believe the Mist is not a threat, but a voice—the Repeller an act of spiritual violence. The bomber left behind a manifesto, comparing Mist Expulsion to ‘silencing the breath of Gaia.’ Three suspects have fled."
-TFTV_INCIDENT_39_OUTCOME_0_FAIL,Text,,"We stabilized the core, but full range is limited. Local security remains on edge. Someone left a strange recording in the emitter logs—chanting layered with melodic feedback. It’s marked Polyphonic Archive – Redacted."
-TFTV_INCIDENT_39_OUTCOME_1_FAIL,Text,,"We found fragments of a Polyphonic symbol near the emitter casing. A local council member admitted a ‘philosophical splinter’ had formed, but downplayed the danger. The Mist continues to creep in while the council debates how to respond."
+TFTV_INCIDENT_39_OUTCOME_0_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech",[OperativeName] worked with Synedrion techs to bring the Repeller back online. Full function restored. One technician found a message etched into the chassis: ‘You cannot repel what you refuse to understand.’ Security has been tightened.
+TFTV_INCIDENT_39_OUTCOME_1_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech","[OperativeName] traced the attack to a small group of Polyphonic radicals calling themselves The Resonant Fold. They believe the Mist is not a threat, but a voice—the Repeller an act of spiritual violence. The bomber left behind a manifesto, comparing Mist Expulsion to ‘silencing the breath of Gaia.’ Three suspects have fled."
+TFTV_INCIDENT_39_OUTCOME_0_FAIL,Text,,"[OperativeName] stabilized the core, but full range is limited. Local security remains on edge. Someone left a strange recording in the emitter logs—chanting layered with melodic feedback. It’s marked Polyphonic Archive – Redacted."
+TFTV_INCIDENT_39_OUTCOME_1_FAIL,Text,,"[OperativeName] found fragments of a Polyphonic symbol near the emitter casing. A local council member admitted a ‘philosophical splinter’ had formed, but downplayed the danger. The Mist continues to creep in while the council debates how to respond."
 TFTV_INCIDENT_40_TITLE_SY,Text,,The Voice Behind the Mask (Volonte Event 1)
 TFTV_INCIDENT_40_DESC,Text,,"Director, there’s unrest brewing. A woman named Kara Volonte, a pre-Collapse media personality turned New Jericho spokesperson, has arrived to [HavenName] under the guise of hosting a public discourse on ‘civil resilience.’ In practice, she’s been calling for strict limits on mutant participation in governance and research. The unsettling part? She’s articulate, charismatic, and gaining support. Synedrion’s council is paralyzed—torn between upholding free expression and preserving internal unity."
 TFTV_INCIDENT_40_CHOICE_0_B_P,Text,,Publicly challenge Kara Volonte’s rhetoric. (Biotech/Psycho-Sociology) 
 TFTV_INCIDENT_40_CHOICE_1_C,Text,,Investigate her affiliations and funding. (Compute) 
 TFTV_INCIDENT_40_CHOICE_2,Text,,Avoid involvement. Synedrion must decide. [END]
-TFTV_INCIDENT_40_OUTCOME_0_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech","Our operatives exposed contradictions in her message—quotes from her earlier broadcasts praising 'evolutionary courage' before she aligned with New Jericho. Public support wavered. She’s still speaking, but the crowd is thinner."
-TFTV_INCIDENT_40_OUTCOME_1_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech","We uncovered private transmissions between Kara and a New Jericho intelligence liaison—her campaign here was coordinated, seeded with talking points and subtle pressure. Synedrion authorities quietly asked her to leave, citing outside manipulation."
-TFTV_INCIDENT_40_OUTCOME_0_FAIL,Text,,"We raised counterarguments, but her charm deflected them easily. Her language is coded, careful. She accuses us of censorship. The council remains deadlocked."
-TFTV_INCIDENT_40_OUTCOME_1_FAIL,Text,,"We found traces of financial support routed through shell collectives tied to New Jericho. It’s enough to raise suspicion, but not expel her outright. She continues her campaign—framed now as ‘resistance to ideological oppression.’"
+TFTV_INCIDENT_40_OUTCOME_0_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech","[OperativeName] exposed contradictions in her message—quotes from her earlier broadcasts praising 'evolutionary courage' before she aligned with New Jericho. Public support wavered. She’s still speaking, but the crowd is thinner."
+TFTV_INCIDENT_40_OUTCOME_1_SUCCESS,Text,"Reward: +4 Syn, +8 haven leader, + 80 tech","[OperativeName] uncovered private transmissions between Kara and a New Jericho intelligence liaison—her campaign here was coordinated, seeded with talking points and subtle pressure. Synedrion authorities quietly asked her to leave, citing outside manipulation."
+TFTV_INCIDENT_40_OUTCOME_0_FAIL,Text,,"[OperativeName] raised counterarguments, but her charm deflected them easily. Her language is coded, careful. She accuses us of censorship. The council remains deadlocked."
+TFTV_INCIDENT_40_OUTCOME_1_FAIL,Text,,"[OperativeName] found traces of financial support routed through shell collectives tied to New Jericho. It’s enough to raise suspicion, but not expel her outright. She continues her campaign—framed now as ‘resistance to ideological oppression.’"
 TFTV_INCIDENT_41_TITLE_SY,Text,Polyphonic tendency > Terraformer tendency,The Garden
 TFTV_INCIDENT_41_DESC,Text,,"Synedrion representatives invite the Phoenix Project to examine a showcase they intend to present to the world. Within a sealed biodome at the haven of [HavenName], they have cultivated a garden of flora and fauna altered by the Pandoravirus.
 
@@ -166,7 +166,7 @@ Every attempt to probe deeper is deflected with prepared statements and ideologi
 
 Technical questions are redirected to subcommittees that never respond.
 
-The leader’s calm confidence leaves Phoenix with impressions—but no insight."
+The leader’s calm confidence leaves [OperativeName] with impressions—but no insight."
 TFTV_INCIDENT_43_TITLE_SY,Text,Requirement: nearby liberated Anu infested haven,Strangers Among Us
 TFTV_INCIDENT_43_DESC,Text,,"The inhabitants of [HavenName] are increasingly uneasy following the arrival of hundreds of refugees from the destroyed Anu haven of [RequirementHavenName].
 
@@ -203,7 +203,7 @@ Frustration grows on both sides, reinforcing the belief that the newcomers are i
 Several systems are taken offline after repeated misuse, worsening the atmosphere further."
 TFTV_INCIDENT_43_OUTCOME_1_FAIL,Text,,"The refugees are wary and defensive.
 
-Phoenix operatives are seen as representatives of Synedrion authority rather than neutral observers.
+[OperativeName] is seen as a representative of Synedrion authority rather than neutral observers.
 
 Conversations collapse into rehearsed slogans and quiet suspicion.
 

--- a/TFTV/TFTVIncidents/IncidentOutcomeSummaryUI.cs
+++ b/TFTV/TFTVIncidents/IncidentOutcomeSummaryUI.cs
@@ -1,4 +1,4 @@
-using Base.Core;
+﻿using Base.Core;
 using HarmonyLib;
 using PhoenixPoint.Geoscape.Entities;
 using PhoenixPoint.Geoscape.Events;
@@ -29,6 +29,10 @@ namespace TFTV.TFTVIncidents
         private static readonly Dictionary<string, int> LeaderByExactKey = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
         private static readonly Dictionary<string, int> LeaderBySiteKey = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
+        // Keyed without the event id, so [OperativeName] can find the leader from a
+        // GeoscapeEventContext alone (that context carries no event id of its own).
+        private static readonly Dictionary<string, int> LeaderBySiteVehicleKey = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
         internal static void RecordIncidentLeader(string completionEventId, int siteId, int vehicleId, int leaderId)
         {
             try
@@ -40,6 +44,7 @@ namespace TFTV.TFTVIncidents
 
                 LeaderByExactKey[BuildExactKey(completionEventId, siteId, vehicleId)] = leaderId;
                 LeaderBySiteKey[BuildSiteKey(completionEventId, siteId)] = leaderId;
+                LeaderBySiteVehicleKey[BuildSiteVehicleKey(siteId, vehicleId)] = leaderId;
             }
             catch (Exception e)
             {
@@ -51,6 +56,39 @@ namespace TFTV.TFTVIncidents
         {
             LeaderByExactKey.Clear();
             LeaderBySiteKey.Clear();
+            LeaderBySiteVehicleKey.Clear();
+        }
+
+        /// <summary>
+        /// Id of the operative who led the incident resolved at this site/vehicle, if one was recorded.
+        /// The event id is optional: outcome text is tokenised from a GeoscapeEventContext, which does
+        /// not expose the event it belongs to.
+        /// </summary>
+        internal static bool TryGetRecordedLeaderId(string eventId, int siteId, int vehicleId, out int leaderId)
+        {
+            leaderId = -1;
+
+            if (!string.IsNullOrEmpty(eventId))
+            {
+                if (vehicleId > 0 && LeaderByExactKey.TryGetValue(BuildExactKey(eventId, siteId, vehicleId), out leaderId))
+                {
+                    return leaderId > 0;
+                }
+
+                if (LeaderBySiteKey.TryGetValue(BuildSiteKey(eventId, siteId), out leaderId))
+                {
+                    return leaderId > 0;
+                }
+            }
+
+            if (siteId > 0 && vehicleId > 0
+                && LeaderBySiteVehicleKey.TryGetValue(BuildSiteVehicleKey(siteId, vehicleId), out leaderId))
+            {
+                return leaderId > 0;
+            }
+
+            leaderId = -1;
+            return false;
         }
 
         private static bool IsIncidentOutcomeEvent(string eventId)
@@ -714,6 +752,15 @@ namespace TFTV.TFTVIncidents
             return string.Join("|", new[]
             {
                 eventId ?? string.Empty,
+                siteId.ToString(CultureInfo.InvariantCulture),
+                vehicleId.ToString(CultureInfo.InvariantCulture)
+            });
+        }
+
+        private static string BuildSiteVehicleKey(int siteId, int vehicleId)
+        {
+            return string.Join("|", new[]
+            {
                 siteId.ToString(CultureInfo.InvariantCulture),
                 vehicleId.ToString(CultureInfo.InvariantCulture)
             });

--- a/TFTV/TFTVIncidents/Resolution.cs
+++ b/TFTV/TFTVIncidents/Resolution.cs
@@ -204,6 +204,37 @@ namespace TFTV.TFTVIncidents
                     && Definitions.Any(d => string.Equals(d.CompletionEventId, eventId, StringComparison.OrdinalIgnoreCase));
             }
 
+            /// <summary>
+            /// Leader of the incident still running at this site/vehicle, used by [OperativeName]
+            /// while the incident is in progress (before the outcome record exists).
+            /// </summary>
+            internal static bool TryGetActiveIncidentLeaderId(int siteId, int vehicleId, out int leaderId)
+            {
+                leaderId = -1;
+                if (siteId <= 0)
+                {
+                    return false;
+                }
+
+                foreach (ActiveTimedProblem active in ActiveByTimerId.Values)
+                {
+                    if (active == null || active.SiteId != siteId || active.LeaderId <= 0)
+                    {
+                        continue;
+                    }
+
+                    if (vehicleId > 0 && active.VehicleId > 0 && active.VehicleId != vehicleId)
+                    {
+                        continue;
+                    }
+
+                    leaderId = active.LeaderId;
+                    return true;
+                }
+
+                return false;
+            }
+
             internal static bool TryGetStoredMatchedNearbyHavenSiteId(string eventId, int siteId, int vehicleId, out int matchedNearbyHavenSiteId)
             {
                 matchedNearbyHavenSiteId = -1;

--- a/TFTV/TFTVIncidents/TextAdjustment.cs
+++ b/TFTV/TFTVIncidents/TextAdjustment.cs
@@ -31,7 +31,8 @@ namespace TFTV.TFTVIncidents
                 {
                     { "[RequirementOperativeName]", GetRequirementOperativeName },
                     { "[RequirementHavenName]", GetRequirementHavenName },
-                    { "[OperativeName]", GetOperativeName }
+                    { "[OperativeName]", GetOperativeName },
+                    { "[OperativeFullName]", GetOperativeFullName }
                 };
 
 
@@ -87,7 +88,10 @@ namespace TFTV.TFTVIncidents
                         return GetRequirementHavenName(context, eventIdOverride);
 
                     case "[OperativeName]":
-                        return GetOperativeName(context);
+                        return GetOperativeName(context, eventIdOverride);
+
+                    case "[OperativeFullName]":
+                        return GetOperativeFullName(context, eventIdOverride);
 
                     default:
                         return string.Empty;
@@ -251,19 +255,112 @@ namespace TFTV.TFTVIncidents
 
             private static string GetOperativeName(GeoscapeEventContext context)
             {
+                return GetOperativeName(context, null);
+            }
+
+            private static string GetOperativeFullName(GeoscapeEventContext context)
+            {
+                return GetOperativeFullName(context, null);
+            }
+
+            /// <summary>
+            /// The operative who led the incident, shortened to one half of their name when the full
+            /// name is too long to sit comfortably in prose. Use [OperativeFullName] where the whole
+            /// name is wanted.
+            /// </summary>
+            private static string GetOperativeName(GeoscapeEventContext context, string eventIdOverride)
+            {
+                return GetShortFormName(GetOperative(context, eventIdOverride));
+            }
+
+            private static string GetOperativeFullName(GeoscapeEventContext context, string eventIdOverride)
+            {
+                return GetCharacterName(GetOperative(context, eventIdOverride));
+            }
+
+            /// <summary>
+            /// The leader recorded when the outcome fired, or the leader of the incident still running
+            /// here. Falls back to the first Phoenix operative on site so the token never renders empty
+            /// outside incident text.
+            /// </summary>
+            private static GeoCharacter GetOperative(GeoscapeEventContext context, string eventIdOverride)
+            {
                 GeoSite site = GetContextSite(context);
                 GeoPhoenixFaction phoenixFaction = GetPhoenixFaction(context);
                 if (site == null || phoenixFaction == null)
                 {
-                    return string.Empty;
+                    return null;
                 }
 
-                GeoCharacter operative = site.Vehicles
+                GeoCharacter leader = GetIncidentLeader(context, site, eventIdOverride);
+                if (leader != null)
+                {
+                    return leader;
+                }
+
+                return site.Vehicles
                     ?.Where(v => v != null && v.Owner == phoenixFaction)
                     .SelectMany(v => v.GetAllCharacters())
                     .FirstOrDefault(IsHumanGeoCharacter);
+            }
 
-                return GetCharacterName(operative);
+            /// <summary>
+            /// Full names read stiff in flowing incident text ("Aleksandra Kowalski recovered logs and
+            /// audio fragments."). Past <see cref="FullNameLengthLimit"/> characters we drop to either
+            /// the forename or the surname.
+            ///
+            /// The half is picked from the operative's id rather than at random, so a soldier is always
+            /// called the same thing: within one screen, across the texts of one incident, and for the
+            /// rest of the campaign. A genuinely random pick would let the same person appear as
+            /// "Aleksandra" in one line and "Kowalski" in the next, or change on a panel redraw.
+            /// </summary>
+            // 10 rather than something longer: sampled rosters average ~13 characters, and a higher
+            // limit leaves a large minority of soldiers on their full name while the rest are
+            // shortened, so the prose reads inconsistently from one incident to the next.
+            private const int FullNameLengthLimit = 10;
+
+            private static string GetShortFormName(GeoCharacter character)
+            {
+                string fullName = GetCharacterName(character);
+                if (string.IsNullOrEmpty(fullName) || fullName.Length <= FullNameLengthLimit)
+                {
+                    return fullName;
+                }
+
+                string[] parts = fullName.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length < 2)
+                {
+                    return fullName;
+                }
+
+                return PrefersForename(character.Id) ? parts[0] : parts[parts.Length - 1];
+            }
+
+            private static bool PrefersForename(int characterId)
+            {
+                // Character ids are handed out in sequence, so mix them before taking a bit: a raw
+                // (id & 1) would alternate forename/surname down the roster.
+                unchecked
+                {
+                    uint mixed = (uint)characterId * 2654435761u;
+                    return ((mixed >> 13) & 1u) == 0u;
+                }
+            }
+
+            private static GeoCharacter GetIncidentLeader(GeoscapeEventContext context, GeoSite site, string eventIdOverride)
+            {
+                GeoVehicle vehicle = GetContextVehicle(context);
+                int siteId = site.SiteId;
+                int vehicleId = vehicle?.VehicleID ?? -1;
+                string eventId = GetEventId(context, eventIdOverride);
+
+                if (!IncidentOutcomeSummaryUI.TryGetRecordedLeaderId(eventId, siteId, vehicleId, out int leaderId)
+                    && !Resolution.IncidentController.TryGetActiveIncidentLeaderId(siteId, vehicleId, out leaderId))
+                {
+                    return null;
+                }
+
+                return LeaderSelection.ResolveLeader(GetGeoLevel(context), vehicle, leaderId);
             }
 
             private static GeoHaven GetFirstNearbyEligibleHaven(


### PR DESCRIPTION
[OperativeName] previously resolved to the first human aboard any Phoenix vehicle at the site, which is rarely the operative who actually led the incident. The lead is chosen by LeaderSelection (and can be overridden by the player in the resolution UI), so the token routinely named the wrong soldier. It was also used in only 4 of the 176 outcome rows.

Resolve the token to the real lead:

- IncidentOutcomeSummaryUI records the leader id under a site+vehicle key as well as the existing event-scoped keys, and exposes TryGetRecordedLeaderId. GeoscapeEventContext carries no event id of its own, so the token postfix cannot rely on one being available.
- Resolution exposes TryGetActiveIncidentLeaderId so the token also resolves while an incident is still running.
- TextAdjustment tries the recorded leader, then the active-incident leader, then falls back to the previous behaviour so the token never renders empty outside incident text.

Shorten long names. Identity.Name is the full "Firstname Lastname", which reads stiff in prose. Past 10 characters the token drops to either the forename or the surname, picked from the operative's id rather than at random: a random pick would let the same soldier appear as "Aleksandra" in one line and "Kowalski" in the next, or disagree with the recap panel's "Leading operative" line rendered beside it. Add [OperativeFullName] for the places the whole name is wanted.

Substitute the token for existing actor phrases ("we", "our operative", "the Phoenix team", "the operatives") in 69 outcome texts across the three incident localization files, naming the lead once per text and leaving later first-person references intact so the report voice survives. Institutional references to Phoenix (custody, archives, jurisdiction, estimates) and first-person plural inside NPC dialogue were left alone.