### PR TITLE
Six gameplay and geoscape UI fixes

### DIFF
--- a/Dist/Assets/Localization/TFTV_GeoUIElements_Localization.csv
+++ b/Dist/Assets/Localization/TFTV_GeoUIElements_Localization.csv
@@ -1,4 +1,4 @@
-Key,Type,Desc,English,Chinese (Simplified),French,German,Italian,Polish,Russian,Spanish,UI_Tester
+﻿Key,Type,Desc,English,Chinese (Simplified),French,German,Italian,Polish,Russian,Spanish,UI_Tester
 KEY_DLC3_MOUNTEGG_NAME,Text,,HAMMERFALL CRATER,,CRATÈRE HAMMERFALL,Hammerfall-Krater,,KRATER HAMMERFALL,КРАТЕР «УДАР МОЛОТА»,CRÁTER CAÍDA DEL MARTILLO,
 KEY_DLC3_THE_GIFT,Text,,AURORA,,AURORA,AURORA,,AURORA,АВРОРА,AURORA,
 KEY_MARKETPLACE_HAVEN_ADDITIONAL_HEADER,Text,,The Bazaar,,Le Bazar,Der Basar,,Bazar,Рынок,El Bazar,
@@ -291,3 +291,8 @@ KEY_HAVEN_INFO_UNDERFED_POPULATION,Text,,FOOD-INSECURE POPULATION,,POPULATION AF
 Haven Screen/KEY_HAVEN_MIST,Text,,INCREASES ATTRITION RATE AND THE RISK OF PANDORAN ATTACK,,ACCÉLÈRE LE DÉCLIN ET AUGMENTE LE RISQUE D'ATTAQUE PANDORIENNE,,,ZWIĘKSZA TEMPO UBYTKU LUDNOŚCI I RYZYKO ATAKU PANDORAN,ПОВЫШАЕТ УБЫЛЬ НАСЕЛЕНИЯ И РИСК НАПАДЕНИЯ ПАНДОРАНОВ,,
 KEY_UI_EDIT_SCREEN_TOGGLEFACE,Text,,SHOW FACE,,,,,,,,
 KEY_UI_EDIT_SCREEN_TOGGLEHELMET,Text,,SHOW HELMET,,,,,,,,
+KEY_TFTV_FOOD_TOOLTIP_PRODUCED,Text,,Food produced: {0} per day,,,,,,,,
+KEY_TFTV_FOOD_TOOLTIP_CONSUMED,Text,,Food consumed: {0} per day,,,,,,,,
+KEY_TFTV_PERSONNEL_TOOLTIP_UNASSIGNED_NO_FOOD,Text,,"Unassigned personnel do not consume food. Only field operatives and personnel assigned to research, manufacturing or training need feeding.",,,,,,,,
+KEY_TFTV_MARKETPLACE_BUTTON_TOP,Text,,MARKET,,,,,,,,
+KEY_TFTV_MARKETPLACE_BUTTON_BOTTOM,Text,,PLACE,,,,,,,,

--- a/TFTV/Assets/Localization/TFTV_GeoUIElements_Localization.csv
+++ b/TFTV/Assets/Localization/TFTV_GeoUIElements_Localization.csv
@@ -1,4 +1,4 @@
-Key,Type,Desc,English,Chinese (Simplified),French,German,Italian,Polish,Russian,Spanish,UI_Tester
+﻿Key,Type,Desc,English,Chinese (Simplified),French,German,Italian,Polish,Russian,Spanish,UI_Tester
 KEY_DLC3_MOUNTEGG_NAME,Text,,HAMMERFALL CRATER,,CRATÈRE HAMMERFALL,Hammerfall-Krater,,KRATER HAMMERFALL,КРАТЕР «УДАР МОЛОТА»,CRÁTER CAÍDA DEL MARTILLO,
 KEY_DLC3_THE_GIFT,Text,,AURORA,,AURORA,AURORA,,AURORA,АВРОРА,AURORA,
 KEY_MARKETPLACE_HAVEN_ADDITIONAL_HEADER,Text,,The Bazaar,,Le Bazar,Der Basar,,Bazar,Рынок,El Bazar,
@@ -291,3 +291,8 @@ KEY_HAVEN_INFO_UNDERFED_POPULATION,Text,,FOOD-INSECURE POPULATION,,POPULATION AF
 Haven Screen/KEY_HAVEN_MIST,Text,,INCREASES ATTRITION RATE AND THE RISK OF PANDORAN ATTACK,,ACCÉLÈRE LE DÉCLIN ET AUGMENTE LE RISQUE D'ATTAQUE PANDORIENNE,,,ZWIĘKSZA TEMPO UBYTKU LUDNOŚCI I RYZYKO ATAKU PANDORAN,ПОВЫШАЕТ УБЫЛЬ НАСЕЛЕНИЯ И РИСК НАПАДЕНИЯ ПАНДОРАНОВ,,
 KEY_UI_EDIT_SCREEN_TOGGLEFACE,Text,,SHOW FACE,,,,,,,,
 KEY_UI_EDIT_SCREEN_TOGGLEHELMET,Text,,SHOW HELMET,,,,,,,,
+KEY_TFTV_FOOD_TOOLTIP_PRODUCED,Text,,Food produced: {0} per day,,,,,,,,
+KEY_TFTV_FOOD_TOOLTIP_CONSUMED,Text,,Food consumed: {0} per day,,,,,,,,
+KEY_TFTV_PERSONNEL_TOOLTIP_UNASSIGNED_NO_FOOD,Text,,"Unassigned personnel do not consume food. Only field operatives and personnel assigned to research, manufacturing or training need feeding.",,,,,,,,
+KEY_TFTV_MARKETPLACE_BUTTON_TOP,Text,,MARKET,,,,,,,,
+KEY_TFTV_MARKETPLACE_BUTTON_BOTTOM,Text,,PLACE,,,,,,,,

--- a/TFTV/TFTV.csproj
+++ b/TFTV/TFTV.csproj
@@ -225,6 +225,7 @@
     <Compile Include="TFTVLaserWeapons\LaserWeaponsBatteryTooltip.cs" />
     <Compile Include="TFTVLaserWeapons\LaserWeaponsFilter.cs" />
     <Compile Include="TFTVLaserWeapons\LaserWeaponsReplenishPatches.cs" />
+    <Compile Include="TFTVMarketplace\MarketplaceButton.cs" />
     <Compile Include="TFTVMarketplace\TFTVKaosGuns.cs" />
     <Compile Include="TFTVMarketplace\TFTVMarketPlaceGenerateOffers.cs" />
     <Compile Include="TFTVMarketplace\TFTVMarketPlaceItems.cs" />

--- a/TFTV/TFTVBaseRework/Data.cs
+++ b/TFTV/TFTVBaseRework/Data.cs
@@ -258,6 +258,15 @@ namespace TFTV.TFTVBaseRework
         {
             return character != null && !HasJustAGrunt(character);
         }
+
+        /// <summary>
+        /// Grunts are rank and file: they can be housed and fed, but they cannot be spent on
+        /// standing up an Outpost or activating a Base.
+        /// </summary>
+        internal static bool CanBeUsedForBaseActivation(GeoCharacter character)
+        {
+            return character != null && !HasJustAGrunt(character);
+        }
     }
 
     internal static class PersonnelData
@@ -374,7 +383,7 @@ namespace TFTV.TFTVBaseRework
 
         /// <summary>
         /// Personnel that may be spent on setting up an Outpost or activating a Base:
-        /// everyone who is not on field duty and not already in training.
+        /// everyone who is not on field duty, not already in training, and not just a grunt.
         /// </summary>
         internal static List<PersonnelInfo> GetPersonnelEligibleForBaseActivation(GeoPhoenixFaction faction)
         {
@@ -385,6 +394,7 @@ namespace TFTV.TFTVBaseRework
 
             return _assignments.Values
                 .Where(person => person?.Character != null && person.Character.Faction == faction)
+                .Where(person => PersonnelRestrictions.CanBeUsedForBaseActivation(person.Character))
                 .Where(person => person.Assignment == PersonnelAssignment.Unassigned
                     || person.Assignment == PersonnelAssignment.Research
                     || person.Assignment == PersonnelAssignment.Manufacturing)
@@ -1389,6 +1399,7 @@ namespace TFTV.TFTVBaseRework
 
             return _assignments.Values
                 .Where(person => person?.Character != null && person.Character.Faction == faction)
+                .Where(person => PersonnelRestrictions.CanBeUsedForBaseActivation(person.Character))
                 .Where(person => person.Assignment == PersonnelAssignment.Unassigned
                     || person.Assignment == PersonnelAssignment.Research
                     || person.Assignment == PersonnelAssignment.Manufacturing)

--- a/TFTV/TFTVDrills/DrillsHarmony.cs
+++ b/TFTV/TFTVDrills/DrillsHarmony.cs
@@ -683,6 +683,168 @@ namespace TFTV.TFTVDrills
                 }
             }
 
+            /// <summary>
+            /// The Flinching option lets targets keep animating while they are being shot, which makes the
+            /// later shots of a burst miss in free aim. Bullet Hell is nothing but one very long burst, so
+            /// while the Bullet Hell operative is the one shooting, the target slowdown is put back to the
+            /// no-flinching value. Anyone else shooting - including the same turn, after switching soldiers -
+            /// gets the player's Flinching setting back.
+            ///
+            /// The slowdown is a plain field on the level controller that the shooting code both adds and
+            /// removes by value, so it must never change while a shot is in flight. Every write is therefore
+            /// gated on FiringSlowdownActive, and it is only ever written from a shot's Activate (before that
+            /// shot has taken its own copy) or once the Bullet Hell status is gone.
+            /// </summary>
+            internal static class FlinchingSuppression
+            {
+                private const float NoFlinchingFireTargetTimeScale = 0.1f;
+
+                private static TacticalLevelController _suppressedLevel;
+                private static float _timeScaleBeforeSuppression;
+
+                /// <summary>
+                /// Called as a shot begins, with whether its shooter is running Bullet Hell.
+                /// </summary>
+                internal static void OnShotStarting(TacticalActor shooter, bool shooterHasBulletHell)
+                {
+                    TacticalLevelController controller = shooter?.TacticalLevel;
+
+                    if (controller == null || !TFTVMain.Main.Config.Flinching)
+                    {
+                        return;
+                    }
+
+                    ForgetStaleLevel(controller);
+
+                    // A shot is already playing (return fire, overwatch): its target has taken a copy of the
+                    // current value and will hand exactly that back, so leave the field alone.
+                    if (controller.FiringSlowdownActive)
+                    {
+                        return;
+                    }
+
+                    if (shooterHasBulletHell)
+                    {
+                        Suppress(controller, shooter);
+                    }
+                    else
+                    {
+                        Restore(controller);
+                    }
+                }
+
+                /// <summary>
+                /// End of the Bullet Hell turn. Nothing is shooting at this point, so the field can go back.
+                /// </summary>
+                internal static void OnBulletHellStatusUnapplied(TacticalActorBase actor)
+                {
+                    TacticalLevelController controller = actor?.TacticalLevel;
+
+                    if (controller == null)
+                    {
+                        return;
+                    }
+
+                    ForgetStaleLevel(controller);
+
+                    if (controller.FiringSlowdownActive)
+                    {
+                        return;
+                    }
+
+                    Restore(controller);
+                }
+
+                private static void Suppress(TacticalLevelController controller, TacticalActor shooter)
+                {
+                    if (_suppressedLevel != null)
+                    {
+                        return;
+                    }
+
+                    _suppressedLevel = controller;
+                    _timeScaleBeforeSuppression = controller.FireTargetTimeScale;
+                    controller.FireTargetTimeScale = NoFlinchingFireTargetTimeScale;
+
+                    TFTVLogger.Always($"Bullet Hell shot by {shooter.DisplayName ?? shooter.name}: suppressing flinching (FireTargetTimeScale {_timeScaleBeforeSuppression} -> {NoFlinchingFireTargetTimeScale}).");
+                }
+
+                private static void Restore(TacticalLevelController controller)
+                {
+                    if (_suppressedLevel == null)
+                    {
+                        return;
+                    }
+
+                    controller.FireTargetTimeScale = _timeScaleBeforeSuppression;
+                    _suppressedLevel = null;
+
+                    TFTVLogger.Always($"Restoring flinching (FireTargetTimeScale -> {_timeScaleBeforeSuppression}).");
+                }
+
+                // A mission that ends mid-Bullet Hell would otherwise leave the suppressed level behind; the
+                // next mission gets its own controller, which starts from the config value anyway.
+                private static void ForgetStaleLevel(TacticalLevelController controller)
+                {
+                    if (_suppressedLevel != null && _suppressedLevel != controller)
+                    {
+                        _suppressedLevel = null;
+                    }
+                }
+            }
+
+            [HarmonyPatch(typeof(ShootAbility), nameof(ShootAbility.Activate))]
+            internal static class ShootAbility_Activate_BulletHellFlinching_Patch
+            {
+                public static void Prefix(ShootAbility __instance)
+                {
+                    try
+                    {
+                        if (!TFTVNewGameOptions.IsReworkEnabled() || _bulletHellSlowStatus == null)
+                        {
+                            return;
+                        }
+
+                        TacticalActor shooter = __instance?.TacticalActor;
+                        if (shooter == null)
+                        {
+                            return;
+                        }
+
+                        bool shooterHasBulletHell = shooter.Status != null && shooter.Status.HasStatus(_bulletHellSlowStatus);
+
+                        FlinchingSuppression.OnShotStarting(shooter, shooterHasBulletHell);
+                    }
+                    catch (Exception e)
+                    {
+                        TFTVLogger.Error(e);
+                    }
+                }
+            }
+
+            [HarmonyPatch(typeof(TacStatus), nameof(TacStatus.OnUnapply))]
+            internal static class TacStatus_OnUnapply_BulletHellFlinching_Patch
+            {
+                public static void Prefix(TacStatus __instance)
+                {
+                    try
+                    {
+                        if (!TFTVNewGameOptions.IsReworkEnabled()
+                            || _bulletHellSlowStatus == null
+                            || __instance?.TacStatusDef != _bulletHellSlowStatus)
+                        {
+                            return;
+                        }
+
+                        FlinchingSuppression.OnBulletHellStatusUnapplied(__instance.TacticalActorBase);
+                    }
+                    catch (Exception e)
+                    {
+                        TFTVLogger.Error(e);
+                    }
+                }
+            }
+
             // Rapid Clearance's kill-triggered boost is applied through the vanilla OnActorDeathEffectStatus
             // pipeline, which has no awareness of Bullet Hell. Without this patch, killing an enemy while a
             // Bullet Hell attack boost is active leaves both boosts (and both of their AP cost reduction child

--- a/TFTV/TFTVExperienceDistribution.cs
+++ b/TFTV/TFTVExperienceDistribution.cs
@@ -167,7 +167,20 @@ namespace TFTV
                         return;
                     }
 
-                    if (!____actor.Status.HasStatus<MindControlStatus>() || ____actor.Status.GetStatus<MindControlStatus>().ControllerActor == null)
+                    // Vehicles are excluded from the mission XP split, so contribution they earn is
+                    // normally thrown away. An operative riding along with the Compute "Mounted Driver"
+                    // benefit is the one making the vehicle perform, so credit them with it in full.
+                    TacticalActor mountedDriver = TFTVIncidents.ComputeMountedAbility.GetBuffingMountedDriver(____actor);
+
+                    if (mountedDriver != null)
+                    {
+                        AddContributionTo(mountedDriver, cp);
+                        Debug.Log($"+{cp} cp for {mountedDriver.name} (through Mounted Driver vehicle {____actor.name}).");
+                    }
+
+                    if (____actor.Status == null
+                        || !____actor.Status.HasStatus<MindControlStatus>()
+                        || ____actor.Status.GetStatus<MindControlStatus>().ControllerActor == null)
                     {
                         return;
                     }
@@ -176,13 +189,7 @@ namespace TFTV
 
                     // TFTVLogger.Always($"{controllingActor.name} has {controllingActor.Contribution.Contribution} CP");
 
-                    FieldInfo contributionFieldInfo = typeof(TacticalContribution).GetField("_contribution", BindingFlags.NonPublic | BindingFlags.Instance);
-
-                    TacticalContribution controllingActorContribution = controllingActor.Contribution;
-
-                    int controllingActorContributionValue = controllingActorContribution.Contribution + cp / 2;
-
-                    contributionFieldInfo.SetValue(controllingActorContribution, controllingActorContributionValue);
+                    AddContributionTo(controllingActor, cp / 2);
 
                     // TFTVLogger.Always($"{controllingActor.name} now has {controllingActor.Contribution.Contribution} CP");
 
@@ -195,6 +202,24 @@ namespace TFTV
                     TFTVLogger.Error(e);
                     throw;
                 }
+            }
+
+            /// <summary>
+            /// Adds to an actor's contribution without going back through AddContribution, which would
+            /// re-enter this patch.
+            /// </summary>
+            private static void AddContributionTo(TacticalActorBase actor, int cp)
+            {
+                if (actor?.Contribution == null || cp <= 0)
+                {
+                    return;
+                }
+
+                FieldInfo contributionFieldInfo = typeof(TacticalContribution).GetField("_contribution", BindingFlags.NonPublic | BindingFlags.Instance);
+
+                TacticalContribution contribution = actor.Contribution;
+
+                contributionFieldInfo.SetValue(contribution, contribution.Contribution + cp);
             }
         }
     }

--- a/TFTV/TFTVIncidents/ComputeMountedAbility.cs
+++ b/TFTV/TFTVIncidents/ComputeMountedAbility.cs
@@ -3,6 +3,7 @@ using Base.Entities.Statuses;
 using Base.Serialization.General;
 using Base.UI;
 using PhoenixPoint.Common.Entities;
+using PhoenixPoint.Common.Entities.GameTags;
 using PhoenixPoint.Tactical.Entities;
 using PhoenixPoint.Tactical.Entities.Abilities;
 using PhoenixPoint.Tactical.Entities.Equipments;
@@ -18,6 +19,7 @@ namespace TFTV.TFTVIncidents
         private const string DiagTag = "[Incidents][ComputeMountedAbility]";
         private static readonly DefCache DefCache = TFTVMain.Main.DefCache;
         private static readonly DefRepository Repo = TFTVMain.Repo;
+        private static readonly GameTagDef VehicleTag = TFTVMain.Shared.SharedGameTags.VehicleTag;
 
         internal static class Defs
         {
@@ -149,9 +151,71 @@ namespace TFTV.TFTVIncidents
             public ItemStatModification[] StatModifications;
         }
 
+        /// <summary>
+        /// The operative whose Mounted Driver passive is currently buffing <paramref name="vehicleActor"/>,
+        /// or null when nobody with the benefit is riding it. Only one driver buffs a vehicle at a time,
+        /// so this is also the operative that should be credited for what the vehicle does.
+        ///
+        /// Called once per contribution event, so it has to stay cheap: the vehicle tag rejects every
+        /// ordinary actor outright, and only the vehicle's own handful of passengers are looked at.
+        /// </summary>
+        internal static TacticalActor GetBuffingMountedDriver(TacticalActorBase vehicleActor)
+        {
+            try
+            {
+                TacticalActor vehicle = vehicleActor as TacticalActor;
+
+                if (vehicle == null
+                    || vehicle.GameTags == null
+                    || !vehicle.GameTags.Contains(VehicleTag))
+                {
+                    return null;
+                }
+
+                VehicleComponent vehicleComponent = vehicle.Vehicle;
+
+                if (vehicleComponent == null)
+                {
+                    return null;
+                }
+
+                foreach (TacticalActorBase passengerBase in vehicleComponent.Passengers)
+                {
+                    TacticalActor passenger = passengerBase as TacticalActor;
+                    if (passenger == null)
+                    {
+                        continue;
+                    }
+
+                    foreach (MountedDriverPassiveAbility ability in passenger.GetAbilities<MountedDriverPassiveAbility>())
+                    {
+                        if (ability != null && ability.BuffedVehicleActor == vehicle)
+                        {
+                            return passenger;
+                        }
+                    }
+                }
+
+                return null;
+            }
+            catch (Exception ex)
+            {
+                TFTVLogger.Error(ex);
+                return null;
+            }
+        }
+
         [SerializeType(InheritCustomCreateFrom = typeof(TacticalAbility))]
         public class MountedDriverPassiveAbility : TacticalAbility
         {
+            internal TacticalActor BuffedVehicleActor
+            {
+                get
+                {
+                    return this._buffedVehicleActor;
+                }
+            }
+
             public MountedDriverPassiveAbilityDef MountedDriverPassiveAbilityDef
             {
                 get

--- a/TFTV/TFTVMarketplace/MarketplaceButton.cs
+++ b/TFTV/TFTVMarketplace/MarketplaceButton.cs
@@ -1,0 +1,648 @@
+﻿using Base.Core;
+using Base.Defs;
+using HarmonyLib;
+using PhoenixPoint.Common.View.ViewControllers;
+using PhoenixPoint.Geoscape.Entities;
+using PhoenixPoint.Geoscape.Entities.Abilities;
+using PhoenixPoint.Geoscape.Entities.Sites;
+using PhoenixPoint.Common.Core;
+using PhoenixPoint.Geoscape.Events;
+using PhoenixPoint.Geoscape.Events.Eventus;
+using PhoenixPoint.Geoscape.Levels;
+using PhoenixPoint.Geoscape.View;
+using PhoenixPoint.Geoscape.View.ViewModules;
+using System;
+using System.Collections;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TFTV.TFTVMarketplace
+{
+    /// <summary>
+    /// A geoscape shortcut to the Marketplace, sitting in the same row as the vanilla Bases button and
+    /// the Haven Recruits button. It appears once the Marketplace has been found, and its icon pulses
+    /// while the stock has rotated since the player last looked.
+    /// </summary>
+    internal static class MarketplaceButton
+    {
+        private const string MarketplaceBtnName = "UIButton_Icon_Marketplace";
+        private const float LeftPaddingPx = 16f;
+
+        // Bases sits at slot 0, Haven Recruits at slot 1, so the Marketplace takes slot 2.
+        private const int ButtonSlot = 2;
+
+        // Bumped by one on every stock rotation (see TFTVMarketPlaceGenerateOffers).
+        private const string StockRotationsVariable = "MarketPlaceRotations";
+
+        // The rotation count the player has already seen. Kept on the event system so it survives saves.
+        private const string StockRotationsSeenVariable = "TFTV_MarketplaceRotationsSeen";
+
+        // Set to 4 the moment the Marketplace site is first visited (TFTVMarketplace/Various.cs).
+        private const string MarketplaceDiscoveredVariable = "NumberOfDLC5MissionsCompletedVariable";
+
+        private static readonly DefRepository Repo = TFTVMain.Repo;
+
+        private static readonly Color FlashColor = new Color(1f, 0.4f, 0f, 1f);
+
+        private static Sprite _marketplaceIcon;
+
+        [HarmonyPatch(typeof(UIModuleSiteManagement), nameof(UIModuleSiteManagement.Awake))]
+        public static class AddMarketplaceButton_OnSiteManagementAwake
+        {
+            public static void Postfix(UIModuleSiteManagement __instance)
+            {
+                try
+                {
+                    PhoenixGeneralButton basesBtn = __instance?.OpenModuleButton;
+                    if (basesBtn == null)
+                    {
+                        TFTVLogger.Always("[MarketplaceBtn] OpenModuleButton is null; abort.");
+                        return;
+                    }
+
+                    RectTransform parent = basesBtn.transform.parent as RectTransform;
+                    if (parent == null)
+                    {
+                        TFTVLogger.Always("[MarketplaceBtn] Bases button parent is not a RectTransform; abort.");
+                        return;
+                    }
+
+                    Transform existingButton = parent.Find(MarketplaceBtnName);
+                    if (existingButton != null)
+                    {
+                        EnsureController(__instance, existingButton.gameObject);
+                        return;
+                    }
+
+                    GameObject templateGO = basesBtn.gameObject;
+                    GameObject cloneGO = UnityEngine.Object.Instantiate(templateGO, parent, worldPositionStays: false);
+                    cloneGO.name = MarketplaceBtnName;
+                    cloneGO.SetActive(true);
+
+                    RectTransform tplRT = templateGO.GetComponent<RectTransform>();
+                    RectTransform rt = cloneGO.GetComponent<RectTransform>();
+                    rt.anchorMin = tplRT.anchorMin;
+                    rt.anchorMax = tplRT.anchorMax;
+                    rt.pivot = tplRT.pivot;
+                    rt.sizeDelta = tplRT.sizeDelta;
+                    rt.localScale = tplRT.localScale;
+                    rt.anchoredPosition = tplRT.anchoredPosition
+                        + new Vector2(-ButtonSlot * (tplRT.sizeDelta.x + LeftPaddingPx), 0f);
+
+                    CanvasGroup cg = cloneGO.GetComponent<CanvasGroup>();
+                    if (cg != null) { cg.alpha = 1f; cg.interactable = true; cg.blocksRaycasts = true; }
+
+                    RectTransform group = cloneGO.transform.Find("Group") as RectTransform;
+                    if (group != null)
+                    {
+                        CanvasGroup groupCanvas = group.GetComponent<CanvasGroup>();
+                        if (groupCanvas != null)
+                        {
+                            groupCanvas.alpha = 1f;
+                            groupCanvas.interactable = true;
+                            groupCanvas.blocksRaycasts = true;
+                        }
+                    }
+
+                    RectTransform stack = BuildContentStack(group);
+                    Transform labelParent = (Transform)stack ?? group;
+
+                    Text label = FindLabel(cloneGO, labelParent, group);
+                    if (label != null)
+                    {
+                        SetupLabel(label, TFTVCommonMethods.ConvertKeyToString("KEY_TFTV_MARKETPLACE_BUTTON_TOP"));
+                        label.gameObject.name = "Label_Top";
+                        label.transform.SetSiblingIndex(0);
+                    }
+
+                    Transform iconTr = FindIcon(cloneGO, stack, group);
+                    Image iconImg = iconTr != null ? iconTr.GetComponent<Image>() : null;
+                    if (iconImg != null)
+                    {
+                        Sprite icon = GetMarketplaceIcon();
+                        if (icon != null)
+                        {
+                            iconImg.sprite = icon;
+                        }
+
+                        SetupIcon(iconImg, labelParent);
+                    }
+
+                    AddBottomLabel(labelParent, label, iconTr, TFTVCommonMethods.ConvertKeyToString("KEY_TFTV_MARKETPLACE_BUTTON_BOTTOM"));
+
+                    WireClick(cloneGO);
+
+                    if (stack != null)
+                    {
+                        LayoutRebuilder.ForceRebuildLayoutImmediate(stack);
+                    }
+                    else if (group != null)
+                    {
+                        LayoutRebuilder.ForceRebuildLayoutImmediate(group);
+                    }
+
+                    EnsureController(__instance, cloneGO);
+                }
+                catch (Exception ex) { TFTVLogger.Error(ex); }
+            }
+        }
+
+        /// <summary>
+        /// Opening the Marketplace at all - through this button, or by flying an aircraft over as usual -
+        /// counts as having seen the current stock, so the button stops calling for attention.
+        /// </summary>
+        [HarmonyPatch(typeof(UIModuleTheMarketplace), nameof(UIModuleTheMarketplace.ShowEncounter))]
+        public static class UIModuleTheMarketplace_ShowEncounter_patch
+        {
+            public static void Postfix()
+            {
+                try
+                {
+                    MarkRestockSeen(GameUtl.CurrentLevel()?.GetComponent<GeoLevelController>());
+                }
+                catch (Exception ex) { TFTVLogger.Error(ex); }
+            }
+        }
+
+        /// <summary>
+        /// The stock has rotated since the last time the player opened the Marketplace.
+        /// </summary>
+        internal static bool HasUnseenRestock(GeoLevelController level)
+        {
+            GeoscapeEventSystem eventSystem = level?.EventSystem;
+            if (eventSystem == null)
+            {
+                return false;
+            }
+
+            return eventSystem.GetVariable(StockRotationsVariable) > eventSystem.GetVariable(StockRotationsSeenVariable);
+        }
+
+        internal static void MarkRestockSeen(GeoLevelController level)
+        {
+            GeoscapeEventSystem eventSystem = level?.EventSystem;
+            if (eventSystem == null)
+            {
+                return;
+            }
+
+            eventSystem.SetVariable(StockRotationsSeenVariable, eventSystem.GetVariable(StockRotationsVariable));
+        }
+
+        private static bool IsMarketplaceDiscovered(GeoLevelController level)
+        {
+            return level != null
+                && level.HasKaosEngines
+                && level.EventSystem != null
+                && level.EventSystem.GetVariable(MarketplaceDiscoveredVariable) > 0;
+        }
+
+        private static void OpenMarketplace()
+        {
+            try
+            {
+                GeoLevelController level = GameUtl.CurrentLevel()?.GetComponent<GeoLevelController>();
+                if (!IsMarketplaceDiscovered(level))
+                {
+                    return;
+                }
+
+                GeoscapeEventDef marketplaceEvent = level.TheMarketplaceSettings?.MarketplaceEvent;
+                GeoSite marketplaceSite = level.Map?.ActiveSites?.FirstOrDefault(site => site.Type == GeoSiteType.Marketplace);
+
+                if (marketplaceEvent == null || marketplaceSite == null)
+                {
+                    TFTVLogger.Always($"[MarketplaceBtn] Cannot open the Marketplace: event {(marketplaceEvent == null ? "missing" : "found")}, site {(marketplaceSite == null ? "missing" : "found")}.");
+                    return;
+                }
+
+                level.View.ToMarketplace(marketplaceEvent.GeoscapeEventData, marketplaceSite);
+            }
+            catch (Exception ex) { TFTVLogger.Error(ex); }
+        }
+
+        /// <summary>
+        /// The same icon the Marketplace site wears on the geoscape. That one lives on a Material (the site
+        /// icons are drawn by a MeshRenderer, not by uGUI), so its texture has to be wrapped in a Sprite
+        /// before an Image can show it. Falls back to the Marketplace ability's icon.
+        /// </summary>
+        private static Sprite GetMarketplaceIcon()
+        {
+            try
+            {
+                if (_marketplaceIcon != null)
+                {
+                    return _marketplaceIcon;
+                }
+
+                _marketplaceIcon = CreateSpriteFromSiteMaterial(GeoSiteVisualsDefs.Instance?.Marketplace);
+
+                if (_marketplaceIcon == null)
+                {
+                    MarketplaceAbilityDef abilityDef = Repo.GetAllDefs<MarketplaceAbilityDef>().FirstOrDefault();
+                    _marketplaceIcon = abilityDef?.ViewElementDef?.LargeIcon ?? abilityDef?.ViewElementDef?.SmallIcon;
+
+                    TFTVLogger.Always($"[MarketplaceBtn] Could not build an icon from the Marketplace site material; {(_marketplaceIcon == null ? "keeping the cloned Bases icon" : "falling back to the Marketplace ability icon")}.");
+                }
+
+                return _marketplaceIcon;
+            }
+            catch (Exception ex)
+            {
+                TFTVLogger.Error(ex);
+                return null;
+            }
+        }
+
+        private static Sprite CreateSpriteFromSiteMaterial(Material siteMaterial)
+        {
+            if (siteMaterial == null)
+            {
+                return null;
+            }
+
+            // Site icon shaders do not all name their texture the same way.
+            Texture2D texture = siteMaterial.mainTexture as Texture2D;
+
+            if (texture == null && siteMaterial.HasProperty("_MainTex"))
+            {
+                texture = siteMaterial.GetTexture("_MainTex") as Texture2D;
+            }
+
+            if (texture == null && siteMaterial.HasProperty("_BaseMap"))
+            {
+                texture = siteMaterial.GetTexture("_BaseMap") as Texture2D;
+            }
+
+            if (texture == null)
+            {
+                return null;
+            }
+
+            TFTVLogger.Always($"[MarketplaceBtn] Using the Marketplace site icon texture '{texture.name}' ({texture.width}x{texture.height}).");
+
+            return Sprite.Create(texture, new Rect(0f, 0f, texture.width, texture.height), new Vector2(0.5f, 0.5f));
+        }
+
+        private static void WireClick(GameObject cloneGO)
+        {
+            PhoenixGeneralButton pgb = cloneGO.GetComponent<PhoenixGeneralButton>();
+            if (pgb?.BaseButton != null)
+            {
+                pgb.BaseButton.onClick.RemoveAllListeners();
+                pgb.BaseButton.onClick.AddListener(OpenMarketplace);
+                return;
+            }
+
+            Button uiBtn = cloneGO.GetComponent<Button>();
+            if (uiBtn != null)
+            {
+                uiBtn.onClick.RemoveAllListeners();
+                uiBtn.onClick.AddListener(OpenMarketplace);
+            }
+        }
+
+        private static RectTransform BuildContentStack(RectTransform group)
+        {
+            if (group == null)
+            {
+                return null;
+            }
+
+            RectTransform stack = group.Find("TFTV_ContentStack") as RectTransform;
+            if (stack == null)
+            {
+                GameObject stackGO = new GameObject("TFTV_ContentStack");
+                stack = stackGO.AddComponent<RectTransform>();
+                stack.SetParent(group, false);
+                stack.anchorMin = Vector2.zero;
+                stack.anchorMax = Vector2.one;
+                stack.pivot = new Vector2(0.5f, 0.5f);
+                stack.offsetMin = Vector2.zero;
+                stack.offsetMax = Vector2.zero;
+            }
+
+            VerticalLayoutGroup stackLayout = stack.GetComponent<VerticalLayoutGroup>()
+                ?? stack.gameObject.AddComponent<VerticalLayoutGroup>();
+            stackLayout.childAlignment = TextAnchor.MiddleCenter;
+            stackLayout.spacing = 8f;
+            stackLayout.childControlWidth = true;
+            stackLayout.childControlHeight = true;
+            stackLayout.childForceExpandWidth = true;
+            stackLayout.childForceExpandHeight = false;
+
+            LayoutElement stackLayoutElement = stack.GetComponent<LayoutElement>()
+                ?? stack.gameObject.AddComponent<LayoutElement>();
+            stackLayoutElement.minWidth = 0f;
+            stackLayoutElement.flexibleWidth = 1f;
+
+            stack.SetAsLastSibling();
+
+            return stack;
+        }
+
+        private static Text FindLabel(GameObject cloneGO, Transform labelParent, RectTransform group)
+        {
+            if (labelParent != null)
+            {
+                foreach (Transform child in labelParent)
+                {
+                    Text textComponent = child.GetComponent<Text>();
+                    if (textComponent != null && !string.Equals(child.gameObject.name, "Label_Bottom", StringComparison.Ordinal))
+                    {
+                        return textComponent;
+                    }
+                }
+            }
+
+            Text found = (group != null ? group : cloneGO.transform)
+                .GetComponentsInChildren<Text>(true)
+                .FirstOrDefault(t => !string.Equals(t.gameObject.name, "Label_Bottom", StringComparison.Ordinal));
+
+            if (found != null && labelParent != null)
+            {
+                found.transform.SetParent(labelParent, false);
+            }
+
+            return found;
+        }
+
+        private static void SetupLabel(Text label, string text)
+        {
+            label.enabled = true;
+            label.gameObject.SetActive(true);
+            label.canvasRenderer.SetAlpha(1f);
+            label.text = text;
+            label.color = Color.white;
+            label.fontSize = 30;
+            label.alignment = TextAnchor.MiddleCenter;
+            label.horizontalOverflow = HorizontalWrapMode.Overflow;
+            label.verticalOverflow = VerticalWrapMode.Overflow;
+
+            RectTransform labelRT = label.rectTransform;
+            labelRT.anchorMin = new Vector2(0f, 0.5f);
+            labelRT.anchorMax = new Vector2(1f, 0.5f);
+            labelRT.pivot = new Vector2(0.5f, 0.5f);
+
+            float preferredHeight = Mathf.Max(labelRT.sizeDelta.y, 30f);
+            labelRT.sizeDelta = new Vector2(0f, preferredHeight);
+            labelRT.anchoredPosition = Vector2.zero;
+
+            LayoutElement labelLayout = label.GetComponent<LayoutElement>() ?? label.gameObject.AddComponent<LayoutElement>();
+            labelLayout.minHeight = Mathf.Max(labelLayout.minHeight, preferredHeight);
+            labelLayout.preferredHeight = Mathf.Max(labelLayout.preferredHeight, preferredHeight);
+            labelLayout.flexibleHeight = 0f;
+            labelLayout.minWidth = 0f;
+            labelLayout.preferredWidth = -1f;
+            labelLayout.flexibleWidth = 1f;
+        }
+
+        private static Transform FindIcon(GameObject cloneGO, RectTransform stack, RectTransform group)
+        {
+            if (stack != null)
+            {
+                Transform iconTr = stack.Find("Image_Icon");
+                if (iconTr != null)
+                {
+                    return iconTr;
+                }
+
+                iconTr = group != null ? group.Find("Image_Icon") : null;
+                iconTr?.SetParent(stack, false);
+                return iconTr;
+            }
+
+            return cloneGO.transform.Find("Group/Image_Icon");
+        }
+
+        private static void SetupIcon(Image iconImg, Transform labelParent)
+        {
+            iconImg.preserveAspect = true;
+            iconImg.enabled = true;
+            iconImg.gameObject.SetActive(true);
+            iconImg.color = Color.white;
+            iconImg.canvasRenderer.SetAlpha(1f);
+
+            RectTransform iconRT = iconImg.rectTransform;
+            iconRT.anchorMin = new Vector2(0.5f, 0.5f);
+            iconRT.anchorMax = new Vector2(0.5f, 0.5f);
+            iconRT.pivot = new Vector2(0.5f, 0.5f);
+            iconRT.anchoredPosition = Vector2.zero;
+
+            Vector2 targetSize = iconRT.sizeDelta;
+            if (targetSize == Vector2.zero)
+            {
+                targetSize = new Vector2(96f, 96f);
+            }
+
+            iconRT.sizeDelta = targetSize;
+
+            LayoutElement iconLayout = iconImg.GetComponent<LayoutElement>() ?? iconImg.gameObject.AddComponent<LayoutElement>();
+            iconLayout.minWidth = 0f;
+            iconLayout.minHeight = 0f;
+            iconLayout.preferredWidth = targetSize.x;
+            iconLayout.preferredHeight = targetSize.y;
+            iconLayout.flexibleWidth = 0f;
+            iconLayout.flexibleHeight = 0f;
+
+            if (labelParent != null)
+            {
+                iconImg.transform.SetSiblingIndex(Mathf.Min(1, labelParent.childCount - 1));
+            }
+        }
+
+        private static void AddBottomLabel(Transform labelParent, Text label, Transform iconTr, string text)
+        {
+            if (labelParent == null || label == null || labelParent.Find("Label_Bottom") != null)
+            {
+                return;
+            }
+
+            GameObject bottomLabelGO = UnityEngine.Object.Instantiate(label.gameObject, labelParent);
+            bottomLabelGO.name = "Label_Bottom";
+
+            Text bottomLabel = bottomLabelGO.GetComponent<Text>();
+            if (bottomLabel != null)
+            {
+                SetupLabel(bottomLabel, text);
+            }
+
+            if (iconTr != null)
+            {
+                bottomLabelGO.transform.SetSiblingIndex(iconTr.GetSiblingIndex() + 1);
+            }
+            else
+            {
+                bottomLabelGO.transform.SetAsLastSibling();
+            }
+        }
+
+        private static Image FindButtonIcon(GameObject button)
+        {
+            Transform iconTransform = button.transform.Find("Group/TFTV_ContentStack/Image_Icon")
+                                   ?? button.transform.Find("Group/Image_Icon");
+
+            return iconTransform != null ? iconTransform.GetComponent<Image>() : null;
+        }
+
+        private static void EnsureController(UIModuleSiteManagement module, GameObject button)
+        {
+            if (module == null || button == null)
+            {
+                return;
+            }
+
+            MarketplaceButtonController controller = module.GetComponent<MarketplaceButtonController>()
+                ?? module.gameObject.AddComponent<MarketplaceButtonController>();
+
+            controller.Initialize(button, FindButtonIcon(button));
+        }
+
+        /// <summary>
+        /// Keeps the button hidden until the Marketplace has been found, and pulses its icon while there
+        /// is stock the player has not seen yet.
+        /// </summary>
+        private sealed class MarketplaceButtonController : MonoBehaviour
+        {
+            private const float PulsePeriodSeconds = 1.2f;
+            private const float StateCheckIntervalSeconds = 0.5f;
+
+            private GameObject _button;
+            private Image _icon;
+            private Coroutine _refreshRoutine;
+            private bool _lastVisible;
+            private bool _hasUnseenRestock;
+
+            internal void Initialize(GameObject button, Image icon)
+            {
+                _button = button;
+                _icon = icon;
+
+                ForceRefreshState();
+
+                if (isActiveAndEnabled && _refreshRoutine == null)
+                {
+                    _refreshRoutine = StartCoroutine(RefreshRoutine());
+                }
+            }
+
+            private void OnEnable()
+            {
+                if (_refreshRoutine == null)
+                {
+                    _refreshRoutine = StartCoroutine(RefreshRoutine());
+                }
+
+                ForceRefreshState();
+            }
+
+            private void ForceRefreshState()
+            {
+                try
+                {
+                    GeoLevelController level = GameUtl.CurrentLevel()?.GetComponent<GeoLevelController>();
+
+                    UpdateVisibility(IsMarketplaceDiscovered(level), force: true);
+
+                    _hasUnseenRestock = _lastVisible && HasUnseenRestock(level);
+                }
+                catch (Exception ex) { TFTVLogger.Error(ex); }
+            }
+
+            private void OnDisable()
+            {
+                if (_refreshRoutine != null)
+                {
+                    StopCoroutine(_refreshRoutine);
+                    _refreshRoutine = null;
+                }
+
+                ResetIconColor();
+            }
+
+            // Nothing here needs a frame-by-frame heartbeat in the common case: while the button is not
+            // pulsing the loop just wakes twice a second to re-read the state, and only steps down to
+            // per-frame updates for as long as there is actually a pulse to animate.
+            private IEnumerator RefreshRoutine()
+            {
+                WaitForSecondsRealtime idleWait = new WaitForSecondsRealtime(StateCheckIntervalSeconds);
+
+                while (true)
+                {
+                    RefreshState();
+
+                    if (!_hasUnseenRestock)
+                    {
+                        yield return idleWait;
+                        continue;
+                    }
+
+                    float nextStateCheck = Time.unscaledTime + StateCheckIntervalSeconds;
+
+                    while (_hasUnseenRestock && Time.unscaledTime < nextStateCheck)
+                    {
+                        UpdateFlashing();
+                        yield return null;
+                    }
+                }
+            }
+
+            private void RefreshState()
+            {
+                bool wasFlashing = _hasUnseenRestock;
+
+                GeoLevelController level = GameUtl.CurrentLevel()?.GetComponent<GeoLevelController>();
+
+                UpdateVisibility(IsMarketplaceDiscovered(level), force: false);
+
+                _hasUnseenRestock = _lastVisible && HasUnseenRestock(level);
+
+                // Leaving the pulse behind means the icon is stuck mid-fade.
+                if (wasFlashing && !_hasUnseenRestock)
+                {
+                    ResetIconColor();
+                }
+            }
+
+            private void UpdateVisibility(bool shouldShow, bool force)
+            {
+                if (_button == null)
+                {
+                    return;
+                }
+
+                if (!force && shouldShow == _lastVisible)
+                {
+                    return;
+                }
+
+                _lastVisible = shouldShow;
+                if (_button.activeSelf != shouldShow)
+                {
+                    _button.SetActive(shouldShow);
+                }
+            }
+
+            private void UpdateFlashing()
+            {
+                if (_icon == null)
+                {
+                    return;
+                }
+
+                float t = Mathf.PingPong(Time.unscaledTime * (2f / PulsePeriodSeconds), 1f);
+                _icon.color = Color.Lerp(Color.white, FlashColor, t);
+            }
+
+            private void ResetIconColor()
+            {
+                if (_icon != null && _icon.color != Color.white)
+                {
+                    _icon.color = Color.white;
+                }
+            }
+
+        }
+    }
+}

--- a/TFTV/TFTVUI/Geoscape/TopInforBar.cs
+++ b/TFTV/TFTVUI/Geoscape/TopInforBar.cs
@@ -778,5 +778,189 @@ namespace TFTV.TFTVUI.Geoscape
 
 
         }
+
+        /// <summary>
+        /// Extra lines on the two info bar tooltips that the mod changes the meaning of: the daily food
+        /// balance behind the Food counter, and - with the base rework on - the fact that idle personnel
+        /// are free to keep.
+        ///
+        /// UITooltipText builds its widget on the first hover and reuses it afterwards, so the text has to
+        /// be refreshed on every hover (TipText for the first one, UpdateText for the rest) or the numbers
+        /// freeze at whatever they were the first time the player looked.
+        ///
+        /// The hook sits on every tooltip in the game, so the two info bar tooltips are located once per
+        /// info bar and then recognised by reference; every other tooltip in every other screen costs two
+        /// reference comparisons and nothing else.
+        /// </summary>
+        internal static class ResourceTooltips
+        {
+            private static UIModuleInfoBar _resolvedAgainst;
+
+            private static UITooltipText _foodTooltip;
+            private static string _foodBaseText;
+
+            private static UITooltipText _personnelTooltip;
+            private static string _personnelBaseText;
+
+            [HarmonyPatch(typeof(UITooltipText), nameof(UITooltipText.OnMouseEnter))]
+            public static class UITooltipText_OnMouseEnter_patch
+            {
+                public static void Prefix(UITooltipText __instance)
+                {
+                    try
+                    {
+                        if (__instance == null)
+                        {
+                            return;
+                        }
+
+                        bool isFood = __instance == _foodTooltip;
+                        bool isPersonnel = !isFood && __instance == _personnelTooltip;
+
+                        if (!isFood && !isPersonnel)
+                        {
+                            // Unknown tooltip. Unless the info bar we last resolved against is gone (new
+                            // geoscape), there is nothing to look for, and this is where every other
+                            // tooltip in the game stops.
+                            if (_resolvedAgainst != null || !TryResolveTooltips())
+                            {
+                                return;
+                            }
+
+                            isFood = __instance == _foodTooltip;
+                            isPersonnel = __instance == _personnelTooltip;
+
+                            if (!isFood && !isPersonnel)
+                            {
+                                return;
+                            }
+                        }
+
+                        if (isPersonnel && !TFTVBaseRework.BaseReworkCheck.BaseReworkEnabled)
+                        {
+                            return;
+                        }
+
+                        GeoPhoenixFaction faction = GameUtl.CurrentLevel()?.GetComponent<GeoLevelController>()?.PhoenixFaction;
+
+                        if (faction == null)
+                        {
+                            return;
+                        }
+
+                        if (isFood)
+                        {
+                            Apply(__instance, _foodBaseText, CreateFoodBalanceText(faction));
+                            return;
+                        }
+
+                        Apply(__instance, _personnelBaseText, TFTVCommonMethods.ConvertKeyToString("KEY_TFTV_PERSONNEL_TOOLTIP_UNASSIGNED_NO_FOOD"));
+                    }
+                    catch (Exception e)
+                    {
+                        TFTVLogger.Error(e);
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Finds both info bar tooltips in one sweep and remembers the info bar they came from. Returns
+            /// false while there is no geoscape info bar to search, so a later hover tries again.
+            /// </summary>
+            private static bool TryResolveTooltips()
+            {
+                UIModuleInfoBar infoBar = GameUtl.CurrentLevel()?.GetComponent<GeoLevelController>()?.View?.GeoscapeModules?.ResourcesModule;
+
+                if (infoBar == null)
+                {
+                    return false;
+                }
+
+                _foodTooltip = FindTooltipUnder(infoBar.FoodController?.transform?.parent);
+                _personnelTooltip = FindTooltipUnder(infoBar.SoldiersLabel?.transform?.parent);
+
+                _foodBaseText = _foodTooltip != null ? CaptureBaseText(_foodTooltip) : null;
+                _personnelBaseText = _personnelTooltip != null ? CaptureBaseText(_personnelTooltip) : null;
+
+                _resolvedAgainst = infoBar;
+
+                TFTVLogger.Always("[TopInfoBar] Resource tooltips resolved: food "
+                    + (_foodTooltip != null ? "found" : "MISSING")
+                    + ", personnel "
+                    + (_personnelTooltip != null ? "found" : "MISSING")
+                    + ".");
+
+                return true;
+            }
+
+            private static UITooltipText FindTooltipUnder(Transform root)
+            {
+                return root != null ? root.GetComponentInChildren<UITooltipText>(true) : null;
+            }
+
+            /// <summary>
+            /// The vanilla text, before we start appending to it. Taken from the localization key when the
+            /// tooltip has one, because that is what the widget would have shown.
+            /// </summary>
+            private static string CaptureBaseText(UITooltipText tooltip)
+            {
+                if (tooltip.TipKey != null && !string.IsNullOrEmpty(tooltip.TipKey.LocalizationKey))
+                {
+                    return tooltip.TipKey.Localize();
+                }
+
+                return tooltip.TipText ?? string.Empty;
+            }
+
+            private static void Apply(UITooltipText tooltip, string baseText, string extraText)
+            {
+                if (string.IsNullOrEmpty(extraText))
+                {
+                    return;
+                }
+
+                string fullText = string.IsNullOrEmpty(baseText) ? extraText : $"{baseText}\n\n{extraText}";
+
+                // The key wins over TipText when the widget is first built, so it has to go.
+                tooltip.TipKey = null;
+                tooltip.TipText = fullText;
+                tooltip.UpdateText(fullText);
+            }
+
+            /// <summary>
+            /// Food is booked as income entries on the faction: production from havens and facilities is
+            /// positive, everything that eats (maintenance) is negative. Both are per hour.
+            /// </summary>
+            private static string CreateFoodBalanceText(GeoPhoenixFaction faction)
+            {
+                float producedPerHour = 0f;
+                float consumedPerHour = 0f;
+
+                if (faction.ResourceIncome != null)
+                {
+                    foreach (FactionResourceOutput.ResourceOutputEntry entry in faction.ResourceIncome.GetEntriesForResource(ResourceType.Supplies))
+                    {
+                        float value = entry.Resources.ByResourceType(ResourceType.Supplies).Value;
+
+                        if (value > 0f)
+                        {
+                            producedPerHour += value;
+                        }
+                        else
+                        {
+                            consumedPerHour -= value;
+                        }
+                    }
+                }
+
+                int producedPerDay = Mathf.RoundToInt(producedPerHour * 24f);
+                int consumedPerDay = Mathf.RoundToInt(consumedPerHour * 24f);
+
+                string produced = string.Format(TFTVCommonMethods.ConvertKeyToString("KEY_TFTV_FOOD_TOOLTIP_PRODUCED"), producedPerDay);
+                string consumed = string.Format(TFTVCommonMethods.ConvertKeyToString("KEY_TFTV_FOOD_TOOLTIP_CONSUMED"), consumedPerDay);
+
+                return $"{produced}\n{consumed}";
+            }
+        }
     }
 }


### PR DESCRIPTION
Credit vehicle contribution to the Compute mounted driver. Vehicles are excluded from the mission XP split, so contribution they earn was simply discarded. When an operative rides along with the Compute "Mounted Driver" benefit, the vehicle's contribution now goes to them in full. The lookup reads the vehicle's own passenger list and is gated on the vehicle tag, so it stays cheap on a path that runs once per damage instance.

Suppress flinching while a Bullet Hell operative shoots. The Flinching option lets targets keep animating mid-burst, which makes later shots miss in free aim - exactly what Bullet Hell is made of. The target slowdown now returns to the no-flinching value for that shooter's shots and back to the player's setting for anyone else, including after switching soldiers in the same turn. Every write is gated on FiringSlowdownActive, because the shooting code adds and removes that scale by value and would leak a permanently slowed actor if it changed mid-shot.

Show the daily food balance on the info bar Food tooltip, and explain on the Personnel tooltip that unassigned personnel do not consume food when the base rework is on. UITooltipText caches its widget after the first hover, so both are refreshed per hover rather than written once.

Keep "Just a Grunt" operatives out of base activation. The filter is applied to both the eligible list and the available-weight total, so the UI cannot advertise personnel that activation would then refuse to spend.

Add a Marketplace button to the geoscape, beside Bases and Haven Recruits. It appears once the Marketplace has been found, opens the same screen the Marketplace ability does, wears the site's own icon, and pulses while the stock has rotated since the player last looked.