### PR TITLE
Shorten crew slot names and clear the portrait in the incident UI

### DIFF
--- a/TFTV/TFTVIncidents/AffinityBenefitChoiceUI.cs
+++ b/TFTV/TFTVIncidents/AffinityBenefitChoiceUI.cs
@@ -30,6 +30,9 @@ namespace TFTV.TFTVIncidents
         private const float PanelRightMargin = 100f;
         private const float PanelTopMargin = 170f;
 
+        // Clearance left between the bottom of the leader portrait and the top of the panel.
+        private const float PortraitClearanceGap = 16f;
+
         private struct BenefitTrack
         {
             internal BenefitTrack(string localizationKey, bool isGeoscape)
@@ -358,7 +361,7 @@ namespace TFTV.TFTVIncidents
             layoutElement.ignoreLayout = true;
 
             RectTransform rootRect = root.GetComponent<RectTransform>();
-            ConfigurePanelRect(rootRect);
+            ConfigurePanelRect(rootRect, module);
 
             Image background = root.GetComponent<Image>();
             background.raycastTarget = false;
@@ -590,7 +593,7 @@ namespace TFTV.TFTVIncidents
 
         }
 
-        private static void ConfigurePanelRect(RectTransform rootRect)
+        private static void ConfigurePanelRect(RectTransform rootRect, UIModuleSiteEncounters module)
         {
             if (rootRect == null)
             {
@@ -602,8 +605,45 @@ namespace TFTV.TFTVIncidents
             rootRect.pivot = new Vector2(1f, 1f);
             rootRect.localScale = Vector3.one;
             rootRect.sizeDelta = new Vector2(PanelWidth, 0f);
-            rootRect.anchoredPosition = new Vector2(-PanelRightMargin, -PanelTopMargin);
+            rootRect.anchoredPosition = new Vector2(-PanelRightMargin, -ResolveTopMargin(rootRect, module));
+        }
 
+        /// <summary>
+        /// The panel is pinned to the top-right of the encounter module, which is also where the
+        /// leader portrait sits, so a fixed top margin lands on top of it. Measure the portrait and
+        /// drop the panel below it instead.
+        ///
+        /// The old fixed margin stays as a floor: if the portrait cannot be measured - not shown, or
+        /// laid out after this runs - the panel ends up exactly where it used to, never higher.
+        /// </summary>
+        private static float ResolveTopMargin(RectTransform rootRect, UIModuleSiteEncounters module)
+        {
+            try
+            {
+                RectTransform parentRect = rootRect.parent as RectTransform;
+                RectTransform portrait = module?.EncounterLeaderImage?.rectTransform;
+
+                if (parentRect == null || portrait == null || !portrait.gameObject.activeInHierarchy)
+                {
+                    TFTVLogger.Always($"{DiagTag} panel top margin: portrait unavailable, using fixed {PanelTopMargin}");
+                    return PanelTopMargin;
+                }
+
+                Vector3[] corners = new Vector3[4];
+                portrait.GetWorldCorners(corners);
+
+                // corners[0] is the bottom-left corner; measure how far it sits below the parent's top edge.
+                float portraitBottom = parentRect.InverseTransformPoint(corners[0]).y;
+                float derived = parentRect.rect.yMax - portraitBottom + PortraitClearanceGap;
+
+                TFTVLogger.Always($"{DiagTag} panel top margin: fixed={PanelTopMargin} portraitDerived={derived:0.#} using={Mathf.Max(PanelTopMargin, derived):0.#}");
+                return Mathf.Max(PanelTopMargin, derived);
+            }
+            catch (Exception e)
+            {
+                TFTVLogger.Error(e);
+                return PanelTopMargin;
+            }
         }
 
         private static void RemoveExistingPanel(Transform parent)

--- a/TFTV/TFTVIncidents/IncidentResolutionUI.cs
+++ b/TFTV/TFTVIncidents/IncidentResolutionUI.cs
@@ -469,6 +469,7 @@ namespace TFTV.TFTVIncidents
 
                     NormalizeRowRect(row.transform as RectTransform);
                     row.SetSoldierData((ICommonActor)character);
+                    ApplyShortNameToRow(row, character);
                     ResetRowSelectionVisualState(row);
 
                     Sprite abilityIcon = ResolveAbilityIcon(character);
@@ -1641,6 +1642,34 @@ namespace TFTV.TFTVIncidents
                 }
 
                 return null;
+            }
+
+            /// <summary>
+            /// SetSoldierData writes the full "Firstname Lastname" into the slot, which overflows the
+            /// crew boxes for longer names. Reuse the same shortening the incident texts use, so an
+            /// operative is called the same thing in the crew list and in the outcome prose.
+            /// </summary>
+            private static void ApplyShortNameToRow(SoldierSlotController row, GeoCharacter character)
+            {
+                try
+                {
+                    if (row?.NameLabel == null || character == null)
+                    {
+                        return;
+                    }
+
+                    string shortName = LeaderSelection.ShortenOperativeName(character.DisplayName, character.Id);
+                    if (string.IsNullOrEmpty(shortName))
+                    {
+                        return;
+                    }
+
+                    row.NameLabel.text = row.CapitalizedName ? shortName.ToUpper() : shortName;
+                }
+                catch (Exception e)
+                {
+                    TFTVLogger.Error(e);
+                }
             }
 
             private static void SetAffinityIconAfterName(SoldierSlotController row, Sprite icon)

--- a/TFTV/TFTVIncidents/LeaderSelection.cs
+++ b/TFTV/TFTVIncidents/LeaderSelection.cs
@@ -587,6 +587,48 @@ namespace TFTV.TFTVIncidents
             }
         }
 
+        /// <summary>
+        /// Operative names are full "Firstname Lastname" strings, which are too long for prose and
+        /// for the crew slots in the resolution UI. Past <see cref="FullNameLengthLimit"/> characters
+        /// we fall back to either the forename or the surname.
+        ///
+        /// The half is picked from the operative's id rather than at random, so a soldier is always
+        /// called the same thing: in the crew list, in the outcome text, and for the rest of the
+        /// campaign. A random pick would let the same person appear as "Aleksandra" in one place and
+        /// "Kowalski" in another, or change on a redraw.
+        /// </summary>
+        // 10 rather than something longer: sampled rosters average ~13 characters, and a higher
+        // limit leaves a large minority of soldiers on their full name while the rest are
+        // shortened, so the result reads inconsistently.
+        internal const int FullNameLengthLimit = 10;
+
+        internal static string ShortenOperativeName(string fullName, int characterId)
+        {
+            if (string.IsNullOrEmpty(fullName) || fullName.Length <= FullNameLengthLimit)
+            {
+                return fullName;
+            }
+
+            string[] parts = fullName.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length < 2)
+            {
+                return fullName;
+            }
+
+            return PrefersForename(characterId) ? parts[0] : parts[parts.Length - 1];
+        }
+
+        private static bool PrefersForename(int characterId)
+        {
+            // Character ids are handed out in sequence, so mix them before taking a bit: a raw
+            // (id & 1) would alternate forename/surname down the roster.
+            unchecked
+            {
+                uint mixed = (uint)characterId * 2654435761u;
+                return ((mixed >> 13) & 1u) == 0u;
+            }
+        }
+
         internal static GeoCharacter SelectFallbackLeader(GeoVehicle vehicle)
         {
             IEnumerable<GeoCharacter> characters = vehicle?.GetAllCharacters() ?? Enumerable.Empty<GeoCharacter>();

--- a/TFTV/TFTVIncidents/TextAdjustment.cs
+++ b/TFTV/TFTVIncidents/TextAdjustment.cs
@@ -304,47 +304,9 @@ namespace TFTV.TFTVIncidents
                     .FirstOrDefault(IsHumanGeoCharacter);
             }
 
-            /// <summary>
-            /// Full names read stiff in flowing incident text ("Aleksandra Kowalski recovered logs and
-            /// audio fragments."). Past <see cref="FullNameLengthLimit"/> characters we drop to either
-            /// the forename or the surname.
-            ///
-            /// The half is picked from the operative's id rather than at random, so a soldier is always
-            /// called the same thing: within one screen, across the texts of one incident, and for the
-            /// rest of the campaign. A genuinely random pick would let the same person appear as
-            /// "Aleksandra" in one line and "Kowalski" in the next, or change on a panel redraw.
-            /// </summary>
-            // 10 rather than something longer: sampled rosters average ~13 characters, and a higher
-            // limit leaves a large minority of soldiers on their full name while the rest are
-            // shortened, so the prose reads inconsistently from one incident to the next.
-            private const int FullNameLengthLimit = 10;
-
             private static string GetShortFormName(GeoCharacter character)
             {
-                string fullName = GetCharacterName(character);
-                if (string.IsNullOrEmpty(fullName) || fullName.Length <= FullNameLengthLimit)
-                {
-                    return fullName;
-                }
-
-                string[] parts = fullName.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-                if (parts.Length < 2)
-                {
-                    return fullName;
-                }
-
-                return PrefersForename(character.Id) ? parts[0] : parts[parts.Length - 1];
-            }
-
-            private static bool PrefersForename(int characterId)
-            {
-                // Character ids are handed out in sequence, so mix them before taking a bit: a raw
-                // (id & 1) would alternate forename/surname down the roster.
-                unchecked
-                {
-                    uint mixed = (uint)characterId * 2654435761u;
-                    return ((mixed >> 13) & 1u) == 0u;
-                }
+                return LeaderSelection.ShortenOperativeName(GetCharacterName(character), character?.Id ?? 0);
             }
 
             private static GeoCharacter GetIncidentLeader(GeoscapeEventContext context, GeoSite site, string eventIdOverride)


### PR DESCRIPTION
Two incident UI fixes.

Crew selection boxes showed the full "Firstname Lastname", which overflows the slot for longer names. Move the name shortening out of TextAdjustment into LeaderSelection.ShortenOperativeName so the token and the UI share one implementation, and apply it to each crew row after SetSoldierData writes the full name in. An operative is now called the same thing in the crew list and in the outcome prose.

The affinity benefit panel was pinned to the encounter module's top-right with a fixed 170px top margin, which is the corner the leader portrait occupies, so it covered the portrait. Measure EncounterLeaderImage's bottom edge in the parent's local space and drop the panel below it with a small gap, keeping the fixed margin as a floor via Mathf.Max: if the portrait cannot be measured - not shown, or laid out after this runs - the panel lands exactly where it did before and never higher. Logs the measurement under the existing diag tag, since the fallback is otherwise silent.