### PR TITLE
Cut per-frame and per-call overhead in hot mod paths

### DIFF
--- a/TFTV/PRMLogger.cs
+++ b/TFTV/PRMLogger.cs
@@ -1,7 +1,7 @@
-﻿using Base.Core;
+using Base.Core;
 using Base.UI.MessageBox;
 using System;
-using System.IO;
+using TFTV;
 
 namespace PRMBetterClasses
 {
@@ -12,6 +12,8 @@ namespace PRMBetterClasses
         private static string _modName;
         private static bool _awake;
 
+        private static readonly TFTVLogPrefix _prefix = new TFTVLogPrefix();
+
         public static void Initialize(string logPath, int debugLevel, string modDirectory, string modName)
         {
             _logPath = logPath;
@@ -19,10 +21,13 @@ namespace PRMBetterClasses
             _modName = modName;
             _awake = true;
 
+            TFTVLogFile.SetPath(logPath);
+            _prefix.SetModName(modName);
+
             Cleanup();
-            Always("----------------------------------------------------------------------------------------------------", false);
+            Always(TFTVLogFile.Separator, false);
             Always($"Logger.Initialize({logPath}, {debugLevel}, {modDirectory}, {modName})");
-            Always("----------------------------------------------------------------------------------------------------", false);
+            Always(TFTVLogFile.Separator, false);
         }
 
 
@@ -39,12 +44,10 @@ namespace PRMBetterClasses
 
         public static void Cleanup()
         {
-            using (StreamWriter writer = new StreamWriter(_logPath, false))
-            {
-                writer.WriteLine("----------------------------------------------------------------------------------------------------", false);
-                writer.WriteLine($"[{_modName} @ {DateTime.Now}] CLEANED UP");
-                writer.WriteLine("----------------------------------------------------------------------------------------------------", false);
-            }
+            TFTVLogFile.Truncate();
+            TFTVLogFile.WriteLine(null, TFTVLogFile.Separator);
+            TFTVLogFile.WriteLine(null, $"[{_modName} @ {DateTime.Now}] CLEANED UP");
+            TFTVLogFile.WriteLine(null, TFTVLogFile.Separator);
         }
 
 
@@ -52,13 +55,11 @@ namespace PRMBetterClasses
         {
             if (_awake && _debugLevel >= 1)
             {
-                using (StreamWriter writer = new StreamWriter(_logPath, true))
-                {
-                    writer.WriteLine("----------------------------------------------------------------------------------------------------", false);
-                    writer.WriteLine($"[{_modName} @ {DateTime.Now}] EXCEPTION:");
-                    writer.WriteLine("Message: " + ex.Message + "<br/>" + Environment.NewLine + "StackTrace: " + ex.StackTrace);
-                    writer.WriteLine("----------------------------------------------------------------------------------------------------", false);
-                }
+                TFTVLogFile.WriteLine(null, TFTVLogFile.Separator);
+                TFTVLogFile.WriteLine(null, $"[{_modName} @ {DateTime.Now}] EXCEPTION:");
+                TFTVLogFile.WriteLine(null, "Message: " + ex.Message + "<br/>" + Environment.NewLine + "StackTrace: " + ex.StackTrace);
+                TFTVLogFile.WriteLine(null, TFTVLogFile.Separator);
+
                 GameUtl.GetMessageBox().ShowSimplePrompt($"<b>An error has occurred in the BetterClasses mod!</b>\nPlease check {_logPath} for further information.\n\n<b>CAUTION:</b>\nContinuing this run may result in unstable behavior or even cause the game to crash.", MessageBoxIcon.Warning, MessageBoxButtons.OK, null);
             }
         }
@@ -68,11 +69,7 @@ namespace PRMBetterClasses
         {
             if (_awake && _debugLevel >= 2)
             {
-                using (StreamWriter writer = new StreamWriter(_logPath, true))
-                {
-                    string prefix = showPrefix ? $"[{_modName} @ {DateTime.Now}] " : "";
-                    writer.WriteLine(prefix + line);
-                }
+                TFTVLogFile.WriteLine(showPrefix ? _prefix.Get() : null, line);
             }
         }
 
@@ -88,11 +85,7 @@ namespace PRMBetterClasses
 
         public static void Always(string line, bool showPrefix = true)
         {
-            using (StreamWriter writer = new StreamWriter(_logPath, true))
-            {
-                string prefix = showPrefix ? $"[{_modName} @ {DateTime.Now}] " : "";
-                writer.WriteLine(prefix + line);
-            }
+            TFTVLogFile.WriteLine(showPrefix ? _prefix.Get() : null, line);
         }
     }
 }

--- a/TFTV/TFTV.csproj
+++ b/TFTV/TFTV.csproj
@@ -353,6 +353,7 @@
     <Compile Include="TFTVHumanEnemies.cs" />
     <Compile Include="TFTVHumanEnemiesNames.cs" />
     <Compile Include="TFTVInfestation.cs" />
+    <Compile Include="TFTVLogFile.cs" />
     <Compile Include="TFTVLogger.cs" />
     <Compile Include="TFTVMain.cs" />
     <Compile Include="TFTVNewGameMenu.cs" />

--- a/TFTV/TFTVArtOfCrab.cs
+++ b/TFTV/TFTVArtOfCrab.cs
@@ -1303,7 +1303,66 @@ namespace TFTV
      
         internal class TargetCulling
         {
-            
+            /// <summary>
+            /// Defs used by the target-culling helpers below.
+            ///
+            /// These helpers hang off AI consideration evaluation and off TacticalAbility.GetTargetActors,
+            /// i.e. they run per actor x per candidate position x per enemy during an AI turn, and once
+            /// per candidate target whenever targeting is recomputed. Resolving the defs by name on every
+            /// call (which is what they used to do - eleven lookups per target in IsValidTarget alone)
+            /// is pure overhead: these are all fixed defs that exist for the whole session.
+            ///
+            /// They are resolved on first use rather than in a static initialiser so that def injection
+            /// has definitely finished by the time we look them up.
+            /// </summary>
+            internal static class CachedDefs
+            {
+                private static bool _resolved;
+
+                internal static AIClosestEnemyConsiderationDef UmbraClosestPathToEnemy;
+                internal static AIClosestEnemyConsiderationDef QueenClosestEnemy;
+                internal static AIClosestEnemyConsiderationDef ChironClosestEnemy;
+                internal static AIClosestEnemyConsiderationDef AcheronClosestLineToEnemy;
+
+                internal static ClassTagDef QueenTag;
+                internal static ClassTagDef AcheronTag;
+                internal static ClassTagDef ChironTag;
+                internal static ClassTagDef CyclopsTag;
+
+                internal static GameTagDef CaterpillarDamageTag;
+
+                internal static DamageKeywordDef ParalysingKeyword;
+                internal static DamageKeywordDef ViralKeyword;
+
+                internal static void Ensure()
+                {
+                    if (_resolved)
+                    {
+                        return;
+                    }
+
+                    UmbraClosestPathToEnemy = DefCache.GetDef<AIClosestEnemyConsiderationDef>("Umbra_ClosestPathToEnemy_AIConsiderationDef");
+                    QueenClosestEnemy = DefCache.GetDef<AIClosestEnemyConsiderationDef>("Queen_ClosestEnemy_AIConsiderationDef");
+                    ChironClosestEnemy = DefCache.GetDef<AIClosestEnemyConsiderationDef>("Chiron_ClosestEnemy_AIConsiderationDef");
+                    AcheronClosestLineToEnemy = DefCache.GetDef<AIClosestEnemyConsiderationDef>("Acheron_ClosestLineToEnemy_AIConsiderationDef");
+
+                    // Note: IsValidTarget also used to resolve Swarmer/Crabman/Siren/Fishman/Human/
+                    // MeleeWeapon defs on every call without ever reading them; those are dropped.
+                    QueenTag = DefCache.GetDef<ClassTagDef>("Queen_ClassTagDef");
+                    AcheronTag = DefCache.GetDef<ClassTagDef>("Acheron_ClassTagDef");
+                    ChironTag = DefCache.GetDef<ClassTagDef>("Chiron_ClassTagDef");
+                    CyclopsTag = DefCache.GetDef<ClassTagDef>("MediumGuardian_ClassTagDef");
+
+                    CaterpillarDamageTag = DefCache.GetDef<GameTagDef>("DamageByCaterpillarTracks_TagDef");
+
+                    SharedDamageKeywordsDataDef sharedKeywords = GameUtl.GameComponent<SharedData>().SharedDamageKeywords;
+                    ParalysingKeyword = sharedKeywords.ParalysingKeyword;
+                    ViralKeyword = sharedKeywords.ViralKeyword;
+
+                    _resolved = true;
+                }
+            }
+
             [HarmonyPatch(typeof(AIClosestEnemyConsideration), nameof(AIClosestEnemyConsideration.Evaluate))]
             public static class AIClosestEnemyConsideration_Evaluate_patch
             {
@@ -1342,7 +1401,9 @@ namespace TFTV
                 {
                     try
                     {
-                        AIClosestEnemyConsiderationDef aIClosestEnemyConsiderationDef = DefCache.GetDef<AIClosestEnemyConsiderationDef>("Umbra_ClosestPathToEnemy_AIConsiderationDef");
+                        CachedDefs.Ensure();
+
+                        AIClosestEnemyConsiderationDef aIClosestEnemyConsiderationDef = CachedDefs.UmbraClosestPathToEnemy;
 
                         if (__instance.BaseDef != aIClosestEnemyConsiderationDef)
                         {
@@ -1752,15 +1813,13 @@ namespace TFTV
                 {
                     try
                     {
-                        AIClosestEnemyConsiderationDef queenConsideration = DefCache.GetDef<AIClosestEnemyConsiderationDef>("Queen_ClosestEnemy_AIConsiderationDef");
-                        AIClosestEnemyConsiderationDef chironConsideration = DefCache.GetDef<AIClosestEnemyConsiderationDef>("Chiron_ClosestEnemy_AIConsiderationDef");
-                        AIClosestEnemyConsiderationDef acheronConsideration = DefCache.GetDef<AIClosestEnemyConsiderationDef>("Acheron_ClosestLineToEnemy_AIConsiderationDef");
+                        CachedDefs.Ensure();
 
-                        List<AIClosestEnemyConsiderationDef> aIClosestEnemyConsiderationDefs = new List<AIClosestEnemyConsiderationDef>() { queenConsideration, chironConsideration, acheronConsideration };
+                        GameTagDef caterpillarDamage = CachedDefs.CaterpillarDamageTag;
 
-                        GameTagDef caterpillarDamage = DefCache.GetDef<GameTagDef>("DamageByCaterpillarTracks_TagDef");
-
-                        if (aIClosestEnemyConsiderationDefs.Contains(closestEnemyConsiderationDef))
+                        if (closestEnemyConsiderationDef == CachedDefs.QueenClosestEnemy
+                            || closestEnemyConsiderationDef == CachedDefs.ChironClosestEnemy
+                            || closestEnemyConsiderationDef == CachedDefs.AcheronClosestLineToEnemy)
                         {
 
                             TacticalActor tacticalActor = (TacticalActor)actor;
@@ -1849,30 +1908,45 @@ namespace TFTV
                 {
                     public static IEnumerable<TacticalAbilityTarget> Postfix(IEnumerable<TacticalAbilityTarget> results, TacticalActorBase sourceActor, TacticalAbility __instance)
                     {
-                        foreach (TacticalAbilityTarget target in results)
+                        // Both the mass-stomp check and the weapon lookup are per-ability, not per-target,
+                        // so hoist them out of the loop instead of redoing them for every candidate.
+                        if (__instance.AbilityDef == BehemothMassStompAbility)
                         {
-                            if (__instance.AbilityDef == DefCache.GetDef<TacticalAbilityDef>("BehemothMassStomp_ApplyEffectAbilityDef"))
+                            foreach (TacticalAbilityTarget target in results)
                             {
-                                // TFTVLogger.Always($"got here for {__instance.AbilityDef?.name}");
                                 yield return target;
                             }
-                            else
-                            {
-                                Weapon weapon = null;
 
-                                if (__instance.SelectedEquipment != null && __instance.SelectedEquipment is Weapon)
-                                {
-                                    weapon = __instance.SelectedEquipment as Weapon;
-                                }
-
-                                if (IsValidTarget(__instance.TacticalActor, target, weapon))
-                                {
-                                    yield return target;
-                                }
-                            }
-
+                            yield break;
                         }
 
+                        Weapon weapon = __instance.SelectedEquipment as Weapon;
+                        TacticalActor tacticalActor = __instance.TacticalActor;
+
+                        foreach (TacticalAbilityTarget target in results)
+                        {
+                            if (IsValidTarget(tacticalActor, target, weapon))
+                            {
+                                yield return target;
+                            }
+                        }
+                    }
+
+                    private static TacticalAbilityDef _behemothMassStompAbility;
+                    private static bool _behemothMassStompResolved;
+
+                    private static TacticalAbilityDef BehemothMassStompAbility
+                    {
+                        get
+                        {
+                            if (!_behemothMassStompResolved)
+                            {
+                                _behemothMassStompAbility = DefCache.GetDef<TacticalAbilityDef>("BehemothMassStomp_ApplyEffectAbilityDef");
+                                _behemothMassStompResolved = true;
+                            }
+
+                            return _behemothMassStompAbility;
+                        }
                     }
                 }
 
@@ -1899,20 +1973,14 @@ namespace TFTV
                         }
 
 
-                        ClassTagDef swarmerTag = DefCache.GetDef<ClassTagDef>("Swarmer_ClassTagDef");
-                        ClassTagDef crabTag = DefCache.GetDef<ClassTagDef>("Crabman_ClassTagDef");
-                        ClassTagDef sirenTag = DefCache.GetDef<ClassTagDef>("Siren_ClassTagDef");
-                        ClassTagDef queenTag = DefCache.GetDef<ClassTagDef>("Queen_ClassTagDef");
-                        ClassTagDef tritonTag = DefCache.GetDef<ClassTagDef>("Fishman_ClassTagDef");
-                        ClassTagDef acheronTag = DefCache.GetDef<ClassTagDef>("Acheron_ClassTagDef");
-                        ClassTagDef chironTag = DefCache.GetDef<ClassTagDef>("Chiron_ClassTagDef");
-                        ClassTagDef cyclopsTag = DefCache.GetDef<ClassTagDef>("MediumGuardian_ClassTagDef");
+                        CachedDefs.Ensure();
 
-                        GameTagDef humanTag = DefCache.GetDef<GameTagDef>("Human_TagDef");
-                        GameTagDef caterpillarDamage = DefCache.GetDef<GameTagDef>("DamageByCaterpillarTracks_TagDef");
-                        ItemClassificationTagDef meleeTag = DefCache.GetDef<ItemClassificationTagDef>("MeleeWeapon_TagDef");
+                        GameTagDef caterpillarDamage = CachedDefs.CaterpillarDamageTag;
 
-                        if (actor.GameTags.Contains(queenTag) || actor.GameTags.Contains(acheronTag) || actor.GameTags.Contains(chironTag) || actor.GameTags.Contains(cyclopsTag))
+                        if (actor.GameTags.Contains(CachedDefs.QueenTag)
+                            || actor.GameTags.Contains(CachedDefs.AcheronTag)
+                            || actor.GameTags.Contains(CachedDefs.ChironTag)
+                            || actor.GameTags.Contains(CachedDefs.CyclopsTag))
                         {
                             if (targetActor.GameTags.Contains(caterpillarDamage) && targetActor.TacticalFaction != actor.TacticalFaction)
                             {
@@ -1927,20 +1995,11 @@ namespace TFTV
                             }
                         }
 
-                        DamageKeywordDef[] excludeDamageDefs =
+                        // The drone/turret name test is checked first because GetDamagePayload() builds a
+                        // payload, and almost no target is a drone or a turret.
+                        if (weapon != null && IsDroneOrTurret(targetActor) && HasExcludedDamageKeyword(weapon))
                         {
-                    GameUtl.GameComponent<SharedData>().SharedDamageKeywords.ParalysingKeyword,
-                    GameUtl.GameComponent<SharedData>().SharedDamageKeywords.ViralKeyword
-                        };
-
-
-                        if (weapon != null && weapon.GetDamagePayload().DamageKeywords.Any(damageKeyordPair => excludeDamageDefs.Contains(damageKeyordPair.DamageKeywordDef)))
-                        {
-                            if (targetActor.ActorDef.name.Equals("SpiderDrone_ActorDef") ||
-                                    targetActor.ActorDef.name.Contains("Turret_ActorDef"))
-                            {
-                                return false;
-                            }
+                            return false;
                         }
 
                         return true;
@@ -1953,11 +2012,38 @@ namespace TFTV
                     }
                 }
 
+                private static bool IsDroneOrTurret(TacticalActor targetActor)
+                {
+                    string actorDefName = targetActor.ActorDef?.name;
+                    if (actorDefName == null)
+                    {
+                        return false;
+                    }
+
+                    return actorDefName.Equals("SpiderDrone_ActorDef") || actorDefName.Contains("Turret_ActorDef");
+                }
+
+                private static bool HasExcludedDamageKeyword(Weapon weapon)
+                {
+                    foreach (DamageKeywordPair damageKeywordPair in weapon.GetDamagePayload().DamageKeywords)
+                    {
+                        DamageKeywordDef keyword = damageKeywordPair.DamageKeywordDef;
+                        if (keyword == CachedDefs.ParalysingKeyword || keyword == CachedDefs.ViralKeyword)
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+
                 public static bool CheckIfTargetingAcheron(TacticalAbilityTarget target)
                 {
                     try
                     {
-                        if (target.Actor != null && !target.Actor.IsDead && target.Actor is TacticalActor tacticalActor && tacticalActor.GameTags != null && tacticalActor.HasGameTag(DefCache.GetDef<ClassTagDef>("Acheron_ClassTagDef")))
+                        CachedDefs.Ensure();
+
+                        if (target.Actor != null && !target.Actor.IsDead && target.Actor is TacticalActor tacticalActor && tacticalActor.GameTags != null && tacticalActor.HasGameTag(CachedDefs.AcheronTag))
                         {
 
                             return true;

--- a/TFTV/TFTVBaseRework/BaseConstructionVisuals.cs
+++ b/TFTV/TFTVBaseRework/BaseConstructionVisuals.cs
@@ -104,11 +104,17 @@ namespace TFTV.TFTVBaseRework
                 return;
             }
 
-            foreach (GeoEventTimer timer in timers.Values.Where(t => t != null))
+            foreach (GeoEventTimer timer in timers.Values)
             {
+                if (timer == null)
+                {
+                    continue;
+                }
+
                 if (!ActivePendingByTimerId.ContainsKey(timer.ID) && TryParsePendingTimer(timer, out PendingActionInfo active))
                 {
                     ActivePendingByTimerId[active.TimerId] = active;
+                    InvalidatePendingVisuals();
 
                     GeoSite site = level?.Map?.AllSites?.FirstOrDefault(s => s.SiteId == active.SiteId);
                     if (site != null && site.ExpiringTimerAt != timer.EndAt)
@@ -119,9 +125,12 @@ namespace TFTV.TFTVBaseRework
             }
         }
 
+        // Reused so the per-frame tick does not allocate.
+        private static readonly List<string> _toCompleteBuffer = new List<string>();
+
         private static void TickPendingActions(GeoscapeEventSystem eventSystem)
         {
-            GeoLevelController level = eventSystem?.gameObject?.GetComponent<GeoLevelController>();
+            GeoLevelController level = ResolveLevel(eventSystem);
             if (eventSystem == null
                 || level == null
                 || level.Map == null
@@ -134,22 +143,35 @@ namespace TFTV.TFTVBaseRework
 
             RehydratePendingActions(eventSystem, level);
 
-            List<string> toComplete = new List<string>();
+            if (ActivePendingByTimerId.Count == 0)
+            {
+                return;
+            }
+
+            List<string> toComplete = _toCompleteBuffer;
+            toComplete.Clear();
+
             foreach (KeyValuePair<string, PendingActionInfo> kv in ActivePendingByTimerId)
             {
-              //  TFTVLogger.Always($"Checking pending action timer {kv.Key} for site {kv.Value.SiteId} and action {kv.Value.Action}. Now={level.Timing.Now}, EndAt={kv.Value.EndAt}");
-                GeoEventTimer timer = eventSystem.GetTimerById(kv.Key);
-              //  TFTVLogger.Always($"Timer exists: {(timer != null)}, TimerEndAt={(timer != null ? timer.EndAt.ToString() : "null")}");
                 if (level.Timing.Now >= kv.Value.EndAt)
                 {
                     toComplete.Add(kv.Key);
                 }
             }
 
+            if (toComplete.Count == 0)
+            {
+                return;
+            }
+
             foreach (string timerId in toComplete)
             {
                 CompletePendingActionFromTimer(level, timerId);
             }
+
+            // Marked afterwards so the rescan is guaranteed to see the completed state, even though
+            // the completion path already refreshes on its own.
+            InvalidatePendingVisuals();
         }
 
         private static bool CompletePendingActionFromTimer(GeoLevelController level, string timerId)
@@ -247,8 +269,13 @@ namespace TFTV.TFTVBaseRework
                 try
                 {
                     TickPendingActions(__instance);
-                    GeoLevelController level = __instance?.gameObject?.GetComponent<GeoLevelController>();
-                    RefreshPendingConstructionVisuals(level);
+
+                    if (!ShouldRescanVisuals())
+                    {
+                        return;
+                    }
+
+                    RefreshPendingConstructionVisuals(ResolveLevel(__instance));
                 }
                 catch (Exception ex)
                 {
@@ -257,6 +284,60 @@ namespace TFTV.TFTVBaseRework
             }
         }
 
+        /// <summary>
+        /// GeoscapeEventSystem is a MonoBehaviour, so its Update runs every frame. Scanning every
+        /// site on the map at that rate is wasted work: pending actions only start and finish on
+        /// discrete events, and the progression visuals animate themselves from their own Update.
+        /// The scan is therefore invalidated explicitly and otherwise throttled to a safety net.
+        /// </summary>
+        private const int VisualRescanFrameInterval = 30;
+
+        private static int _lastVisualScanFrame = int.MinValue;
+        private static bool _visualsDirty = true;
+
+        internal static void InvalidatePendingVisuals()
+        {
+            _visualsDirty = true;
+        }
+
+        private static bool ShouldRescanVisuals()
+        {
+            return _visualsDirty
+                || UnityEngine.Time.frameCount - _lastVisualScanFrame >= VisualRescanFrameInterval;
+        }
+
+        // GeoscapeEventSystem and GeoLevelController live on the same GameObject, so the lookup only
+        // has to happen once per event system rather than on every frame.
+        private static GeoscapeEventSystem _cachedLevelOwner;
+        private static GeoLevelController _cachedLevel;
+
+        private static GeoLevelController ResolveLevel(GeoscapeEventSystem eventSystem)
+        {
+            if (eventSystem == null)
+            {
+                return null;
+            }
+
+            if (!ReferenceEquals(_cachedLevelOwner, eventSystem) || _cachedLevel == null)
+            {
+                _cachedLevelOwner = eventSystem;
+                _cachedLevel = eventSystem.gameObject != null
+                    ? eventSystem.gameObject.GetComponent<GeoLevelController>()
+                    : null;
+            }
+
+            return _cachedLevel;
+        }
+
+        // Reused across scans so the refresh does not allocate on the geoscape.
+        private static readonly HashSet<int> _activeSiteIdsBuffer = new HashSet<int>();
+        private static readonly List<int> _staleSiteIdsBuffer = new List<int>();
+
+        // Progression ranges already pushed into each visual. SetProgression touches renderer
+        // materials, so it must only be called when the range actually changes.
+        private static readonly Dictionary<int, KeyValuePair<TimeUnit, TimeUnit>> AppliedProgression =
+            new Dictionary<int, KeyValuePair<TimeUnit, TimeUnit>>();
+
         public static void RefreshPendingConstructionVisuals(GeoLevelController level)
         {
             if (level?.Map?.AllSites == null)
@@ -264,9 +345,20 @@ namespace TFTV.TFTVBaseRework
                 return;
             }
 
-            HashSet<int> activeSiteIds = new HashSet<int>();
-            foreach (GeoSite site in level.Map.AllSites.Where(s => s != null && PhoenixBaseVisitFlow.HasPendingActionPublic(s)))
+            // Also resets the throttle for callers that refresh directly after a player action.
+            _visualsDirty = false;
+            _lastVisualScanFrame = UnityEngine.Time.frameCount;
+
+            HashSet<int> activeSiteIds = _activeSiteIdsBuffer;
+            activeSiteIds.Clear();
+
+            foreach (GeoSite site in level.Map.AllSites)
             {
+                if (site == null || !PhoenixBaseVisitFlow.HasPendingActionPublic(site))
+                {
+                    continue;
+                }
+
                 if (site.ExpiringTimerAt == TimeUnit.Zero || site.ExpiringTimerAt <= level.Timing.Now)
                 {
                     if (!PendingVisualMissingLogged.Contains(site.SiteId))
@@ -321,16 +413,41 @@ namespace TFTV.TFTVBaseRework
 
                 float durationHours = PhoenixBaseVisitFlow.GetPendingDurationHours(site);
                 TimeUnit startAt = site.ExpiringTimerAt - TimeUnit.FromHours(durationHours);
-                controller.SetProgression(startAt, site.ExpiringTimerAt, level.Timing);
-                controller.gameObject.SetActive(true);
+
+                // SetProgression writes to the renderer's material, and the controller animates
+                // itself from its own Update, so only push the range when it has actually changed.
+                if (!AppliedProgression.TryGetValue(site.SiteId, out KeyValuePair<TimeUnit, TimeUnit> applied)
+                    || applied.Key != startAt
+                    || applied.Value != site.ExpiringTimerAt)
+                {
+                    controller.SetProgression(startAt, site.ExpiringTimerAt, level.Timing);
+                    AppliedProgression[site.SiteId] = new KeyValuePair<TimeUnit, TimeUnit>(startAt, site.ExpiringTimerAt);
+                }
+
+                if (!controller.gameObject.activeSelf)
+                {
+                    controller.gameObject.SetActive(true);
+                }
             }
 
-            foreach (int staleId in PendingConstructionVisuals.Keys.Where(id => !activeSiteIds.Contains(id)).ToList())
+            List<int> staleSiteIds = _staleSiteIdsBuffer;
+            staleSiteIds.Clear();
+
+            foreach (int id in PendingConstructionVisuals.Keys)
+            {
+                if (!activeSiteIds.Contains(id))
+                {
+                    staleSiteIds.Add(id);
+                }
+            }
+
+            foreach (int staleId in staleSiteIds)
             {
                 GeoActorProgressionVisualController controller = PendingConstructionVisuals[staleId];
                 PendingConstructionVisuals.Remove(staleId);
                 PendingVisualCreationLogged.Remove(staleId);
                 PendingVisualMissingLogged.Remove(staleId);
+                AppliedProgression.Remove(staleId);
 
                 if (controller != null)
                 {

--- a/TFTV/TFTVBaseRework/Data.cs
+++ b/TFTV/TFTVBaseRework/Data.cs
@@ -15,6 +15,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using TFTV.TFTVIncidents;
 using static TFTV.TFTVBaseRework.Workers;
 
@@ -171,14 +172,78 @@ namespace TFTV.TFTVBaseRework
             return DismissedOperativeAbility;
         }
 
+        /// <summary>
+        /// Memo of marker lookups per character.
+        ///
+        /// HasMarkerAbility is reached from the GeoPhoenixFaction.Soldiers postfix, so it runs for
+        /// every soldier on every enumeration of that property - which the geoscape UI does
+        /// constantly. Scanning the character's whole ability list each time (with a case-insensitive
+        /// string compare per ability that is not reference-equal) was costing thousands of string
+        /// comparisons per enumeration.
+        ///
+        /// The memo is keyed on the character object, so it disappears by itself when a save is
+        /// loaded, and it is rechecked whenever the character's ability count changes - which covers
+        /// both the marker add/remove paths below and any external change to the ability list.
+        /// </summary>
+        private sealed class MarkerAbilityMemo
+        {
+            public int AbilityCount = -1;
+            public readonly Dictionary<TacticalAbilityDef, bool> Results = new Dictionary<TacticalAbilityDef, bool>();
+        }
+
+        private static readonly ConditionalWeakTable<GeoCharacter, MarkerAbilityMemo> _markerMemos =
+            new ConditionalWeakTable<GeoCharacter, MarkerAbilityMemo>();
+
         private static bool HasMarkerAbility(GeoCharacter character, TacticalAbilityDef marker)
         {
-            if (character?.Progression?.Abilities == null || marker == null)
+            IReadOnlyList<TacticalAbilityDef> abilities = character?.Progression?.Abilities;
+            if (abilities == null || marker == null)
             {
                 return false;
             }
 
-            return character.Progression.Abilities.Any(ability => AbilityMatches(ability, marker));
+            MarkerAbilityMemo memo = _markerMemos.GetOrCreateValue(character);
+
+            if (memo.AbilityCount != abilities.Count)
+            {
+                memo.AbilityCount = abilities.Count;
+                memo.Results.Clear();
+            }
+            else if (memo.Results.TryGetValue(marker, out bool cached))
+            {
+                return cached;
+            }
+
+            bool found = false;
+            for (int i = 0; i < abilities.Count; i++)
+            {
+                if (AbilityMatches(abilities[i], marker))
+                {
+                    found = true;
+                    break;
+                }
+            }
+
+            memo.Results[marker] = found;
+            return found;
+        }
+
+        /// <summary>
+        /// Drops the memo for a character whose marker abilities were just changed in place, i.e.
+        /// without the ability count moving.
+        /// </summary>
+        private static void InvalidateMarkerMemo(GeoCharacter character)
+        {
+            if (character == null)
+            {
+                return;
+            }
+
+            if (_markerMemos.TryGetValue(character, out MarkerAbilityMemo memo))
+            {
+                memo.AbilityCount = -1;
+                memo.Results.Clear();
+            }
         }
 
         private static bool AddMarkerAbility(GeoCharacter character, PassiveModifierAbilityDef marker, string markerName)
@@ -194,6 +259,7 @@ namespace TFTV.TFTVBaseRework
             }
 
             character.Progression.AddAbility(marker);
+            InvalidateMarkerMemo(character);
             TFTVLogger.Always($"[{markerName}] Added marker to {character.DisplayName}.");
             return true;
         }
@@ -217,6 +283,7 @@ namespace TFTV.TFTVBaseRework
             int removed = abilities.RemoveAll(ability => AbilityMatches(ability, marker));
             if (removed > 0)
             {
+                InvalidateMarkerMemo(character);
                 TFTVLogger.Always($"[{markerName}] Removed marker from {character.DisplayName}.");
                 return true;
             }

--- a/TFTV/TFTVBaseRework/LivingQuarters.cs
+++ b/TFTV/TFTVBaseRework/LivingQuarters.cs
@@ -70,29 +70,49 @@ internal class LivingQuarters
             }
 
             // ── Heal / stamina rework ────────────────────────────────────────
-            List<HealFacilityComponent> healComponents = layout
-                .QueryFacilitiesWithComponent<HealFacilityComponent>(onlyWorking: true)
-                .Where(component => component.HealSoldier)
-                .ToList();
+            // Single pass: the previous version built three intermediate lists and evaluated
+            // IsLivingQuartersComponent (a Unity GetComponent) twice per facility. This runs on
+            // every base and roster change, so it is worth keeping allocation-free.
+            int livingQuartersCount = 0;
+            int livingQuartersStaminaTotal = 0;
+            int livingQuartersStaminaMax = 0;
 
-            if (healComponents.Count == 0)
+            int medicalCount = 0;
+            int medicalHpTotal = 0;
+            int medicalHpMax = 0;
+
+            foreach (HealFacilityComponent component in layout.QueryFacilitiesWithComponent<HealFacilityComponent>(onlyWorking: true))
             {
-                return;
+                if (component == null || !component.HealSoldier)
+                {
+                    continue;
+                }
+
+                if (IsLivingQuartersComponent(component))
+                {
+                    int stamina = (int)component.StaminaHealOutput;
+                    livingQuartersCount++;
+                    livingQuartersStaminaTotal += stamina;
+                    if (stamina > livingQuartersStaminaMax)
+                    {
+                        livingQuartersStaminaMax = stamina;
+                    }
+                }
+                else
+                {
+                    int hp = (int)component.HealOutput;
+                    medicalCount++;
+                    medicalHpTotal += hp;
+                    if (hp > medicalHpMax)
+                    {
+                        medicalHpMax = hp;
+                    }
+                }
             }
 
-            List<HealFacilityComponent> livingQuarters = healComponents
-                .Where(IsLivingQuartersComponent)
-                .ToList();
-
-            List<HealFacilityComponent> medicalFacilities = healComponents
-                .Where(component => !IsLivingQuartersComponent(component))
-                .ToList();
-
-            if (livingQuarters.Count > 1)
+            if (livingQuartersCount > 1)
             {
-                int totalStamina = livingQuarters.Sum(c => (int)c.StaminaHealOutput);
-                int maxStamina = livingQuarters.Max(c => (int)c.StaminaHealOutput);
-                int reduction = totalStamina - maxStamina;
+                int reduction = livingQuartersStaminaTotal - livingQuartersStaminaMax;
                 if (reduction > 0)
                 {
                     int current = HealSoldiersStaminaField(__instance);
@@ -100,7 +120,15 @@ internal class LivingQuarters
                 }
             }
 
-            AdjustMedicalHealing(__instance, medicalFacilities);
+            if (medicalCount > 1)
+            {
+                int reduction = medicalHpTotal - medicalHpMax;
+                if (reduction > 0)
+                {
+                    int current = HealSoldiersHPField(__instance);
+                    HealSoldiersHPField(__instance) = Math.Max(0, current - reduction);
+                }
+            }
         }
 
         private static bool IsLivingQuartersComponent(HealFacilityComponent component)
@@ -118,25 +146,6 @@ internal class LivingQuarters
 
             ContainerFacilityComponent container = facility.GetComponent<ContainerFacilityComponent>();
             return container != null && container.SoldiersCapacity > 0;
-        }
-
-        private static void AdjustMedicalHealing(PhoenixBaseStats stats, List<HealFacilityComponent> medicalFacilities)
-        {
-            if (medicalFacilities == null || medicalFacilities.Count <= 1)
-            {
-                return;
-            }
-
-            int totalHp = medicalFacilities.Sum(component => (int)component.HealOutput);
-            int maxHp = medicalFacilities.Max(component => (int)component.HealOutput);
-            int reduction = totalHp - maxHp;
-            if (reduction <= 0)
-            {
-                return;
-            }
-
-            int current = HealSoldiersHPField(stats);
-            HealSoldiersHPField(stats) = Math.Max(0, current - reduction);
         }
     }
 }

--- a/TFTV/TFTVHumanEnemies.cs
+++ b/TFTV/TFTVHumanEnemies.cs
@@ -30,6 +30,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using UnityEngine;
 using static PhoenixPoint.Tactical.View.ViewModules.UIModuleCharacterStatus;
 using static PhoenixPoint.Tactical.View.ViewModules.UIModuleCharacterStatus.CharacterData;
@@ -851,15 +852,38 @@ namespace TFTV
         [HarmonyPatch(typeof(TacticalActorBase), "get_DisplayName")]
         public static class TacticalActorBase_GetDisplayName_HumanEnemiesGenerator_Patch
         {
+            private sealed class RankedNameCache
+            {
+                public bool Computed;
+                // null means this actor has no human-enemy rank, which is the case for every
+                // Pandoran and every player soldier.
+                public string RankedName;
+            }
+
+            // DisplayName is read constantly by the tactical UI - health bars, hover, tooltips, the
+            // combat log. The old body allocated a List of the actor's tags (twice, plus two 3-element
+            // arrays and two string Splits) on every single read, including for actors that have no
+            // rank at all. An actor's faction and tier tags are fixed at spawn, so the result is
+            // computed once per actor and reused.
+            private static readonly ConditionalWeakTable<TacticalActorBase, RankedNameCache> _rankedNames =
+                new ConditionalWeakTable<TacticalActorBase, RankedNameCache>();
+
             public static void Postfix(TacticalActorBase __instance, ref string __result)
             {
                 try
                 {
-                    if (GetFactionTierAndClassTags(__instance.GameTags.ToList())[0] != null)
+                    RankedNameCache cache = _rankedNames.GetOrCreateValue(__instance);
+
+                    if (!cache.Computed)
                     {
-                        __result = __instance.name + GetRankName(GetFactionTierAndClassTags(__instance.GameTags.ToList()));
+                        cache.Computed = true;
+                        cache.RankedName = BuildRankedName(__instance);
                     }
 
+                    if (cache.RankedName != null)
+                    {
+                        __result = cache.RankedName;
+                    }
                 }
 
                 catch (Exception e)
@@ -868,8 +892,20 @@ namespace TFTV
                 }
 
             }
+
+            private static string BuildRankedName(TacticalActorBase actor)
+            {
+                GameTagDef[] factionTierAndClass = GetFactionTierAndClassTags(actor.GameTags);
+
+                if (factionTierAndClass[0] == null)
+                {
+                    return null;
+                }
+
+                return actor.name + GetRankName(factionTierAndClass);
+            }
         }
-        public static GameTagDef[] GetFactionTierAndClassTags(List<GameTagDef> data)
+        public static GameTagDef[] GetFactionTierAndClassTags(IEnumerable<GameTagDef> data)
         {
             try
             {
@@ -987,7 +1023,7 @@ namespace TFTV
 
                     //  __instance.ClassIcon.MainClassIcon.color = _regularIconColor;
 
-                    GameTagDef[] factionAndTier = GetFactionTierAndClassTags(data.Tags.ToList());
+                    GameTagDef[] factionAndTier = GetFactionTierAndClassTags(data.Tags);
                     TFTVUI.Tactical.TargetIcons.RemoveRankFromInfoPanel(actorClassIconElement);
 
                     if (factionAndTier[0] != null)
@@ -1177,7 +1213,7 @@ namespace TFTV
             {
                 int startingLevel = tacticalActor.LevelProgression.Level;
                 TFTVLogger.Always("Starting level is " + startingLevel);
-                GameTagDef tierTagDef = GetFactionTierAndClassTags(tacticalActor.GameTags.ToList())[1];
+                GameTagDef tierTagDef = GetFactionTierAndClassTags(tacticalActor.GameTags)[1];
 
                 string rank = tierTagDef.name.Split('_')[1];
                 int rankOrder = int.Parse(rank);
@@ -1427,7 +1463,7 @@ namespace TFTV
                 }
 
                 int level = GetAdjustedLevel(tacticalActor);
-                GameTagDef classTagDef = GetFactionTierAndClassTags(tacticalActor.GameTags.ToList())[2];
+                GameTagDef classTagDef = GetFactionTierAndClassTags(tacticalActor.GameTags)[2];
 
                 AdjustStats(tacticalActor, classTagDef);
 
@@ -1594,7 +1630,7 @@ namespace TFTV
 
             try
             {
-                GameTagDef tierTagDef = GetFactionTierAndClassTags(tacticalActor.GameTags.ToList())[1];
+                GameTagDef tierTagDef = GetFactionTierAndClassTags(tacticalActor.GameTags)[1];
                 string rank = tierTagDef.name.Split('_')[1];
                 int rankOrder = int.Parse(rank);
 

--- a/TFTV/TFTVIncidents/AdvanceWarningHavenAttack.cs
+++ b/TFTV/TFTVIncidents/AdvanceWarningHavenAttack.cs
@@ -7,6 +7,7 @@ using PhoenixPoint.Geoscape.View;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using UnityEngine;
 
 namespace TFTV.TFTVIncidents
@@ -66,7 +67,7 @@ namespace TFTV.TFTVIncidents
 
             public static RiskWindow GetRisk(GeoSite site)
             {
-                if (site == null)
+                if (site == null || SiteRiskById.Count == 0)
                 {
                     return RiskWindow.None;
                 }
@@ -91,7 +92,7 @@ namespace TFTV.TFTVIncidents
             {
                 SiteRiskById.Clear();
 
-               
+
 
                 Dictionary<GeoSite, int> minCounterByHaven = new Dictionary<GeoSite, int>();
 
@@ -180,7 +181,106 @@ namespace TFTV.TFTVIncidents
         {
             private const string MarkerRootName = "HavenAttackRiskMarker";
 
+            private static readonly Color Hours4Color = new Color(1f, 0.2f, 0.2f, 1f);
+            private static readonly Color Hours8Color = new Color(1f, 0.6f, 0.1f, 1f);
+            private static readonly Color Hours12Color = new Color(1f, 0.92f, 0.2f, 1f);
+
+            /// <summary>
+            /// Per-controller marker bookkeeping. This runs from GeoSiteVisualsController.Update, i.e.
+            /// once per site visual per frame, so nothing here may re-discover or re-style the marker
+            /// on every call: Transform.Find is a native child-name search, and assigning TextMesh.text
+            /// or fontSize regenerates the glyph mesh even when the value is unchanged.
+            /// </summary>
+            private sealed class MarkerState
+            {
+                public int SiteId = int.MinValue;
+                public bool Probed;
+                public Transform Marker;
+                public TextMesh Text;
+                public RiskWindow AppliedRisk = RiskWindow.None;
+                public bool AlignedFromTemplate;
+            }
+
+            private static readonly ConditionalWeakTable<GeoSiteVisualsController, MarkerState> MarkerStates =
+                new ConditionalWeakTable<GeoSiteVisualsController, MarkerState>();
+
+            private static Camera _cachedCamera;
+
             public static void RefreshMarker(GeoSiteVisualsController controller, RiskWindow risk)
+            {
+                MarkerState state = MarkerStates.GetOrCreateValue(controller);
+
+                GeoSite site = controller.Site;
+                int siteId = site != null ? site.SiteId : int.MinValue;
+
+                // Site visuals are recycled between sites, so a marker left over from a previous
+                // occupant has to be re-discovered when the controller changes hands.
+                if (state.SiteId != siteId)
+                {
+                    state.SiteId = siteId;
+                    state.Probed = false;
+                }
+
+                if (!state.Probed)
+                {
+                    state.Probed = true;
+                    Transform iconParent = controller.LocationIconParent;
+                    AdoptMarker(state, iconParent != null ? iconParent.Find(MarkerRootName) : null);
+                }
+
+                if (risk == RiskWindow.None)
+                {
+                    DestroyMarker(state);
+                    return;
+                }
+
+                if (state.Marker == null)
+                {
+                    CreateMarker(controller, state);
+                    if (state.Marker == null)
+                    {
+                        return;
+                    }
+                }
+
+                // Re-align until a template transform is actually available: on the frame the marker
+                // is created the site visual's text objects may not be wired up yet.
+                if (!state.AlignedFromTemplate || state.AppliedRisk != risk)
+                {
+                    state.AlignedFromTemplate = AlignMarkerTransform(controller, state.Marker);
+                }
+
+                if (state.AppliedRisk != risk)
+                {
+                    state.AppliedRisk = risk;
+                    EnsureTextVisibility(state.Text);
+                    ApplyRiskStyle(state.Text, risk);
+                }
+
+                // The camera moves every frame so the billboard genuinely has to update every frame,
+                // but only havens that are actually flagged ever get here.
+                FaceMarkerTowardsCamera(state.Marker);
+            }
+
+            private static void AdoptMarker(MarkerState state, Transform existing)
+            {
+                if (existing == null)
+                {
+                    state.Marker = null;
+                    state.Text = null;
+                    state.AppliedRisk = RiskWindow.None;
+                    state.AlignedFromTemplate = false;
+                    return;
+                }
+
+                state.Marker = existing;
+                state.Text = existing.GetComponent<TextMesh>() ?? existing.gameObject.AddComponent<TextMesh>();
+                // The adopted marker's styling is unknown, so force a re-apply on the next refresh.
+                state.AppliedRisk = RiskWindow.None;
+                state.AlignedFromTemplate = false;
+            }
+
+            private static void CreateMarker(GeoSiteVisualsController controller, MarkerState state)
             {
                 Transform iconParent = controller.LocationIconParent;
                 if (iconParent == null)
@@ -188,57 +288,62 @@ namespace TFTV.TFTVIncidents
                     return;
                 }
 
-                Transform existing = iconParent.Find(MarkerRootName);
-                if (risk == RiskWindow.None)
-                {
-                    if (existing != null)
-                    {
-                        UnityEngine.Object.Destroy(existing.gameObject);
-                    }
+                GameObject markerRoot = new GameObject(MarkerRootName);
+                markerRoot.transform.SetParent(iconParent, false);
 
+                TextMesh textMesh = markerRoot.AddComponent<TextMesh>();
+                textMesh.anchor = TextAnchor.MiddleCenter;
+                textMesh.alignment = TextAlignment.Center;
+                textMesh.characterSize = 0.1f;
+                textMesh.fontSize = 64;
+
+                state.Marker = markerRoot.transform;
+                state.Text = textMesh;
+                state.AppliedRisk = RiskWindow.None;
+                state.AlignedFromTemplate = false;
+            }
+
+            private static void DestroyMarker(MarkerState state)
+            {
+                if (state.Marker != null)
+                {
+                    UnityEngine.Object.Destroy(state.Marker.gameObject);
+                }
+
+                state.Marker = null;
+                state.Text = null;
+                state.AppliedRisk = RiskWindow.None;
+                state.AlignedFromTemplate = false;
+            }
+
+            private static void ApplyRiskStyle(TextMesh textMesh, RiskWindow risk)
+            {
+                if (textMesh == null)
+                {
                     return;
                 }
-
-                GameObject markerRoot;
-                TextMesh textMesh;
-                if (existing == null)
-                {
-                    markerRoot = new GameObject(MarkerRootName);
-                    markerRoot.transform.SetParent(iconParent, false);
-
-                    textMesh = markerRoot.AddComponent<TextMesh>();
-                    textMesh.anchor = TextAnchor.MiddleCenter;
-                    textMesh.alignment = TextAlignment.Center;
-                    textMesh.characterSize = 0.1f;
-                    textMesh.fontSize = 64;
-                }
-                else
-                {
-                    markerRoot = existing.gameObject;
-                    textMesh = markerRoot.GetComponent<TextMesh>() ?? markerRoot.AddComponent<TextMesh>();
-                }
-
-                AlignMarkerTransform(controller, markerRoot.transform);
-                EnsureTextVisibility(textMesh);
 
                 switch (risk)
                 {
                     case RiskWindow.Hours4:
                         textMesh.text = "[4h]";
-                        textMesh.color = new Color(1f, 0.2f, 0.2f, 1f);
+                        textMesh.color = Hours4Color;
                         break;
                     case RiskWindow.Hours8:
                         textMesh.text = "[8h]";
-                        textMesh.color = new Color(1f, 0.6f, 0.1f, 1f);
+                        textMesh.color = Hours8Color;
                         break;
                     default:
                         textMesh.text = "[12h]";
-                        textMesh.color = new Color(1f, 0.92f, 0.2f, 1f);
+                        textMesh.color = Hours12Color;
                         break;
                 }
             }
 
-            private static void AlignMarkerTransform(GeoSiteVisualsController controller, Transform marker)
+            /// <summary>
+            /// Returns true when a template transform was found and used.
+            /// </summary>
+            private static bool AlignMarkerTransform(GeoSiteVisualsController controller, Transform marker)
             {
                 Transform template = null;
                 if (controller.SoldiersAvailableCountText != null)
@@ -263,11 +368,16 @@ namespace TFTV.TFTVIncidents
                 float scale = template != null ? Mathf.Max(0.14f, Mathf.Abs(template.localScale.x) * 2.4f) : 0.18f;
                 marker.localScale = new Vector3(scale, scale, scale);
 
-                FaceMarkerTowardsCamera(marker);
+                return template != null;
             }
 
             private static void EnsureTextVisibility(TextMesh textMesh)
             {
+                if (textMesh == null)
+                {
+                    return;
+                }
+
                 textMesh.characterSize = Mathf.Max(textMesh.characterSize, 0.14f);
                 textMesh.fontSize = Mathf.Max(textMesh.fontSize, 90);
                 textMesh.fontStyle = FontStyle.Bold;
@@ -281,13 +391,18 @@ namespace TFTV.TFTVIncidents
 
             private static void FaceMarkerTowardsCamera(Transform marker)
             {
-                Camera mainCamera = Camera.main;
-                if (mainCamera == null)
+                // Camera.main is a tagged-object search on this Unity version, so hold on to it.
+                if (_cachedCamera == null)
+                {
+                    _cachedCamera = Camera.main;
+                }
+
+                if (_cachedCamera == null)
                 {
                     return;
                 }
 
-                Vector3 viewDirection = mainCamera.transform.position - marker.position;
+                Vector3 viewDirection = _cachedCamera.transform.position - marker.position;
                 if (viewDirection.sqrMagnitude < 0.0001f)
                 {
                     return;

--- a/TFTV/TFTVLogFile.cs
+++ b/TFTV/TFTVLogFile.cs
@@ -1,0 +1,165 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace TFTV
+{
+    /// <summary>
+    /// The single writer behind <see cref="TFTVLogger"/> and PRMBetterClasses.PRMLogger, which both
+    /// log to the same file.
+    ///
+    /// Both loggers used to do <c>new StreamWriter(path, append: true)</c> per line, i.e. a CreateFile
+    /// plus seek-to-end for every message. There are thousands of call sites and hundreds of them sit
+    /// inside loops, so that open/close dominated the cost of logging.
+    ///
+    /// The handle is now opened once and kept open with AutoFlush, which hands every line to the OS
+    /// immediately - the same crash-durability the old open/write/close had, without the syscalls.
+    /// </summary>
+    internal static class TFTVLogFile
+    {
+        internal const string Separator = "----------------------------------------------------------------------------------------------------";
+
+        private static readonly object _lock = new object();
+        private static string _path;
+        private static StreamWriter _writer;
+
+        internal static void SetPath(string path)
+        {
+            lock (_lock)
+            {
+                if (string.Equals(_path, path, StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                Close();
+                _path = path;
+            }
+        }
+
+        /// <summary>
+        /// Empties the log and reopens it. Kept so the loggers' Cleanup() behaviour is unchanged.
+        /// </summary>
+        internal static void Truncate()
+        {
+            lock (_lock)
+            {
+                Close();
+                Open(append: false);
+            }
+        }
+
+        /// <summary>
+        /// Writes "<paramref name="prefix"/><paramref name="line"/>" followed by a newline.
+        /// <paramref name="prefix"/> may be null.
+        /// </summary>
+        internal static void WriteLine(string prefix, string line)
+        {
+            lock (_lock)
+            {
+                StreamWriter writer = _writer ?? Open(append: true);
+                if (writer == null)
+                {
+                    return;
+                }
+
+                try
+                {
+                    if (prefix != null)
+                    {
+                        writer.Write(prefix);
+                    }
+
+                    writer.WriteLine(line);
+                }
+                catch (Exception)
+                {
+                    // Logging must never take the game down. Drop the handle so the next call retries.
+                    Close();
+                }
+            }
+        }
+
+        private static StreamWriter Open(bool append)
+        {
+            if (string.IsNullOrEmpty(_path))
+            {
+                return null;
+            }
+
+            try
+            {
+                // FileShare.ReadWrite so players can still open or copy the log while the game runs.
+                FileStream stream = new FileStream(
+                    _path,
+                    append ? FileMode.Append : FileMode.Create,
+                    FileAccess.Write,
+                    FileShare.ReadWrite,
+                    bufferSize: 4096);
+
+                _writer = new StreamWriter(stream, new UTF8Encoding(false))
+                {
+                    AutoFlush = true
+                };
+            }
+            catch (Exception)
+            {
+                _writer = null;
+            }
+
+            return _writer;
+        }
+
+        private static void Close()
+        {
+            if (_writer == null)
+            {
+                return;
+            }
+
+            try
+            {
+                _writer.Dispose();
+            }
+            catch (Exception)
+            {
+                // Nothing useful to do - the writer is being discarded either way.
+            }
+
+            _writer = null;
+        }
+    }
+
+    /// <summary>
+    /// Builds the "[modName @ timestamp] " prefix, rebuilding it only when the second changes.
+    /// The default DateTime.ToString() only has second resolution, so a line written within the
+    /// same second gets a byte-identical prefix to the one the old per-line formatting produced.
+    /// </summary>
+    internal sealed class TFTVLogPrefix
+    {
+        private string _modName;
+        private long _second = -1;
+        private string _cached;
+
+        internal void SetModName(string modName)
+        {
+            _modName = modName;
+            _second = -1;
+            _cached = null;
+        }
+
+        internal string Get()
+        {
+            DateTime now = DateTime.Now;
+            long second = now.Ticks / TimeSpan.TicksPerSecond;
+
+            if (second != _second || _cached == null)
+            {
+                _second = second;
+                _cached = $"[{_modName} @ {now}] ";
+            }
+
+            return _cached;
+        }
+    }
+}

--- a/TFTV/TFTVLogger.cs
+++ b/TFTV/TFTVLogger.cs
@@ -1,25 +1,24 @@
-﻿using Base.Core;
+using Base.Core;
 using Base.UI.MessageBox;
 using System;
-using System.IO;
 
 namespace TFTV
 {
     public class TFTVLogger
     {
-        private static string _logPath;
         private static int _debugLevel;
         private static string _modName;
         private static bool _awake;
 
+        private static readonly TFTVLogPrefix _prefix = new TFTVLogPrefix();
+
         public static void Initialize(string logPath, bool debugLevel, string modDirectory, string modName)
         {
-            _logPath = logPath;
-            if (debugLevel) 
+            if (debugLevel)
             {
                 _debugLevel = 1;
             }
-            else 
+            else
             {
                 _debugLevel = 0;
             }
@@ -27,10 +26,13 @@ namespace TFTV
             _modName = modName;
             _awake = true;
 
+            TFTVLogFile.SetPath(logPath);
+            _prefix.SetModName(modName);
+
             Cleanup();
-            Always("----------------------------------------------------------------------------------------------------", false);
+            Always(TFTVLogFile.Separator, false);
             Always($"Logger.Initialize({logPath}, {debugLevel}, {modDirectory}, {modName})");
-            Always("----------------------------------------------------------------------------------------------------", false);
+            Always(TFTVLogFile.Separator, false);
         }
 
 
@@ -47,12 +49,10 @@ namespace TFTV
 
         public static void Cleanup()
         {
-            using (StreamWriter writer = new StreamWriter(_logPath, false))
-            {
-                writer.WriteLine("----------------------------------------------------------------------------------------------------", false);
-                writer.WriteLine($"[{_modName} @ {DateTime.Now}] CLEANED UP");
-                writer.WriteLine("----------------------------------------------------------------------------------------------------", false);
-            }
+            TFTVLogFile.Truncate();
+            TFTVLogFile.WriteLine(null, TFTVLogFile.Separator);
+            TFTVLogFile.WriteLine(null, $"[{_modName} @ {DateTime.Now}] CLEANED UP");
+            TFTVLogFile.WriteLine(null, TFTVLogFile.Separator);
         }
 
 
@@ -60,13 +60,11 @@ namespace TFTV
         {
             if (_awake && _debugLevel >= 1)
             {
-                using (StreamWriter writer = new StreamWriter(_logPath, true))
-                {
-                    writer.WriteLine("----------------------------------------------------------------------------------------------------", false);
-                    writer.WriteLine($"[{_modName} @ {DateTime.Now}] EXCEPTION:");
-                    writer.WriteLine("Message: " + ex.Message + "<br/>" + Environment.NewLine + "StackTrace: " + ex.StackTrace);
-                    writer.WriteLine("----------------------------------------------------------------------------------------------------", false);
-                }
+                TFTVLogFile.WriteLine(null, TFTVLogFile.Separator);
+                TFTVLogFile.WriteLine(null, $"[{_modName} @ {DateTime.Now}] EXCEPTION:");
+                TFTVLogFile.WriteLine(null, "Message: " + ex.Message + "<br/>" + Environment.NewLine + "StackTrace: " + ex.StackTrace);
+                TFTVLogFile.WriteLine(null, TFTVLogFile.Separator);
+
                 GameUtl.GetMessageBox().ShowSimplePrompt($"<b>An error has occurred in the Terror from the Void mod!</b>\nPlease report it in our #bug-reporting channel at the Terror from the Void Discord server by posting the log you can find at {TFTVMain.LogPath}." +
                     $"\n\n<b>CAUTION:</b>\nContinuing this run may result in unstable behavior or even cause the game to crash", MessageBoxIcon.Warning, MessageBoxButtons.OK, null);
             }
@@ -77,11 +75,7 @@ namespace TFTV
         {
             if (_awake && _debugLevel >= 2)
             {
-                using (StreamWriter writer = new StreamWriter(_logPath, true))
-                {
-                    string prefix = showPrefix ? $"[{_modName} @ {DateTime.Now}] " : "";
-                    writer.WriteLine(prefix + line);
-                }
+                TFTVLogFile.WriteLine(showPrefix ? _prefix.Get() : null, line);
             }
         }
 
@@ -97,11 +91,7 @@ namespace TFTV
 
         public static void Always(string line, bool showPrefix = true)
         {
-            using (StreamWriter writer = new StreamWriter(_logPath, true))
-            {
-                string prefix = showPrefix ? $"[{_modName} @ {DateTime.Now}] " : "";
-                writer.WriteLine(prefix + line);
-            }
+            TFTVLogFile.WriteLine(showPrefix ? _prefix.Get() : null, line);
         }
     }
 }


### PR DESCRIPTION
Profiling the mod by inspection turned up a handful of places doing expensive work far more often than needed. None of these change behaviour; they change how often the work happens.

Logging (TFTVLogFile.cs, TFTVLogger.cs, PRMLogger.cs)

Both loggers opened and closed the log file for every single line - a CreateFile plus seek-to-end per call, across ~2900 call sites, ~420 of which sit inside loops. They also both wrote to the same path, so they now share one writer instead of two handles contending for the file. The handle is opened once and kept open with AutoFlush, which gives the same crash-durability as the old open/write/close (every line still reaches the OS immediately) without the syscalls. FileShare.ReadWrite keeps the log readable while the game runs. The "[mod @ timestamp] " prefix is rebuilt only when the second changes; the default DateTime.ToString() has second resolution, so output is unchanged. Failures to open are now swallowed rather than thrown - logging should never take the game down.

Per-frame Update postfixes

GeoSiteVisualsController.Update and GeoscapeEventSystem.Update are both genuine Unity per-frame Updates (verified against the decompiled game assembly).

- AdvanceWarningHavenAttack: the haven risk marker did a Transform.Find by name every frame for every haven, then rewrote TextMesh.text/fontSize/colour and the whole transform - and assigning TextMesh.text regenerates the glyph mesh even when the value is unchanged. Marker state is now cached per controller (keyed on site id, so recycled site visuals re-probe), the Find happens once per controller, and styling is applied only when the risk level changes. Only the billboard rotation stays per-frame, and only for havens that are actually flagged. Camera.main is cached.

- BaseConstructionVisuals: the map-wide site scan ran every frame. It is now invalidated explicitly on start/complete/rehydrate with a 30-frame safety rescan. SetProgression is only pushed when the range changes - the progression controller animates itself from its own Update, so the per-frame call was redundant and touched renderer materials. Scratch collections are reused, the LINQ is gone, and the GetComponent<GeoLevelController>() lookup is cached. Also drops a GetTimerById call whose only consumer was commented-out logging.

Hot per-call paths

- TFTVArtOfCrab: the AI target-culling helpers hang off consideration evaluation and TacticalAbility.GetTargetActors, so they run per actor x per candidate position x per enemy. They resolved defs by name on every call - eleven lookups plus two GameComponent<SharedData>() calls and an array allocation per target in IsValidTarget alone. Defs are now resolved once into a cache. Six of those lookups were dead (resolved, never read) and are removed. GetDamagePayload() is gated behind the cheap drone/turret name test, an .Any() closure became a plain loop, and GetTargetActors hoists the mass-stomp check and weapon lookup out of the per-target loop.

- TFTVHumanEnemies: the TacticalActorBase.DisplayName postfix allocated a List of the actor's tags twice, plus two 3-element arrays and two string Splits, on every read - including for every Pandoran and player soldier, which have no rank at all. DisplayName is read constantly by the tactical UI. The result is now computed once per actor. GetFactionTierAndClassTags takes IEnumerable<GameTagDef> so the other four call sites drop their .ToList() too.

- TFTVBaseRework/Data: HasMarkerAbility is reached from the GeoPhoenixFaction.Soldiers postfix, so it ran for every soldier on every enumeration of that property, scanning the character's whole ability list with a case-insensitive string compare per ability. Now memoised per character, rechecked when the ability count changes and invalidated on marker add/remove. The name-comparison fallback in AbilityMatches is kept deliberately - it guards against a save holding a pre-reinjection def instance, so removing it would be a behaviour change rather than a cleanup.

- LivingQuarters: PhoenixBaseStats.Update is not a Unity Update (it is called from GeoPhoenixBase.UpdateStats on discrete events), so this is a minor win rather than a frame-rate one, but it was building three intermediate lists and calling GetComponent twice per facility. Rewritten as a single allocation-free pass.