### PR TITLE
Add gamepad navigation to the mod's custom UI

### DIFF
--- a/TFTV/TFTV.csproj
+++ b/TFTV/TFTV.csproj
@@ -190,6 +190,7 @@
     <Compile Include="TFTVDrills\DrillsPublicClasses.cs" />
     <Compile Include="TFTVDrills\DrillsHarmony.cs" />
     <Compile Include="TFTVDrills\DrillsUI.cs" />
+    <Compile Include="TFTVDrills\DrillsUI.ControllerNav.cs" />
     <Compile Include="TFTVDrills\DrillsUI.HeaderContext.cs" />
     <Compile Include="TFTVDrills\DrillsUI.Helpers.cs" />
     <Compile Include="TFTVDrills\DrillsUI.InputHelper.cs" />
@@ -231,12 +232,15 @@
     <Compile Include="TFTVMarketplace\TFTVMarketPlaceItems.cs" />
     <Compile Include="TFTVMarketplace\TFTVMarketPlaceUI.cs" />
     <Compile Include="TFTVMarketplace\TFTVMercenaries.cs" />
+    <Compile Include="TFTVUI\Common\ControllerNav.cs" />
     <Compile Include="TFTVUI\Common\Various.cs" />
     <Compile Include="TFTVUI\Data.cs" />
     <Compile Include="TFTVUI\Geoscape\AircraftOrder.cs" />
     <Compile Include="TFTVUI\Geoscape\ContainmentScreen.cs" />
     <Compile Include="TFTVUI\Geoscape\Facilities.cs" />
     <Compile Include="TFTVUI\Geoscape\MissionDeployment.cs" />
+    <Compile Include="TFTVUI\Geoscape\SiteManagementNav.cs" />
+    <Compile Include="TFTVUI\Home\NewGameOptionsNav.cs" />
     <Compile Include="TFTVUI\Geoscape\TFTVHavenRecruitsUI\HavenRecruitAbilityIconView.cs" />
     <Compile Include="TFTVUI\Geoscape\TFTVHavenRecruitsUI\HavenRecruitAbilityTooltipTrigger.cs" />
     <Compile Include="TFTVUI\Geoscape\TFTVHavenRecruitsUI\HavenRecruitResourceChipView.cs" />

--- a/TFTV/TFTVBaseRework/BaseActivationPersonnelSelection.cs
+++ b/TFTV/TFTVBaseRework/BaseActivationPersonnelSelection.cs
@@ -1,9 +1,14 @@
+using Base.Core;
+using Base.Input;
+using Base.UI;
+using PhoenixPoint.Common.View.ViewControllers;
 using PhoenixPoint.Geoscape.Levels.Factions;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using TFTV.TFTVIncidents;
+using TFTV.TFTVUI.Common;
 using UnityEngine;
 using UnityEngine.UI;
 using Object = UnityEngine.Object;
@@ -206,7 +211,7 @@ namespace TFTV.TFTVBaseRework
                 },
                 out confirmImage);
 
-            CreateButton(
+            Button cancelButton = CreateButton(
                 buttonRow.transform,
                 TFTVCommonMethods.ConvertKeyToString("KEY_BASE_PERSONNEL_SELECT_CANCEL"),
                 CancelColor,
@@ -215,6 +220,126 @@ namespace TFTV.TFTVBaseRework
 
             RefreshFooter(rows, requiredPersonnel, counter, confirmImage, confirmButton);
             LayoutRebuilder.ForceRebuildLayoutImmediate(panelRect);
+
+            SetupControllerNavigation(panel.transform, listContent, confirmButton, cancelButton);
+            _overlay.AddComponent<CancelToCloseWatcher>();
+        }
+
+        /// <summary>
+        /// Two navigable sections - the personnel list, then the Confirm/Cancel row - chained so up and
+        /// down move between them. Both outrank the activation modal underneath (which sits at
+        /// <see cref="ControllerNav.DefaultRootPriority"/>), and the list outranks the buttons so the
+        /// overlay opens with the list focused.
+        /// </summary>
+        private static void SetupControllerNavigation(
+            Transform panel,
+            Transform listContent,
+            Button confirmButton,
+            Button cancelButton)
+        {
+            try
+            {
+                List<Selectable> rowSelectables = new List<Selectable>();
+                for (int i = 0; i < listContent.childCount; i++)
+                {
+                    Button rowButton = listContent.GetChild(i)?.GetComponent<Button>();
+                    if (rowButton != null)
+                    {
+                        rowSelectables.Add(rowButton);
+                    }
+                }
+
+                VerticalScrollRectScroller scroller =
+                    ControllerNav.EnsureVerticalScroller(listContent.GetComponentInParent<ScrollRect>());
+
+                UINavigationalElementsHolder listHolder = CreateHolderObject(panel, "TFTV_PersonnelNav_List");
+                UINavigationalElementsHolder buttonsHolder = CreateHolderObject(panel, "TFTV_PersonnelNav_Buttons");
+
+                ControllerNav.Apply(
+                    buttonsHolder,
+                    new List<Selectable> { confirmButton, cancelButton },
+                    NavigationHolderMode.Horizontal,
+                    rootPriority: 190);
+
+                ControllerNav.Apply(
+                    listHolder,
+                    rowSelectables,
+                    NavigationHolderMode.Vertical,
+                    rootPriority: 200,
+                    loop: false,
+                    scrollController: scroller);
+
+                ControllerNav.LinkSections(listHolder, buttonsHolder);
+            }
+            catch (Exception e)
+            {
+                TFTVLogger.Error(e);
+            }
+        }
+
+        /// <summary>
+        /// Holders navigate an explicit element list, so they need no children of their own - but the
+        /// panel is a vertical layout group, so the host object has to opt out of the layout or it would
+        /// add an empty row.
+        /// </summary>
+        private static UINavigationalElementsHolder CreateHolderObject(Transform panel, string name)
+        {
+            GameObject go = new GameObject(name, typeof(RectTransform));
+            go.SetActive(false);
+            go.transform.SetParent(panel, false);
+            go.AddComponent<LayoutElement>().ignoreLayout = true;
+
+            UINavigationalElementsHolder holder = ControllerNav.EnsureHolder(go);
+            go.SetActive(true);
+            return holder;
+        }
+
+        /// <summary>
+        /// Closes the overlay on the Cancel action, matching what the Cancel button does. Sits ahead of
+        /// the free cursor and the global navigation controller so the modal underneath does not also
+        /// react to the same press.
+        /// </summary>
+        private sealed class CancelToCloseWatcher : MonoBehaviour
+        {
+            private InputController _input;
+
+            private void OnEnable()
+            {
+                try
+                {
+                    _input = GameUtl.GameComponent<InputController>();
+                    _input?.EventHandlers.AddUnique(HandleInput, -110);
+                }
+                catch (Exception e) { TFTVLogger.Error(e); }
+            }
+
+            private void OnDisable()
+            {
+                try
+                {
+                    _input?.EventHandlers.Remove(HandleInput);
+                }
+                catch (Exception e) { TFTVLogger.Error(e); }
+            }
+
+            private bool HandleInput(InputEvent ev)
+            {
+                try
+                {
+                    if (ev.Type != InputEventType.Pressed || ev.Name != "Cancel" || _overlay == null)
+                    {
+                        return false;
+                    }
+
+                    Close();
+                    return true;
+                }
+                catch (Exception e)
+                {
+                    TFTVLogger.Error(e);
+                    return false;
+                }
+            }
         }
 
         private static void RefreshFooter(

--- a/TFTV/TFTVBaseRework/BaseActivationUI.cs
+++ b/TFTV/TFTVBaseRework/BaseActivationUI.cs
@@ -1,4 +1,5 @@
 ﻿using Base.Core;
+using Base.UI;
 using Base.UI.MessageBox;
 using HarmonyLib;
 using PhoenixPoint.Common.Core;
@@ -19,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using TFTV.TFTVUI.Common;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -218,7 +220,15 @@ namespace TFTV.TFTVBaseRework
 
                     Transform root = EnsureButtonsRoot(__instance);
 
+                    // Unregister the navigation holder before the buttons it points at are destroyed.
+                    UINavigationalElementsHolder navHolder = root != null
+                        ? root.GetComponent<UINavigationalElementsHolder>()
+                        : null;
+                    ControllerNav.Release(navHolder);
+
                     ClearChildren(root);
+
+                    List<PhoenixGeneralButton> actionButtons = new List<PhoenixGeneralButton>();
 
                     // Exploration-gate prefix: prepended to tooltips when the base is not yet explored.
                     string exploreFirstPrefix = !isExplored
@@ -237,6 +247,7 @@ namespace TFTV.TFTVBaseRework
                         () => ExecuteAndCloseOnSuccess(modal, () => BaseLowQualityScanning.TryStartLowQualityScan(site, faction)));
                     ApplyCostRow(scanBtn, faction, BaseLowQualityScanning.GetScanCostPack(site), 0);
                     SetButtonTooltip(scanBtn, TFTVCommonMethods.ConvertKeyToString("KEY_BASE_PING_SCAN_TOOLTIP"));
+                    actionButtons.Add(scanBtn);
 
                     PhoenixGeneralButton ransackBtn = CreateClonedActionButton(
                         __instance.Confirm,
@@ -251,6 +262,7 @@ namespace TFTV.TFTVBaseRework
                     }
                     SetButtonTooltip(ransackBtn,
                         $"{exploreFirstPrefix}{TFTVCommonMethods.ConvertKeyToString("KEY_BASE_RANSACK_TOOLTIP")}");
+                    actionButtons.Add(ransackBtn);
 
                     if (!isOutpost)
                     {
@@ -268,6 +280,7 @@ namespace TFTV.TFTVBaseRework
                         ApplyCostRow(outpostBtn, faction, PhoenixBaseVisitFlow.GetOutpostCostPack(), PhoenixBaseVisitFlow.GetOutpostPersonnelCost());
                         SetButtonTooltip(outpostBtn,
                             $"{exploreFirstPrefix}{TFTVCommonMethods.ConvertKeyToString("KEY_BASE_OUTPOST_TOOLTIP")}");
+                        actionButtons.Add(outpostBtn);
                     }
 
                     bool fromOutpost = isOutpost;
@@ -289,8 +302,17 @@ namespace TFTV.TFTVBaseRework
                     SetButtonTooltip(activateBaseBtn, fromOutpost
                         ? $"{exploreFirstPrefix}{TFTVCommonMethods.ConvertKeyToString("KEY_BASE_OUTPOST_UPGRADE_TOOLTIP")}"
                         : $"{exploreFirstPrefix}{TFTVCommonMethods.ConvertKeyToString("KEY_BASE_ACTIVATE_OPTION_TOOLTIP")}");
+                    actionButtons.Add(activateBaseBtn);
 
                     __instance.Confirm.gameObject.SetActive(false);
+
+                    // Register the freshly built buttons so a gamepad can reach them. The vanilla modal
+                    // already owns a nav holder for its facility icons, which would otherwise pin the
+                    // virtual cursor to those and leave these unreachable.
+                    ControllerNav.Apply(
+                        navHolder,
+                        ControllerNav.SelectablesOf(actionButtons),
+                        NavigationHolderMode.Vertical);
 
                     site.RefreshVisuals();
                 }
@@ -618,10 +640,15 @@ namespace TFTV.TFTVBaseRework
                     Transform root = parent.Find(ExtraButtonsRootName);
                     if (root != null)
                     {
+                        ControllerNav.EnsureHolder(root.gameObject);
                         return root;
                     }
 
                     GameObject go = new GameObject(ExtraButtonsRootName, typeof(RectTransform), typeof(VerticalLayoutGroup), typeof(ContentSizeFitter));
+
+                    // Built inactive so the navigation holder can be attached without its OnEnable
+                    // registering an empty element list with UIGlobalNavigationController.
+                    go.SetActive(false);
                     go.transform.SetParent(parent, false);
 
                     RectTransform rt = go.GetComponent<RectTransform>();
@@ -639,6 +666,10 @@ namespace TFTV.TFTVBaseRework
                     ContentSizeFitter fitter = go.GetComponent<ContentSizeFitter>();
                     fitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
                     fitter.horizontalFit = ContentSizeFitter.FitMode.Unconstrained;
+
+                    ControllerNav.EnsureHolder(go);
+
+                    go.SetActive(true);
 
                     return go.transform;
                 }

--- a/TFTV/TFTVDrills/DrillSwapUI.cs
+++ b/TFTV/TFTVDrills/DrillSwapUI.cs
@@ -334,6 +334,8 @@ namespace TFTV.TFTVDrills
 
                 controller.ConfigureContent(viewportRect, contentRect, MenuWidth, MenuMaxHeight);
                 overlay.transform.SetAsLastSibling();
+
+                ControllerNavigation.Setup(overlay, panelRect, contentRect, gridRect, controller);
             }
 
             private static HeaderContext BuildHeaderContext(UIModuleCharacterProgression ui, AbilityTrackSlot slot, TacticalAbilityDef original, bool baseAbilityLearned, AbilityTrack track, int abilityLevel, int baseAbilityCost, AbilityTrackSkillEntryElement entry)

--- a/TFTV/TFTVDrills/DrillsUI.ControllerNav.cs
+++ b/TFTV/TFTVDrills/DrillsUI.ControllerNav.cs
@@ -1,0 +1,212 @@
+using Base.Core;
+using Base.Input;
+using Base.UI;
+using PhoenixPoint.Common.View.ViewControllers;
+using System;
+using System.Collections.Generic;
+using TFTV.TFTVUI.Common;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TFTV.TFTVDrills
+{
+    internal static partial class DrillsUI
+    {
+        /// <summary>
+        /// Gamepad navigation for the drill selection overlay: the header's acquire button as one section,
+        /// the 6-column drill grid as another.
+        ///
+        /// The overlay closes itself when the pointer leaves the panel (see DrillOverlayController's
+        /// LateUpdate), which works in our favour - focusing the grid snaps the virtual cursor inside the
+        /// panel, so it stays open, and every drill the cursor lands on fires its own hover tooltip with
+        /// no extra wiring.
+        /// </summary>
+        private static class ControllerNavigation
+        {
+            internal static void Setup(
+                GameObject overlay,
+                RectTransform panelRect,
+                RectTransform contentRect,
+                RectTransform gridRect,
+                DrillOverlayController controller)
+            {
+                try
+                {
+                    if (overlay == null || contentRect == null)
+                    {
+                        return;
+                    }
+
+                    List<Selectable> gridOptions = CollectGridOptions(gridRect);
+                    List<Selectable> headerButtons = CollectHeaderButtons(contentRect, gridRect);
+
+                    if (gridOptions.Count == 0 && headerButtons.Count == 0)
+                    {
+                        return;
+                    }
+
+                    VerticalScrollRectScroller scroller = panelRect != null
+                        ? ControllerNav.EnsureVerticalScroller(panelRect.GetComponent<ScrollRect>())
+                        : null;
+
+                    UINavigationalElementsHolder headerHolder =
+                        CreateHolderObject(overlay.transform, "TFTV_DrillsNav_Header");
+                    UINavigationalElementsHolder gridHolder =
+                        CreateHolderObject(overlay.transform, "TFTV_DrillsNav_Grid");
+
+                    ControllerNav.Apply(
+                        headerHolder,
+                        headerButtons,
+                        NavigationHolderMode.Horizontal,
+                        rootPriority: 190,
+                        scrollController: scroller);
+
+                    // Grid mode with the same column count the GridLayoutGroup uses, so the built links
+                    // match what is on screen. Never loops, so running off an edge hands over to the
+                    // header section instead of wrapping.
+                    bool gridApplied = ControllerNav.Apply(
+                        gridHolder,
+                        gridOptions,
+                        NavigationHolderMode.Grid,
+                        gridColumns: GridColumns,
+                        rootPriority: 200,
+                        loop: false,
+                        scrollController: scroller);
+
+                    ControllerNav.LinkSections(headerHolder, gridHolder);
+
+                    overlay.AddComponent<OverlayInputWatcher>().Initialize(controller);
+
+                    // Snapping the cursor into the panel is also what keeps the overlay from closing:
+                    // it only stays open while the pointer is near.
+                    ControllerNav.Focus(gridApplied ? gridHolder : headerHolder);
+                }
+                catch (Exception ex) { TFTVLogger.Error(ex); }
+            }
+
+            private static List<Selectable> CollectGridOptions(RectTransform gridRect)
+            {
+                List<Selectable> options = new List<Selectable>();
+
+                if (gridRect == null || !gridRect.gameObject.activeSelf)
+                {
+                    return options;
+                }
+
+                for (int i = 0; i < gridRect.childCount; i++)
+                {
+                    Transform child = gridRect.GetChild(i);
+                    Button button = child != null ? child.GetComponent<Button>() : null;
+                    if (button != null)
+                    {
+                        options.Add(button);
+                    }
+                }
+
+                return options;
+            }
+
+            /// <summary>
+            /// Everything clickable in the header - in practice the acquire button, when the base ability
+            /// has not been bought yet. Excludes the grid, which is its own section.
+            /// </summary>
+            private static List<Selectable> CollectHeaderButtons(RectTransform contentRect, RectTransform gridRect)
+            {
+                List<Selectable> buttons = new List<Selectable>();
+
+                foreach (Button button in contentRect.GetComponentsInChildren<Button>(includeInactive: false))
+                {
+                    if (button == null || (gridRect != null && button.transform.IsChildOf(gridRect)))
+                    {
+                        continue;
+                    }
+
+                    buttons.Add(button);
+                }
+
+                return buttons;
+            }
+
+            private static UINavigationalElementsHolder CreateHolderObject(Transform parent, string name)
+            {
+                GameObject go = new GameObject(name, typeof(RectTransform));
+                go.SetActive(false);
+                go.transform.SetParent(parent, false);
+                go.AddComponent<LayoutElement>().ignoreLayout = true;
+
+                UINavigationalElementsHolder holder = ControllerNav.EnsureHolder(go);
+                go.SetActive(true);
+                return holder;
+            }
+
+            /// <summary>
+            /// Closes the overlay on Cancel, and clears the global navigation suppression flag for as long
+            /// as the overlay is up - holder navigation does nothing at all while that flag is set, and
+            /// whichever screen is underneath may well have set it. The previous value is restored on
+            /// close so the host screen is left as it was found.
+            /// </summary>
+            private sealed class OverlayInputWatcher : MonoBehaviour
+            {
+                private DrillOverlayController _controller;
+                private InputController _input;
+                private UIGlobalNavigationController _globalNavigation;
+                private bool _restoreSuppression;
+
+                internal void Initialize(DrillOverlayController controller)
+                {
+                    _controller = controller;
+                }
+
+                private void OnEnable()
+                {
+                    try
+                    {
+                        _input = GameUtl.GameComponent<InputController>();
+                        _input?.EventHandlers.AddUnique(HandleInput, -110);
+
+                        _globalNavigation = GameUtl.CurrentLevel()?.GetComponent<UIGlobalNavigationController>();
+                        if (_globalNavigation != null && _globalNavigation.SupressInputEvents)
+                        {
+                            _restoreSuppression = true;
+                            _globalNavigation.SupressInputEvents = false;
+                        }
+                    }
+                    catch (Exception ex) { TFTVLogger.Error(ex); }
+                }
+
+                private void OnDisable()
+                {
+                    try
+                    {
+                        _input?.EventHandlers.Remove(HandleInput);
+
+                        if (_restoreSuppression && _globalNavigation != null)
+                        {
+                            _globalNavigation.SupressInputEvents = true;
+                        }
+                    }
+                    catch (Exception ex) { TFTVLogger.Error(ex); }
+                }
+
+                private bool HandleInput(InputEvent ev)
+                {
+                    try
+                    {
+                        if (ev.Type != InputEventType.Pressed || ev.Name != "Cancel" || _controller == null)
+                        {
+                            return false;
+                        }
+
+                        _controller.Close();
+                        return true;
+                    }
+                    catch (Exception ex)
+                    {
+                        TFTVLogger.Error(ex);
+                        return false;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/TFTV/TFTVIncidents/AffinityBenefitChoiceUI.cs
+++ b/TFTV/TFTVIncidents/AffinityBenefitChoiceUI.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
+using TFTV.TFTVUI.Common;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -426,6 +427,47 @@ namespace TFTV.TFTVIncidents
             }
 
             LayoutRebuilder.ForceRebuildLayoutImmediate(rootRect);
+
+            SetupControllerNavigation(root);
+        }
+
+        /// <summary>
+        /// The benefit choice is the active decision while this panel is up, so its buttons outrank the
+        /// encounter screen's own holder underneath and take focus on open. The panel is destroyed when
+        /// the choice is made, which unregisters the holder and hands navigation back.
+        /// </summary>
+        private static void SetupControllerNavigation(GameObject panelRoot)
+        {
+            try
+            {
+                List<Selectable> buttons = new List<Selectable>();
+                foreach (Button button in panelRoot.GetComponentsInChildren<Button>(includeInactive: false))
+                {
+                    if (button != null)
+                    {
+                        buttons.Add(button);
+                    }
+                }
+
+                if (buttons.Count == 0)
+                {
+                    return;
+                }
+
+                GameObject holderObject = new GameObject("TFTV_AffinityChoiceNav", typeof(RectTransform));
+                holderObject.SetActive(false);
+                holderObject.transform.SetParent(panelRoot.transform, false);
+                holderObject.AddComponent<LayoutElement>().ignoreLayout = true;
+
+                UINavigationalElementsHolder holder = ControllerNav.EnsureHolder(holderObject);
+                holderObject.SetActive(true);
+
+                if (ControllerNav.Apply(holder, buttons, NavigationHolderMode.Vertical, rootPriority: 200, loop: false))
+                {
+                    ControllerNav.Focus(holder);
+                }
+            }
+            catch (Exception ex) { TFTVLogger.Error(ex); }
         }
 
         private static void CreateBenefitSelector(

--- a/TFTV/TFTVIncidents/IncidentResolutionUI.cs
+++ b/TFTV/TFTVIncidents/IncidentResolutionUI.cs
@@ -17,6 +17,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using TFTV.TFTVBaseRework;
+using TFTV.TFTVUI.Common;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
@@ -522,9 +523,243 @@ namespace TFTV.TFTVIncidents
 
                     // Shrink choice buttons after approach data is populated to make room for icons.
                     AdjustChoiceButtons(__instance, geoEvent);
+
+                    SetupApproachIconNavigation(__instance);
                 }
 
                 IncidentIntroTutorialPanel.TryShowPanel(__instance, geoEvent);   // ADD THIS LINE after crew list is built, before AdjustChoiceButtons
+            }
+
+            /// <summary>
+            /// Makes the approach icons reachable with a gamepad by laying the encounter screen's own
+            /// navigation holder out as rows: each row is a choice button followed by its approach icons,
+            /// so up and down move between choices and left and right run along a choice's approaches.
+            ///
+            /// This retargets the vanilla holder rather than registering a competing one, so it keeps its
+            /// place in the navigation order and the module's own ForceJoystickCursorToPosition still
+            /// works. It only takes over when there are icons to reach - without them the vanilla grid
+            /// layout is left completely alone.
+            /// </summary>
+            private static void SetupApproachIconNavigation(UIModuleSiteEncounters module)
+            {
+                try
+                {
+                    UINavigationalElementsHolder holder = module?.InteractableElementsHolder;
+                    if (holder == null || module.ChoiceButtonsContainer == null)
+                    {
+                        return;
+                    }
+
+                    List<IList<Selectable>> rows = new List<IList<Selectable>>();
+                    List<int> heads = new List<int>();
+
+                    // Crew list first - it sits above the choices, and picking the operative is the first
+                    // decision. Without it the leader can only be chosen with a mouse.
+                    AddCrewRows(module, rows, heads);
+
+                    bool anyIcons = AddChoiceRows(module, rows, heads);
+
+                    // Nothing mod-specific to reach: leave vanilla's own grid layout completely alone.
+                    if (!anyIcons && rows.Count == 0)
+                    {
+                        return;
+                    }
+
+                    ControllerNav.ApplyRowsToExistingHolder(holder, rows, heads);
+                }
+                catch (Exception ex) { TFTVLogger.Error(ex); }
+            }
+
+            /// <summary>
+            /// The crew grid, chunked into navigation rows the same way it is laid out on screen.
+            /// </summary>
+            private static void AddCrewRows(
+                UIModuleSiteEncounters module,
+                List<IList<Selectable>> rows,
+                List<int> heads)
+            {
+                Transform grid = FindDeepChild(module.transform, CrewGridName);
+
+                // Deliberately not gated on activeInHierarchy: the crew list is built here but its
+                // container is not switched on until the encounter is actually presented, so requiring it
+                // to be live at this point drops every row. Listing not-yet-active elements is what the
+                // game's own holders do - the navigation code skips inactive ones at selection time and
+                // picks them up once they appear.
+                if (grid == null)
+                {
+                    return;
+                }
+
+                List<Selectable> current = new List<Selectable>();
+
+                for (int i = 0; i < grid.childCount; i++)
+                {
+                    Transform child = grid.GetChild(i);
+                    if (child == null || !child.gameObject.activeSelf)
+                    {
+                        continue;
+                    }
+
+                    SoldierSlotController slot = child.GetComponent<SoldierSlotController>();
+                    if (slot == null)
+                    {
+                        continue;
+                    }
+
+                    Selectable selectable = EnsureCrewRowSelectable(slot);
+                    if (selectable == null)
+                    {
+                        continue;
+                    }
+
+                    current.Add(selectable);
+
+                    if (current.Count == GridColumns)
+                    {
+                        rows.Add(current);
+                        heads.Add(0);
+                        current = new List<Selectable>();
+                    }
+                }
+
+                if (current.Count > 0)
+                {
+                    rows.Add(current);
+                    heads.Add(0);
+                }
+            }
+
+            /// <summary>
+            /// Returns the Selectable the cursor should snap to for a crew row, which has to be the row
+            /// root so the cursor lands on the whole row rather than some sub-element of the vanilla
+            /// prefab. If the root carries no Selectable of its own, one is added and wired straight to
+            /// the row's ActorSelected callback - the prefab's own click handler is private, so relying on
+            /// it being reachable from wherever the cursor happens to land is not safe.
+            /// </summary>
+            private static Selectable EnsureCrewRowSelectable(SoldierSlotController slot)
+            {
+                Selectable existing = slot.GetComponent<Selectable>();
+                if (existing != null)
+                {
+                    return existing;
+                }
+
+                Button button = slot.gameObject.AddComponent<Button>();
+                button.transition = Selectable.Transition.None;
+
+                Graphic graphic = slot.GetComponent<Graphic>();
+                if (graphic != null)
+                {
+                    button.targetGraphic = graphic;
+                }
+
+                SoldierSlotController captured = slot;
+                button.onClick.AddListener(() =>
+                {
+                    try
+                    {
+                        captured.ActorSelected?.Invoke(captured.Soldier);
+                    }
+                    catch (Exception ex) { TFTVLogger.Error(ex); }
+                });
+
+                return button;
+            }
+
+            /// <summary>
+            /// One row per choice: the choice button plus its approach icons, ordered by where they
+            /// actually sit on screen. Choice 0 wears its icons on the left and choice 1 on the right, so
+            /// a fixed order would send the stick the wrong way for one of them. The choice button stays
+            /// the row's head regardless, so vertical movement always lands back on the choice itself.
+            /// </summary>
+            /// <returns>True if any approach icon was found.</returns>
+            private static bool AddChoiceRows(
+                UIModuleSiteEncounters module,
+                List<IList<Selectable>> rows,
+                List<int> heads)
+            {
+                SiteBaseChoiceButton[] buttons =
+                    module.ChoiceButtonsContainer.GetComponentsInChildren<SiteBaseChoiceButton>(includeInactive: false);
+
+                List<Selectable> all = new List<Selectable>();
+                HashSet<Selectable> choiceSelectables = new HashSet<Selectable>();
+                bool anyIcons = false;
+
+                foreach (SiteBaseChoiceButton button in buttons)
+                {
+                    if (button == null)
+                    {
+                        continue;
+                    }
+
+                    Selectable choiceSelectable = button.Button != null
+                        ? (button.Button.BaseButton ?? button.Button.GetComponent<Selectable>())
+                        : button.GetComponent<Selectable>();
+
+                    if (choiceSelectable != null)
+                    {
+                        all.Add(choiceSelectable);
+                        choiceSelectables.Add(choiceSelectable);
+                    }
+
+                    Transform iconsRoot = button.transform.Find(ChoiceIconsRootName);
+                    if (iconsRoot == null || !iconsRoot.gameObject.activeSelf)
+                    {
+                        continue;
+                    }
+
+                    for (int i = 0; i < iconsRoot.childCount; i++)
+                    {
+                        Transform icon = iconsRoot.GetChild(i);
+                        if (icon == null || !icon.gameObject.activeSelf)
+                        {
+                            continue;
+                        }
+
+                        Button iconButton = icon.GetComponent<Button>();
+                        if (iconButton != null && iconButton.interactable)
+                        {
+                            all.Add(iconButton);
+                            anyIcons = true;
+                        }
+                    }
+                }
+
+                // Grouped by screen position, not by which button owns what: two choices sit side by side
+                // on one line, each wearing its approach icons on its outer edge, so the whole line is one
+                // navigation row - icons, choice, choice, icons - and left/right walks it in visual order.
+                foreach (IList<Selectable> row in ControllerNav.GroupIntoRowsByPosition(all))
+                {
+                    // The row's head is its first actual choice, so vertical movement always lands on a
+                    // choice rather than on one of the approach icons flanking it.
+                    int head = 0;
+                    for (int i = 0; i < row.Count; i++)
+                    {
+                        if (choiceSelectables.Contains(row[i]))
+                        {
+                            head = i;
+                            break;
+                        }
+                    }
+
+                    rows.Add(row);
+                    heads.Add(head);
+                }
+
+                return anyIcons;
+            }
+
+            private static Transform FindDeepChild(Transform root, string name)
+            {
+                foreach (Transform child in root.GetComponentsInChildren<Transform>(includeInactive: true))
+                {
+                    if (child != null && child.name == name)
+                    {
+                        return child;
+                    }
+                }
+
+                return null;
             }
 
             private static void UpdateChoiceButtonsForSelectedOperative(
@@ -581,6 +816,11 @@ namespace TFTV.TFTVIncidents
 
                     ApplyChoiceIcons(button, i);
                 }
+
+                // ApplyChoiceIcons resets every icon's navigation to Mode.None, which strips the row links
+                // and leaves the cursor with nowhere to go once it lands on an icon. This runs on every
+                // leader change, so the layout has to be rewritten each time.
+                SetupApproachIconNavigation(module);
             }
 
             private static ChoiceButtonVisualState EnsureChoiceButtonVisualState(SiteBaseChoiceButton button)

--- a/TFTV/TFTVMarketplace/TFTVMarketPlaceUI.cs
+++ b/TFTV/TFTVMarketplace/TFTVMarketPlaceUI.cs
@@ -1,6 +1,7 @@
 ﻿using Assets.Code.PhoenixPoint.Geoscape.Entities.Sites.TheMarketplace;
 using Base;
 using Base.Core;
+using Base.UI;
 using com.ootii.Collections;
 using HarmonyLib;
 using PhoenixPoint.Common.View.ViewControllers;
@@ -14,6 +15,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using TFTV.TFTVUI.Common;
 using TFTV.Vehicles.Ammo;
 using UnityEngine;
 using UnityEngine.UI;
@@ -390,12 +392,127 @@ namespace TFTV
                         otherToggle.GetComponent<RectTransform>().sizeDelta = new Vector2(allToggle.GetComponent<RectTransform>().sizeDelta.x, allToggle.GetComponent<RectTransform>().sizeDelta.y);
                         otherToggle.transform.GetComponentsInChildren<Image>().FirstOrDefault(c => c.name == "Icon").sprite = Helper.CreateSpriteFromImageFile("Geoscape_Icon_Research.png");
 
+                        // Records the toggles in screen order (top row left to right, then bottom row) and
+                        // arms the guard above - without this assignment the guard never fires and every
+                        // UpdateVisuals stacks another four toggles on top of the previous set.
+                        _filterToggles.Clear();
+                        _filterToggles.Add(vehicleToggle);
+                        _filterToggles.Add(equipmentToggle);
+                        _filterToggles.Add(otherToggle);
+                        _filterToggles.Add(allToggle);
+                        MarketToggleButton = allToggle;
                     }
 
+                    AppendFiltersToNavigation();
                 }
                 catch (Exception e)
                 {
                     TFTVLogger.Error(e);
+                }
+            }
+
+            private static readonly List<PhoenixGeneralButton> _filterToggles = new List<PhoenixGeneralButton>();
+
+            private static UINavigationalElementsHolder _filterNavHolder;
+
+            /// <summary>
+            /// The filter toggles sit as a 2x2 block to the right of the offer list, so they get their own
+            /// holder linked to the right of the Marketplace's: pressing right from any offer moves onto
+            /// the filters, pressing left goes back to the list. Within the block, left and right run along
+            /// a row and up and down move between the two rows, matching the layout on screen.
+            ///
+            /// The offer list itself keeps the vanilla holder - retargeted so each offer is its own row,
+            /// which is what makes running off its right edge hand over to the filters.
+            ///
+            /// The filter holder is deliberately not a root: it must never take focus when the screen
+            /// opens, only when the player navigates into it.
+            /// </summary>
+            internal static void AppendFiltersToNavigation()
+            {
+                try
+                {
+                    UIModuleTheMarketplace marketplaceUI =
+                        GameUtl.CurrentLevel()?.GetComponent<GeoLevelController>()?.View?.GeoscapeModules?.TheMarketplaceModule;
+
+                    UINavigationalElementsHolder offersHolder = marketplaceUI?.InteractableElementsHolder;
+                    if (offersHolder == null || offersHolder.GlobalNavigation == null)
+                    {
+                        return;
+                    }
+
+                    List<Selectable> filters = new List<Selectable>();
+                    foreach (PhoenixGeneralButton toggle in _filterToggles)
+                    {
+                        Selectable selectable = toggle != null
+                            ? (toggle.BaseButton ?? toggle.GetComponent<Selectable>())
+                            : null;
+
+                        if (selectable != null && selectable.gameObject.activeInHierarchy)
+                        {
+                            filters.Add(selectable);
+                        }
+                    }
+
+                    if (filters.Count == 0)
+                    {
+                        return;
+                    }
+
+                    // One row per offer, so left and right fall off the edge and reach the filters.
+                    List<IList<Selectable>> offerRows = new List<IList<Selectable>>();
+                    if (offersHolder.InteractiveList != null)
+                    {
+                        foreach (Selectable offer in offersHolder.InteractiveList)
+                        {
+                            if (offer != null && !filters.Contains(offer))
+                            {
+                                offerRows.Add(new List<Selectable> { offer });
+                            }
+                        }
+                    }
+
+                    if (offerRows.Count > 0)
+                    {
+                        ControllerNav.ApplyRowsToExistingHolder(offersHolder, offerRows);
+                    }
+
+                    if (_filterNavHolder == null)
+                    {
+                        GameObject holderObject = new GameObject("TFTV_MarketplaceFilterNav", typeof(RectTransform));
+                        holderObject.SetActive(false);
+                        holderObject.transform.SetParent(marketplaceUI.transform, false);
+                        holderObject.AddComponent<LayoutElement>().ignoreLayout = true;
+
+                        _filterNavHolder = ControllerNav.EnsureHolder(holderObject);
+                        holderObject.SetActive(true);
+                    }
+
+                    // A real 2x2 grid of equivalent cells, so up and down keep the column rather than
+                    // dropping onto the row head: down from EQUIPMENT reaches ALL, not OTHER.
+                    ControllerNav.ApplyRows(
+                        _filterNavHolder,
+                        ControllerNav.GroupIntoRowsByPosition(filters),
+                        isRoot: false,
+                        verticalLinking: RowVerticalLinking.SameColumn);
+
+                    ControllerNav.LinkHorizontally(offersHolder, _filterNavHolder);
+                }
+                catch (Exception e)
+                {
+                    TFTVLogger.Error(e);
+                }
+            }
+
+            /// <summary>
+            /// Vanilla rebuilds the holder's element list here from the offer buttons alone, which drops
+            /// the filter toggles; they have to be put back after every encounter change.
+            /// </summary>
+            [HarmonyPatch(typeof(UIModuleTheMarketplace), "SetEncounter")]
+            public static class UIModuleTheMarketplace_SetEncounter_FilterNav_patch
+            {
+                public static void Postfix()
+                {
+                    AppendFiltersToNavigation();
                 }
             }
 

--- a/TFTV/TFTVNewGameMenu.cs
+++ b/TFTV/TFTVNewGameMenu.cs
@@ -1282,6 +1282,10 @@ float lengthScale, List<ModSettingController> optionsType = null)
 
                         SetAllVisibility(false);
                         DefaultDifficulties.UpdateOptionsOnSelectingDifficutly();
+
+                        // Called from here rather than a second postfix so it is guaranteed to run after
+                        // every row above has been created; Harmony does not order postfixes on its own.
+                        TFTVUI.Home.NewGameOptionsNav.Setup(__instance, rectTransform);
                     }
                     catch (Exception e)
                     {

--- a/TFTV/TFTVUI/Common/ControllerNav.cs
+++ b/TFTV/TFTVUI/Common/ControllerNav.cs
@@ -1,0 +1,827 @@
+using Base.Core;
+using Base.Input;
+using Base.UI;
+using PhoenixPoint.Common.View.ViewControllers;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TFTV.TFTVUI.Common
+{
+    /// <summary>
+    /// How vertical movement behaves between rows published by <see cref="ControllerNav.ApplyRows"/>.
+    /// </summary>
+    internal enum RowVerticalLinking
+    {
+        /// <summary>
+        /// Up and down land on the neighbouring row's head element. Right for ragged rows built around
+        /// one primary control - a recruit's name flanked by icons, a choice flanked by its approaches -
+        /// where the columns do not line up and landing on the primary control is what reads correctly.
+        /// </summary>
+        RowHead,
+
+        /// <summary>
+        /// Up and down stay in the same column, clamping to the last element when the neighbouring row is
+        /// shorter. Right for an actual grid of equivalent cells.
+        /// </summary>
+        SameColumn
+    }
+
+    /// <summary>
+    /// Makes mod-built UI reachable with a gamepad.
+    ///
+    /// Phoenix Point drives its controller UI through <see cref="UIGlobalNavigationController"/>: a panel
+    /// registers a <see cref="UINavigationalElementsHolder"/>, the holder exposes a list of
+    /// <see cref="Selectable"/>s, and the stick/D-pad moves the virtual cursor
+    /// (<see cref="SlimUI.ConsoleCursors.FreeCursorController"/>) from one of them to the next. The cursor
+    /// is what actually clicks, so anything the holder does not list can never be reached once a root
+    /// holder is active - free cursor movement is switched off for as long as one is registered.
+    ///
+    /// Nothing the mod builds registers a holder, which is why none of it responds to a controller.
+    /// Attach a holder with <see cref="EnsureHolder"/> when the panel is built, call <see cref="Apply"/>
+    /// once its buttons exist, and <see cref="Release"/> before tearing them down.
+    /// </summary>
+    internal static class ControllerNav
+    {
+        /// <summary>
+        /// Root priority for mod panels. Vanilla holders are authored in the scene and sit well below
+        /// this, so a mod panel opened on top of a vanilla screen takes navigation focus.
+        /// </summary>
+        internal const int DefaultRootPriority = 100;
+
+        /// <summary>
+        /// Navigation layer for mod panels. The global controller's priority fallbacks
+        /// (<see cref="EmptyNavLinkBehaviour"/>) only ever consider holders on the same layer, so keeping
+        /// mod holders off layer 0 stops a section switch from escaping into a vanilla screen underneath.
+        /// </summary>
+        internal const int ModNavigationLayer = 17;
+
+        private static readonly FieldInfo ScrollerInterpolationCurveField =
+            typeof(VerticalScrollRectScroller).GetField("_interpolationCurve", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        /// <summary>
+        /// Attaches a dormant holder to <paramref name="panel"/>, leaving it disabled so it does not
+        /// register with an empty element list. Cheapest when <paramref name="panel"/> is still inactive;
+        /// on a live object the component is added behind a brief deactivation so its OnEnable does not
+        /// run before the holder is configured.
+        /// </summary>
+        internal static UINavigationalElementsHolder EnsureHolder(GameObject panel)
+        {
+            try
+            {
+                if (panel == null)
+                {
+                    return null;
+                }
+
+                UINavigationalElementsHolder holder = panel.GetComponent<UINavigationalElementsHolder>();
+                if (holder != null)
+                {
+                    return holder;
+                }
+
+                bool wasActive = panel.activeSelf;
+                if (wasActive)
+                {
+                    panel.SetActive(false);
+                }
+
+                holder = panel.AddComponent<UINavigationalElementsHolder>();
+                holder.enabled = false;
+                holder.transition = Selectable.Transition.None;
+                holder.navigation = new Navigation { mode = Navigation.Mode.None };
+
+                if (wasActive)
+                {
+                    panel.SetActive(true);
+                }
+
+                return holder;
+            }
+            catch (Exception ex)
+            {
+                TFTVLogger.Error(ex);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Publishes <paramref name="items"/> as the holder's navigable elements and registers it as the
+        /// active navigation root. Re-registers cleanly if the holder was already live, so it is safe to
+        /// call again whenever the panel's contents are rebuilt.
+        /// </summary>
+        /// <returns>True when the holder ended up registered with at least one element.</returns>
+        internal static bool Apply(
+            UINavigationalElementsHolder holder,
+            IList<Selectable> items,
+            NavigationHolderMode mode = NavigationHolderMode.Vertical,
+            int gridColumns = 0,
+            int rootPriority = DefaultRootPriority,
+            bool loop = true,
+            int navigationLayer = ModNavigationLayer,
+            VerticalScrollRectScroller scrollController = null)
+        {
+            try
+            {
+                if (!Configure(holder, items, mode, gridColumns, rootPriority, loop, navigationLayer, scrollController))
+                {
+                    return false;
+                }
+
+                holder.enabled = true;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                TFTVLogger.Error(ex);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Publishes a set of rows - each a left-to-right run of elements - and registers the holder.
+        /// Vertical movement always lands on the first element of a row, horizontal movement runs along it.
+        ///
+        /// Uses <see cref="NavigationHolderMode.Grid"/> because it is the only mode whose links the global
+        /// controller honours on all four axes: in Vertical mode a left or right press unconditionally
+        /// switches section, and in Horizontal mode so does up or down. The holder's own grid builder
+        /// cannot express rows of differing lengths, so the links are rewritten here afterwards - nothing
+        /// reads <see cref="UINavigationalElementsHolder.InteractableGridView"/> during navigation.
+        /// </summary>
+        /// <returns>True when the holder ended up registered with at least one element.</returns>
+        internal static bool ApplyRows(
+            UINavigationalElementsHolder holder,
+            IList<IList<Selectable>> rows,
+            IList<int> headIndices = null,
+            int rootPriority = DefaultRootPriority,
+            bool isRoot = true,
+            int navigationLayer = ModNavigationLayer,
+            VerticalScrollRectScroller scrollController = null,
+            RowVerticalLinking verticalLinking = RowVerticalLinking.RowHead)
+        {
+            try
+            {
+                List<IList<Selectable>> validRows = new List<IList<Selectable>>();
+                List<int> validHeads = new List<int>();
+                List<Selectable> flattened = new List<Selectable>();
+                CollectRows(rows, headIndices, validRows, validHeads, flattened);
+
+                // Never loops: the global controller only offers a section switch when a link comes back
+                // null, so wrapping around would trap the cursor inside this holder forever.
+                if (!Configure(holder, flattened, NavigationHolderMode.Grid, 1, rootPriority, loop: false,
+                        navigationLayer: navigationLayer, scrollController: scrollController, isRoot: isRoot))
+                {
+                    return false;
+                }
+
+                WriteRowLinks(validRows, validHeads, verticalLinking);
+
+                holder.enabled = true;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                TFTVLogger.Error(ex);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Gives an existing holder - typically one the game authored and already registered - a row
+        /// layout, without touching its registration at all: IsRoot, priority, layer and enabled state are
+        /// left exactly as the game set them, so it keeps its place in the navigation order and whatever
+        /// focus handling the owning screen does still applies.
+        ///
+        /// Use this to weave mod-added elements into a vanilla screen rather than competing with it.
+        /// </summary>
+        internal static bool ApplyRowsToExistingHolder(
+            UINavigationalElementsHolder holder,
+            IList<IList<Selectable>> rows,
+            IList<int> headIndices = null,
+            RowVerticalLinking verticalLinking = RowVerticalLinking.RowHead)
+        {
+            try
+            {
+                if (holder == null)
+                {
+                    return false;
+                }
+
+                List<IList<Selectable>> validRows = new List<IList<Selectable>>();
+                List<int> validHeads = new List<int>();
+                List<Selectable> flattened = new List<Selectable>();
+                CollectRows(rows, headIndices, validRows, validHeads, flattened);
+
+                if (flattened.Count == 0)
+                {
+                    return false;
+                }
+
+                holder.InteractableContainers = null;
+                holder.NavigationMode = NavigationHolderMode.Grid;
+                holder.GridColumns = 1;
+
+                // Re-publishing the element list makes the global controller reselect the holder's first
+                // element, which would yank the cursor back to the top of the panel. When the same
+                // elements are simply being relaid out - a host screen that rebuilds its widgets and
+                // resets their navigation - only the links need rewriting, and the cursor stays put.
+                if (!SameElements(holder.InteractiveList, flattened))
+                {
+                    holder.SetFixedInteractableElements(flattened);
+                }
+
+                WriteRowLinks(validRows, validHeads, verticalLinking);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                TFTVLogger.Error(ex);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Finds the holder that already lists <paramref name="element"/> - the way to discover which
+        /// authored holder owns a region of a vanilla screen, when a mod button has been dropped into it
+        /// and needs to join the same list.
+        /// </summary>
+        internal static UINavigationalElementsHolder FindHolderContaining(Selectable element)
+        {
+            try
+            {
+                if (element == null)
+                {
+                    return null;
+                }
+
+                // Usually the holder sits on an ancestor of the elements it owns.
+                UINavigationalElementsHolder holder = element.GetComponentInParent<UINavigationalElementsHolder>();
+                if (holder != null && holder.Contains(element))
+                {
+                    return holder;
+                }
+
+                Transform root = element.transform.root;
+                foreach (UINavigationalElementsHolder candidate in
+                         root.GetComponentsInChildren<UINavigationalElementsHolder>(includeInactive: true))
+                {
+                    if (candidate != null && candidate.Contains(element))
+                    {
+                        return candidate;
+                    }
+                }
+
+                return null;
+            }
+            catch (Exception ex)
+            {
+                TFTVLogger.Error(ex);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Splices one element into an existing holder's list, immediately after
+        /// <paramref name="insertAfter"/>, without touching the holder's registration.
+        ///
+        /// The position is given explicitly because the holder links its elements in list order, so list
+        /// order has to match what is on screen - getting it wrong rewires the neighbouring elements too,
+        /// which reads as the screen's own buttons breaking rather than as a misplaced newcomer.
+        ///
+        /// Does nothing when the element is already in the right place, so this is safe to call on every
+        /// refresh: re-publishing the list would otherwise pull focus back to the top of the panel.
+        /// </summary>
+        internal static bool InsertIntoExistingHolder(
+            UINavigationalElementsHolder holder,
+            Selectable element,
+            Selectable insertAfter)
+        {
+            try
+            {
+                if (holder == null || element == null || holder.GlobalNavigation == null)
+                {
+                    return false;
+                }
+
+                // A holder driven by InteractableContainers rebuilds its list from the hierarchy every
+                // refresh and ignores FixedInteractableElements entirely. Publishing a fixed list there
+                // would be dead weight at best, and would fight the holder's own rebuild at worst - a
+                // refresh is all it needs to notice a new child.
+                if (holder.InteractableContainers != null && holder.InteractableContainers.Count > 0)
+                {
+                    holder.RefreshInteractableList();
+                    return holder.Contains(element);
+                }
+
+                List<Selectable> elements = new List<Selectable>();
+                if (holder.InteractiveList != null)
+                {
+                    elements.AddRange(holder.InteractiveList);
+                }
+
+                // Refuse to publish a list that would drop what the holder already owns: without the
+                // anchor present this is not the right holder, or its list has not been built yet, and
+                // replacing it would strip the screen's own buttons out of navigation.
+                if (insertAfter == null || !elements.Contains(insertAfter))
+                {
+                    return false;
+                }
+
+                int target = elements.IndexOf(insertAfter) + 1;
+
+                int existing = elements.IndexOf(element);
+                if (existing == target)
+                {
+                    return true;
+                }
+
+                if (existing >= 0)
+                {
+                    elements.RemoveAt(existing);
+                    if (existing < target)
+                    {
+                        target--;
+                    }
+                }
+
+                elements.Insert(Mathf.Clamp(target, 0, elements.Count), element);
+                holder.SetFixedInteractableElements(elements);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                TFTVLogger.Error(ex);
+                return false;
+            }
+        }
+
+        private static bool SameElements(IList<Selectable> current, IList<Selectable> candidate)
+        {
+            if (current == null || current.Count != candidate.Count)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < candidate.Count; i++)
+            {
+                if (current[i] != candidate[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static void CollectRows(
+            IList<IList<Selectable>> rows,
+            IList<int> headIndices,
+            List<IList<Selectable>> validRows,
+            List<int> validHeads,
+            List<Selectable> flattened)
+        {
+            if (rows == null)
+            {
+                return;
+            }
+
+            for (int r = 0; r < rows.Count; r++)
+            {
+                IList<Selectable> row = rows[r];
+                if (row == null)
+                {
+                    continue;
+                }
+
+                int requestedHead = headIndices != null && r < headIndices.Count ? headIndices[r] : 0;
+                int head = 0;
+
+                List<Selectable> validRow = new List<Selectable>();
+                for (int i = 0; i < row.Count; i++)
+                {
+                    if (row[i] == null)
+                    {
+                        continue;
+                    }
+
+                    // Tracked while filtering so the head survives nulls being dropped.
+                    if (i == requestedHead)
+                    {
+                        head = validRow.Count;
+                    }
+
+                    validRow.Add(row[i]);
+                }
+
+                if (validRow.Count > 0)
+                {
+                    validRows.Add(validRow);
+                    validHeads.Add(Mathf.Clamp(head, 0, validRow.Count - 1));
+                    flattened.AddRange(validRow);
+                }
+            }
+        }
+
+        private static void WriteRowLinks(
+            List<IList<Selectable>> validRows,
+            List<int> heads,
+            RowVerticalLinking verticalLinking)
+        {
+            for (int r = 0; r < validRows.Count; r++)
+            {
+                IList<Selectable> row = validRows[r];
+                IList<Selectable> rowAbove = r > 0 ? validRows[r - 1] : null;
+                IList<Selectable> rowBelow = r < validRows.Count - 1 ? validRows[r + 1] : null;
+
+                for (int i = 0; i < row.Count; i++)
+                {
+                    Navigation navigation = row[i].navigation;
+                    navigation.mode = Navigation.Mode.Explicit;
+                    navigation.selectOnLeft = i > 0 ? row[i - 1] : null;
+                    navigation.selectOnRight = i < row.Count - 1 ? row[i + 1] : null;
+                    navigation.selectOnUp = PickVerticalTarget(rowAbove, r > 0 ? heads[r - 1] : 0, i, verticalLinking);
+                    navigation.selectOnDown = PickVerticalTarget(rowBelow, r < validRows.Count - 1 ? heads[r + 1] : 0, i, verticalLinking);
+                    row[i].navigation = navigation;
+                }
+            }
+        }
+
+        private static Selectable PickVerticalTarget(
+            IList<Selectable> targetRow,
+            int targetHead,
+            int column,
+            RowVerticalLinking verticalLinking)
+        {
+            if (targetRow == null)
+            {
+                return null;
+            }
+
+            if (verticalLinking == RowVerticalLinking.SameColumn)
+            {
+                return targetRow[Mathf.Min(column, targetRow.Count - 1)];
+            }
+
+            return targetRow[targetHead];
+        }
+
+        /// <summary>
+        /// Shared setup for <see cref="Apply"/> and <see cref="ApplyRows"/>: validates the elements and
+        /// writes the holder's configuration, leaving it dormant so the caller can adjust links before
+        /// anything registers with the global controller.
+        /// </summary>
+        private static bool Configure(
+            UINavigationalElementsHolder holder,
+            IList<Selectable> items,
+            NavigationHolderMode mode,
+            int gridColumns,
+            int rootPriority,
+            bool loop,
+            int navigationLayer,
+            VerticalScrollRectScroller scrollController,
+            bool isRoot = true)
+        {
+            if (holder == null)
+            {
+                return false;
+            }
+
+            // Nulls only: vanilla holders list inactive and non-interactable elements too (the
+            // activation modal's own facility icons are non-interactable), and the global
+            // controller skips them at selection time via GetFirstActiveElement.
+            List<Selectable> valid = new List<Selectable>();
+            if (items != null)
+            {
+                foreach (Selectable item in items)
+                {
+                    if (item != null)
+                    {
+                        valid.Add(item);
+                    }
+                }
+            }
+
+            // Unregister first: reconfiguring a live holder would leave a stale entry in the
+            // global controller's root list.
+            Release(holder);
+
+            if (valid.Count == 0)
+            {
+                return false;
+            }
+
+            holder.IsRoot = isRoot;
+            holder.RootPriority = rootPriority;
+            holder.NavigationLayer = navigationLayer;
+            holder.NavigationMode = mode;
+            holder.GridColumns = mode == NavigationHolderMode.Grid ? Math.Max(1, gridColumns) : 0;
+            holder.IsLoopingVertical = loop;
+            holder.IsLoopingHorizontal = loop;
+
+            // Lets ForceCursorToPosition scroll a selected element into view instead of parking the
+            // virtual cursor outside the viewport.
+            holder.ScrollController = scrollController;
+
+            // InitInteractableList prefers InteractableContainers, then FixedInteractableElements,
+            // and only falls back to scanning direct children. Clearing the containers keeps it on
+            // the explicit list, which is the only reliable option for dynamically built panels.
+            holder.InteractableContainers = null;
+            holder.FixedInteractableElements = valid;
+
+            // Build the list and the explicit Navigation links while still dormant, so OnEnable
+            // finds a populated holder.
+            holder.RefreshInteractableList();
+            return true;
+        }
+
+        /// <summary>
+        /// Unregisters the holder from <see cref="UIGlobalNavigationController"/>, restoring the previous
+        /// navigation root and re-enabling free cursor movement. Call before destroying the elements the
+        /// holder points at.
+        /// </summary>
+        internal static void Release(UINavigationalElementsHolder holder)
+        {
+            try
+            {
+                if (holder == null || !holder.enabled)
+                {
+                    return;
+                }
+
+                // The holder's OnDisable reaches for the level's navigation controller without a null
+                // check, so disabling one while the level is being torn down throws. Leaving it enabled
+                // is harmless there - it is about to be destroyed with everything else.
+                if (GameUtl.CurrentLevel() == null)
+                {
+                    return;
+                }
+
+                holder.enabled = false;
+            }
+            catch (Exception ex)
+            {
+                TFTVLogger.Error(ex);
+            }
+        }
+
+        /// <summary>
+        /// Forces navigation focus onto an already-applied holder and parks the virtual cursor on its
+        /// first element.
+        ///
+        /// Registering a holder is not enough on its own: Add() only makes one current when its priority
+        /// strictly exceeds the current root's, so a holder deliberately ranked below the panels it opens
+        /// can be accepted and then ignored. ForceSelect bypasses that comparison, and free cursor
+        /// movement has to be switched off by hand because only Add() does it.
+        /// </summary>
+        internal static bool Focus(UINavigationalElementsHolder holder)
+        {
+            try
+            {
+                // Focusing is a gamepad concept: on mouse the free cursor follows the pointer, and forcing
+                // a snap would fight it.
+                if (holder == null || !holder.enabled || !IsUsingController())
+                {
+                    return false;
+                }
+
+                UIGlobalNavigationController globalNavigation = holder.GlobalNavigation;
+                Selectable first = holder.GetFirstActiveElement();
+                if (globalNavigation == null || first == null)
+                {
+                    return false;
+                }
+
+                globalNavigation.ForceSelect(holder, first);
+                GameUtl.GetFreeCursorController()?.DisableInput();
+                return true;
+            }
+            catch (Exception ex)
+            {
+                TFTVLogger.Error(ex);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// True while the game is being driven by a gamepad. Use it to branch on interactions that have no
+        /// controller equivalent - double-click, right-click, hover-only affordances.
+        /// </summary>
+        internal static bool IsUsingController()
+        {
+            try
+            {
+                InputController input = GameUtl.GameComponent<InputController>();
+                return input != null && input.InputType == InputType.Joystick;
+            }
+            catch (Exception ex)
+            {
+                TFTVLogger.Error(ex);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Links two holders that sit side by side, so running off the right edge of
+        /// <paramref name="left"/> moves into <paramref name="right"/> and vice versa. Same mechanism as
+        /// <see cref="LinkSections"/>, but for a horizontal split - a list with a panel beside it, rather
+        /// than stacked sections.
+        /// </summary>
+        internal static void LinkHorizontally(
+            UINavigationalElementsHolder left,
+            UINavigationalElementsHolder right)
+        {
+            try
+            {
+                if (left == null || right == null)
+                {
+                    return;
+                }
+
+                Navigation leftNav = left.navigation;
+                leftNav.mode = Navigation.Mode.Explicit;
+                leftNav.selectOnRight = right;
+                left.navigation = leftNav;
+
+                Navigation rightNav = right.navigation;
+                rightNav.mode = Navigation.Mode.Explicit;
+                rightNav.selectOnLeft = left;
+                right.navigation = rightNav;
+            }
+            catch (Exception ex)
+            {
+                TFTVLogger.Error(ex);
+            }
+        }
+
+        /// <summary>
+        /// Groups elements into rows by where they actually sit on screen - top to bottom, then left to
+        /// right within each row. Use this rather than creation order whenever a panel is laid out by
+        /// absolute position, so stick directions match what the player sees.
+        /// </summary>
+        internal static List<IList<Selectable>> GroupIntoRowsByPosition(
+            IList<Selectable> items,
+            float rowTolerance = 40f)
+        {
+            List<IList<Selectable>> rows = new List<IList<Selectable>>();
+
+            try
+            {
+                List<Selectable> remaining = new List<Selectable>();
+                foreach (Selectable item in items ?? new List<Selectable>())
+                {
+                    if (item != null)
+                    {
+                        remaining.Add(item);
+                    }
+                }
+
+                // Highest first: screen space y grows upwards.
+                remaining.Sort((a, b) => b.transform.position.y.CompareTo(a.transform.position.y));
+
+                int index = 0;
+                while (index < remaining.Count)
+                {
+                    float rowY = remaining[index].transform.position.y;
+                    List<Selectable> row = new List<Selectable>();
+
+                    while (index < remaining.Count
+                           && Mathf.Abs(remaining[index].transform.position.y - rowY) <= rowTolerance)
+                    {
+                        row.Add(remaining[index]);
+                        index++;
+                    }
+
+                    row.Sort((a, b) => a.transform.position.x.CompareTo(b.transform.position.x));
+                    rows.Add(row);
+                }
+            }
+            catch (Exception ex)
+            {
+                TFTVLogger.Error(ex);
+            }
+
+            return rows;
+        }
+
+        /// <summary>
+        /// Chains holders top to bottom so the right stick switches between them as sections. The global
+        /// controller resolves a section switch with <c>FindFirstActiveSelectableUp/Down</c> on the holder
+        /// itself - holders are <see cref="Selectable"/>s - so the links have to be explicit.
+        /// Pass them in visual order.
+        /// </summary>
+        internal static void LinkSections(params UINavigationalElementsHolder[] holders)
+        {
+            try
+            {
+                if (holders == null)
+                {
+                    return;
+                }
+
+                List<UINavigationalElementsHolder> chain = new List<UINavigationalElementsHolder>();
+                foreach (UINavigationalElementsHolder holder in holders)
+                {
+                    if (holder != null)
+                    {
+                        chain.Add(holder);
+                    }
+                }
+
+                for (int i = 0; i < chain.Count; i++)
+                {
+                    Navigation navigation = chain[i].navigation;
+                    navigation.mode = Navigation.Mode.Explicit;
+                    navigation.selectOnUp = i > 0 ? chain[i - 1] : null;
+                    navigation.selectOnDown = i < chain.Count - 1 ? chain[i + 1] : null;
+                    navigation.selectOnLeft = null;
+                    navigation.selectOnRight = null;
+                    chain[i].navigation = navigation;
+                }
+            }
+            catch (Exception ex)
+            {
+                TFTVLogger.Error(ex);
+            }
+        }
+
+        /// <summary>
+        /// Attaches the game's scroller to a mod-built <see cref="ScrollRect"/> so a holder can scroll its
+        /// selection into view.
+        ///
+        /// Two things have to be repaired for a runtime-added instance: the serialised interpolation curve
+        /// is null (its default is only applied by the editor's Reset), which would throw inside the scroll
+        /// coroutine; and <see cref="ScrollRect.viewport"/> must be set, since the scroller dereferences it
+        /// directly. Assigning the ScrollRect's own transform matches what Unity already falls back to
+        /// internally, so it changes no layout.
+        /// </summary>
+        internal static VerticalScrollRectScroller EnsureVerticalScroller(ScrollRect scrollRect)
+        {
+            try
+            {
+                if (scrollRect == null)
+                {
+                    return null;
+                }
+
+                if (scrollRect.viewport == null)
+                {
+                    scrollRect.viewport = scrollRect.transform as RectTransform;
+                }
+
+                VerticalScrollRectScroller scroller = scrollRect.GetComponent<VerticalScrollRectScroller>();
+                if (scroller == null)
+                {
+                    scroller = scrollRect.gameObject.AddComponent<VerticalScrollRectScroller>();
+                }
+
+                if (ScrollerInterpolationCurveField != null
+                    && ScrollerInterpolationCurveField.GetValue(scroller) == null)
+                {
+                    ScrollerInterpolationCurveField.SetValue(scroller, AnimationCurve.EaseInOut(0f, 0f, 1f, 1f));
+                }
+
+                return scroller;
+            }
+            catch (Exception ex)
+            {
+                TFTVLogger.Error(ex);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Collects the underlying <see cref="Selectable"/>s of a set of vanilla buttons, skipping any
+        /// that failed to clone.
+        /// </summary>
+        internal static List<Selectable> SelectablesOf(IEnumerable<PhoenixGeneralButton> buttons)
+        {
+            List<Selectable> result = new List<Selectable>();
+
+            if (buttons == null)
+            {
+                return result;
+            }
+
+            foreach (PhoenixGeneralButton button in buttons)
+            {
+                if (button == null)
+                {
+                    continue;
+                }
+
+                Selectable selectable = button.BaseButton != null
+                    ? button.BaseButton
+                    : button.GetComponent<Selectable>();
+
+                if (selectable != null)
+                {
+                    result.Add(selectable);
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/TFTV/TFTVUI/Geoscape/SiteManagementNav.cs
+++ b/TFTV/TFTVUI/Geoscape/SiteManagementNav.cs
@@ -1,0 +1,298 @@
+using Base.Core;
+using Base.Input;
+using Base.UI;
+using HarmonyLib;
+using PhoenixPoint.Common.View.ViewControllers;
+using PhoenixPoint.Geoscape.View.ViewModules;
+using PhoenixPoint.Geoscape.View.ViewStates;
+using System;
+using System.Collections.Generic;
+using TFTV.TFTVUI.Common;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TFTV.TFTVUI.Geoscape
+{
+    /// <summary>
+    /// Gamepad access to the row of square buttons at the edge of the geoscape - vanilla's Bases button
+    /// plus the mod's Haven Recruits and Marketplace clones.
+    ///
+    /// Vanilla binds Y straight to opening the Bases panel, which leaves the two mod buttons with no
+    /// controller route at all. Here Y instead focuses the row so all three can be picked, and the Bases
+    /// panel opens from its own button as it always did.
+    ///
+    /// The geoscape map runs with <see cref="UIGlobalNavigationController.SupressInputEvents"/> on, which
+    /// disables holder navigation entirely so the free cursor can roam the map. Vanilla clears that flag
+    /// just before it opens a nav-driven panel and restores it in ResetGamepadCursor; this mirrors that,
+    /// and the flag has to stay cleared while a mod overlay opened from one of these buttons is up, or the
+    /// overlay's own navigation is dead on arrival.
+    /// </summary>
+    internal static class SiteManagementNav
+    {
+        private const string HolderName = "TFTV_SiteManagementButtonsNav";
+        private const string RecruitsButtonName = "UIButton_Icon_Recruits";
+        private const string MarketplaceButtonName = "UIButton_Icon_Marketplace";
+
+        private static UIModuleSiteManagement _module;
+        private static UINavigationalElementsHolder _holder;
+        private static bool _focused;
+
+        internal static bool IsFocused => _focused;
+
+        [HarmonyPatch(typeof(UIModuleSiteManagement), nameof(UIModuleSiteManagement.Init))]
+        internal static class UIModuleSiteManagement_Init_ButtonGroupNav_patch
+        {
+            public static void Postfix(UIModuleSiteManagement __instance)
+            {
+                try
+                {
+                    // Init runs after both mod buttons have been cloned in Awake, so the row is complete.
+                    _module = __instance;
+                    _focused = false;
+                    _holder = EnsureHolder(__instance);
+                }
+                catch (Exception ex) { TFTVLogger.Error(ex); }
+            }
+        }
+
+        [HarmonyPatch(typeof(UIModuleSiteManagement), nameof(UIModuleSiteManagement.Deinit))]
+        internal static class UIModuleSiteManagement_Deinit_ButtonGroupNav_patch
+        {
+            public static void Postfix()
+            {
+                try
+                {
+                    ReleaseFocus(restoreSuppression: false);
+                }
+                catch (Exception ex) { TFTVLogger.Error(ex); }
+            }
+        }
+
+        /// <summary>
+        /// Intercepts Y before vanilla expands the Bases panel, so it focuses the button row instead.
+        /// Everything else - including Y while the panel is already open, which still closes it - falls
+        /// through to the original.
+        ///
+        /// Both map states carry their own copy of the Y branch and both drive the same module, so both
+        /// need intercepting: the geoscape sits in UIStateVehicleSelected whenever an aircraft or site is
+        /// selected, which is most of the time.
+        /// </summary>
+        [HarmonyPatch(typeof(UIStateNothingSelected), "OnInputEvent")]
+        internal static class UIStateNothingSelected_OnInputEvent_ButtonGroupNav_patch
+        {
+            public static bool Prefix(InputEvent ev, ref bool __result)
+            {
+                return !TryHandleYButton(ev, ref __result);
+            }
+        }
+
+        [HarmonyPatch(typeof(UIStateVehicleSelected), "OnInputEvent")]
+        internal static class UIStateVehicleSelected_OnInputEvent_ButtonGroupNav_patch
+        {
+            public static bool Prefix(InputEvent ev, ref bool __result)
+            {
+                return !TryHandleYButton(ev, ref __result);
+            }
+        }
+
+        /// <summary>Returns true when the event was consumed and the original must be skipped.</summary>
+        private static bool TryHandleYButton(InputEvent ev, ref bool __result)
+        {
+            try
+            {
+                if (ev.Type != InputEventType.Pressed || ev.Name != "Joystick Geoscape YButton")
+                {
+                    return false;
+                }
+
+                if (_module == null || _module.IsModuleExtended)
+                {
+                    return false;
+                }
+
+                if (_focused)
+                {
+                    ReleaseFocus(restoreSuppression: true);
+                }
+                else
+                {
+                    FocusButtons();
+                }
+
+                __result = true;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                TFTVLogger.Error(ex);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Cancel on the map already restores the suppression flag in vanilla; the holder has to come off
+        /// with it, otherwise it keeps holding navigation focus over the map.
+        /// </summary>
+        [HarmonyPatch(typeof(UIStateNothingSelected), "OnCancel")]
+        internal static class UIStateNothingSelected_OnCancel_ButtonGroupNav_patch
+        {
+            public static void Prefix()
+            {
+                ReleaseOnCancel();
+            }
+        }
+
+        [HarmonyPatch(typeof(UIStateVehicleSelected), "OnCancel")]
+        internal static class UIStateVehicleSelected_OnCancel_ButtonGroupNav_patch
+        {
+            public static void Prefix()
+            {
+                ReleaseOnCancel();
+            }
+        }
+
+        private static void ReleaseOnCancel()
+        {
+            try
+            {
+                if (_focused)
+                {
+                    ReleaseFocus(restoreSuppression: true);
+                }
+            }
+            catch (Exception ex) { TFTVLogger.Error(ex); }
+        }
+
+        /// <summary>
+        /// Opening the Bases panel hands navigation over to that panel's own holder, so the button row
+        /// steps aside - but the suppression flag stays cleared, because the panel needs it.
+        /// </summary>
+        [HarmonyPatch(typeof(UIModuleSiteManagement), nameof(UIModuleSiteManagement.ShowModule))]
+        internal static class UIModuleSiteManagement_ShowModule_ButtonGroupNav_patch
+        {
+            public static void Postfix()
+            {
+                try
+                {
+                    ReleaseFocus(restoreSuppression: false);
+                }
+                catch (Exception ex) { TFTVLogger.Error(ex); }
+            }
+        }
+
+        private static UINavigationalElementsHolder EnsureHolder(UIModuleSiteManagement module)
+        {
+            Transform parent = module?.OpenModuleButton?.transform?.parent;
+            if (parent == null)
+            {
+                return null;
+            }
+
+            Transform existing = parent.Find(HolderName);
+            if (existing != null)
+            {
+                return existing.GetComponent<UINavigationalElementsHolder>();
+            }
+
+            // A dedicated empty child rather than the buttons' own parent: the holder only ever navigates
+            // an explicit element list, so it needs no children of its own, and this avoids disturbing the
+            // live buttons when the component is attached.
+            GameObject go = new GameObject(HolderName, typeof(RectTransform));
+            go.SetActive(false);
+            go.transform.SetParent(parent, false);
+
+            UINavigationalElementsHolder holder = ControllerNav.EnsureHolder(go);
+            go.SetActive(true);
+            return holder;
+        }
+
+        /// <summary>
+        /// Collects whichever of the three buttons are currently visible, left to right.
+        /// </summary>
+        private static List<Selectable> CollectButtons()
+        {
+            List<Selectable> buttons = new List<Selectable>();
+
+            if (_module?.OpenModuleButton == null)
+            {
+                return buttons;
+            }
+
+            Transform parent = _module.OpenModuleButton.transform.parent;
+
+            AddButton(buttons, _module.OpenModuleButton.gameObject);
+            AddButton(buttons, parent?.Find(RecruitsButtonName)?.gameObject);
+            AddButton(buttons, parent?.Find(MarketplaceButtonName)?.gameObject);
+
+            buttons.Sort((a, b) => a.transform.position.x.CompareTo(b.transform.position.x));
+            return buttons;
+        }
+
+        private static void AddButton(List<Selectable> into, GameObject go)
+        {
+            if (go == null || !go.activeInHierarchy)
+            {
+                return;
+            }
+
+            Selectable selectable = go.GetComponent<PhoenixGeneralButton>()?.BaseButton
+                                    ?? go.GetComponent<Selectable>();
+
+            if (selectable != null)
+            {
+                into.Add(selectable);
+            }
+        }
+
+        private static void FocusButtons()
+        {
+            List<Selectable> buttons = CollectButtons();
+
+            if (buttons.Count == 0)
+            {
+                return;
+            }
+
+            UIGlobalNavigationController globalNavigation = GetGlobalNavigation();
+            if (globalNavigation != null)
+            {
+                // Must precede Apply: while this is set, Add() refuses to make any holder current.
+                globalNavigation.SupressInputEvents = false;
+            }
+
+            // Loops horizontally so the row cycles; there is nowhere else to navigate to from here, and
+            // the row is left with Y or Cancel rather than by running off an end.
+            bool applied = ControllerNav.Apply(_holder, buttons, NavigationHolderMode.Horizontal, rootPriority: 90);
+
+            // Ranked below the panels these buttons open, so Add() will not hand it focus on its own.
+            _focused = applied && ControllerNav.Focus(_holder);
+        }
+
+        private static void ReleaseFocus(bool restoreSuppression)
+        {
+            ControllerNav.Release(_holder);
+            _focused = false;
+
+            if (!restoreSuppression)
+            {
+                return;
+            }
+
+            UIGlobalNavigationController globalNavigation = GetGlobalNavigation();
+            if (globalNavigation != null)
+            {
+                globalNavigation.SupressInputEvents = true;
+            }
+
+            if (ControllerNav.IsUsingController())
+            {
+                GameUtl.GetFreeCursorController()?.ForceCursorToCenterScreen();
+            }
+        }
+
+        private static UIGlobalNavigationController GetGlobalNavigation()
+        {
+            return GameUtl.CurrentLevel()?.GetComponent<UIGlobalNavigationController>();
+        }
+    }
+}

--- a/TFTV/TFTVUI/Geoscape/TFTVHavenRecruitsUI/HavenRecruitsMain.cs
+++ b/TFTV/TFTVUI/Geoscape/TFTVHavenRecruitsUI/HavenRecruitsMain.cs
@@ -1,5 +1,8 @@
 ﻿using Base.Core;
+using Base.Input;
+using Base.UI;
 using PhoenixPoint.Common.Core;
+using PhoenixPoint.Common.View.ViewControllers;
 using PhoenixPoint.Common.View.ViewControllers.Inventory;
 using PhoenixPoint.Geoscape.Entities;
 using PhoenixPoint.Geoscape.Levels;
@@ -11,6 +14,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using TFTV.TFTVHavenRecruitsUI;
+using TFTV.TFTVUI.Common;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
@@ -336,7 +340,7 @@ namespace TFTV
                             var mutationSlot = child.GetComponent<UIInventorySlot>();
                             if (mutationSlot != null)
                             {
-                                Object.Destroy(child.gameObject);
+                                RecruitOverlayManagerHelpers.DetachAndDestroy(child);
                                 continue;
                             }
 
@@ -347,7 +351,7 @@ namespace TFTV
                                 continue;
                             }
 
-                            Object.Destroy(child.gameObject);
+                            RecruitOverlayManagerHelpers.DetachAndDestroy(child);
                         }
                         AbilityContainer.gameObject.SetActive(false);
                     }
@@ -372,11 +376,11 @@ namespace TFTV
                             var slot = child.GetComponent<UIInventorySlot>();
                             if (slot != null)
                             {
-                                Object.Destroy(child.gameObject);
+                                RecruitOverlayManagerHelpers.DetachAndDestroy(child);
                                 continue;
                             }
 
-                            Object.Destroy(child.gameObject);
+                            RecruitOverlayManagerHelpers.DetachAndDestroy(child);
                         }
                     }
 
@@ -414,6 +418,13 @@ namespace TFTV
                     if (pendingSingle != null) { StopCoroutine(pendingSingle); pendingSingle = null; }
                     OnDouble?.Invoke();
                 }
+                else if (ControllerNav.IsUsingController())
+                {
+                    // The delay only exists to disambiguate a double-click, and the free cursor always
+                    // reports clickCount 1 - so on a pad it would just add lag to every selection.
+                    if (pendingSingle != null) { StopCoroutine(pendingSingle); pendingSingle = null; }
+                    OnSingle?.Invoke();
+                }
                 else
                 {
                     if (pendingSingle != null) StopCoroutine(pendingSingle);
@@ -426,6 +437,29 @@ namespace TFTV
                 yield return new WaitForSecondsRealtime(doubleClickDelay);
                 OnSingle?.Invoke();
                 pendingSingle = null;
+            }
+        }
+
+        /// <summary>
+        /// Relays a click on a child of a card - the name, an ability icon - back to the card itself.
+        /// Those children need their own Selectable to be gamepad-navigable, and a Selectable is an
+        /// IPointerClickHandler, so ExecuteHierarchy would otherwise stop there and never reach the card.
+        /// The original event is passed through so the mouse's double-click still registers.
+        /// </summary>
+        internal sealed class CardClickForwarder : MonoBehaviour, IPointerClickHandler
+        {
+            public CardClickHandler Target;
+
+            public void OnPointerClick(PointerEventData e)
+            {
+                try
+                {
+                    Target?.OnPointerClick(e);
+                }
+                catch (Exception ex)
+                {
+                    TFTVLogger.Error(ex);
+                }
             }
         }
 
@@ -452,6 +486,13 @@ namespace TFTV
             private static readonly Queue<RecruitCardView> _cardPool = new Queue<RecruitCardView>();
             private static readonly List<RecruitCardView> _activeCards = new List<RecruitCardView>();
             private static Transform _cardPoolRoot;
+
+            // Gamepad navigation. Three sections, chained top to bottom so the right stick moves between
+            // them; the cards section is rebuilt on every RefreshColumns. See ControllerNav.
+            internal static UINavigationalElementsHolder _sortNavHolder;
+            internal static UINavigationalElementsHolder _factionTabsNavHolder;
+            internal static UINavigationalElementsHolder _cardsNavHolder;
+            private static VerticalScrollRectScroller _cardsScroller;
 
             private static readonly Queue<AbilityIconView> _abilityIconPool = new Queue<AbilityIconView>();
             private static Transform _abilityPoolRoot;
@@ -542,6 +583,10 @@ namespace TFTV
                     OverlayAbilityTooltip = null;
                     OverlayRootRect = null;
                     OverlayCanvas = null;
+                    _sortNavHolder = null;
+                    _factionTabsNavHolder = null;
+                    _cardsNavHolder = null;
+                    _cardsScroller = null;
                     _overlayAnimator = null;
                     _detailAnimator = null;
                     _isOverlayVisible = false;
@@ -647,6 +692,23 @@ namespace TFTV
                     }
 
                     _isOverlayVisible = show;
+
+                    // The geoscape map keeps holder navigation suppressed so the free cursor can roam it.
+                    // The overlay's own navigation cannot work while that is on, and it has to be restored
+                    // on close - unless the geoscape button row still holds focus behind us.
+                    UIGlobalNavigationController globalNavigation =
+                        GameUtl.CurrentLevel()?.GetComponent<UIGlobalNavigationController>();
+                    if (globalNavigation != null)
+                    {
+                        if (show)
+                        {
+                            globalNavigation.SupressInputEvents = false;
+                        }
+                        else if (!TFTVUI.Geoscape.SiteManagementNav.IsFocused)
+                        {
+                            globalNavigation.SupressInputEvents = true;
+                        }
+                    }
 
                     if (!show)
                     {
@@ -768,10 +830,70 @@ namespace TFTV
 
 
                     overlayPanel.SetActive(false);
+
+                    // After the panel is inactive: attaching the holders now means their OnEnable does not
+                    // fire until the overlay is actually shown, so nothing registers with the global
+                    // navigation controller while the overlay is hidden.
+                    SetupControllerNavigation();
+
                     EnsureOverlayLayout(force: true);
                 }
                 catch (Exception ex) { TFTVLogger.Error(ex); }
             }
+
+            /// <summary>
+            /// Splits the overlay into three gamepad-navigable sections - sort toggles, faction tabs, and
+            /// the recruit list - chained in visual order so the right stick moves between them. The cards
+            /// holder is left empty here; RefreshColumns fills it each time the list is rebuilt.
+            /// </summary>
+            private static void SetupControllerNavigation()
+            {
+                try
+                {
+                    if (overlayPanel == null)
+                    {
+                        return;
+                    }
+
+                    Transform toolbar = overlayPanel.transform.Find("Toolbar");
+                    Transform factionTabs = overlayPanel.transform.Find("FactionTabs");
+
+                    _sortNavHolder = toolbar != null ? ControllerNav.EnsureHolder(toolbar.gameObject) : null;
+                    _factionTabsNavHolder = factionTabs != null ? ControllerNav.EnsureHolder(factionTabs.gameObject) : null;
+                    _cardsNavHolder = _recruitListRoot != null ? ControllerNav.EnsureHolder(_recruitListRoot.gameObject) : null;
+
+                    Transform recruitList = overlayPanel.transform.Find("RecruitList");
+                    _cardsScroller = recruitList != null
+                        ? ControllerNav.EnsureVerticalScroller(recruitList.GetComponent<ScrollRect>())
+                        : null;
+
+                    List<Selectable> sortSelectables = new List<Selectable>();
+                    foreach (var kvp in _sortToggles)
+                    {
+                        if (kvp.Value != null)
+                        {
+                            sortSelectables.Add(kvp.Value);
+                        }
+                    }
+
+                    List<Selectable> tabSelectables = new List<Selectable>();
+                    foreach (FactionFilter filter in new[] { FactionFilter.Anu, FactionFilter.NewJericho, FactionFilter.Synedrion })
+                    {
+                        if (_factionTabs.TryGetValue(filter, out var tab) && tab?.Toggle != null)
+                        {
+                            tabSelectables.Add(tab.Toggle);
+                        }
+                    }
+
+                    // The cards holder outranks the other two so opening the overlay lands on the list.
+                    ControllerNav.Apply(_sortNavHolder, sortSelectables, NavigationHolderMode.Horizontal, rootPriority: 100);
+                    ControllerNav.Apply(_factionTabsNavHolder, tabSelectables, NavigationHolderMode.Horizontal, rootPriority: 110);
+
+                    ControllerNav.LinkSections(_sortNavHolder, _factionTabsNavHolder, _cardsNavHolder);
+                }
+                catch (Exception ex) { TFTVLogger.Error(ex); }
+            }
+
             internal static GeoRosterAbilityDetailTooltip EnsureOverlayTooltip()
             {
                 try
@@ -1292,6 +1414,55 @@ namespace TFTV
             }
             internal sealed class OverlayRightClickDismissWatcher : MonoBehaviour
             {
+                private InputController _input;
+
+                private void OnEnable()
+                {
+                    try
+                    {
+                        // Right-click has no gamepad equivalent, so the overlay also closes on the Cancel
+                        // action (B / Escape). Ahead of the free cursor (-100) and the global navigation
+                        // controller (-90) so the overlay closes before anything underneath reacts.
+                        _input = GameUtl.GameComponent<InputController>();
+                        _input?.EventHandlers.AddUnique(HandleInput, -110);
+                    }
+                    catch (Exception ex)
+                    {
+                        TFTVLogger.Error(ex);
+                    }
+                }
+
+                private void OnDisable()
+                {
+                    try
+                    {
+                        _input?.EventHandlers.Remove(HandleInput);
+                    }
+                    catch (Exception ex)
+                    {
+                        TFTVLogger.Error(ex);
+                    }
+                }
+
+                private bool HandleInput(InputEvent ev)
+                {
+                    try
+                    {
+                        if (!_isOverlayVisible || ev.Type != InputEventType.Pressed || ev.Name != "Cancel")
+                        {
+                            return false;
+                        }
+
+                        SetOverlayVisible(false);
+                        return true;
+                    }
+                    catch (Exception ex)
+                    {
+                        TFTVLogger.Error(ex);
+                        return false;
+                    }
+                }
+
                 private void Update()
                 {
                     try
@@ -1853,6 +2024,9 @@ namespace TFTV
 
                     ClearSelection();
 
+                    // Unregister before the cards it points at go back to the pool.
+                    ControllerNav.Release(_cardsNavHolder);
+
                     RecycleActiveCards();
                     RecruitOverlayManagerHelpers.ClearTransformChildren(_recruitListRoot);
 
@@ -1895,6 +2069,7 @@ namespace TFTV
                     HavenRecruitsUtils.SortRecruits(recruits);
 
                     bool collapse = recruits.Count > 4;   // show compact by default if many
+                    List<RecruitCardView> builtCards = new List<RecruitCardView>();
                     foreach (var r in recruits)
                     {
                         var cardView = GetCard(_recruitListRoot);
@@ -1904,7 +2079,31 @@ namespace TFTV
                         }
 
                         HavenRecruitsRecruitItem.PopulateRecruitItem(cardView, r, collapse);
+                        builtCards.Add(cardView);
                     }
+
+                    // The rows have to be measured after a layout pass: BuildNavigationRow orders each
+                    // card's icons by screen position, and the layout groups have not run yet.
+                    if (_recruitListRoot is RectTransform listRect)
+                    {
+                        LayoutRebuilder.ForceRebuildLayoutImmediate(listRect);
+                    }
+
+                    List<IList<Selectable>> navRows = new List<IList<Selectable>>();
+                    foreach (var cardView in builtCards)
+                    {
+                        var navRow = HavenRecruitsRecruitItem.BuildNavigationRow(cardView);
+                        if (navRow.Count > 0)
+                        {
+                            navRows.Add(navRow);
+                        }
+                    }
+
+                    ControllerNav.ApplyRows(
+                        _cardsNavHolder,
+                        navRows,
+                        rootPriority: 120,
+                        scrollController: _cardsScroller);
                 }
                 catch (Exception ex)
                 {

--- a/TFTV/TFTVUI/Geoscape/TFTVHavenRecruitsUI/HavenRecruitsPrice.cs
+++ b/TFTV/TFTVUI/Geoscape/TFTVHavenRecruitsUI/HavenRecruitsPrice.cs
@@ -159,7 +159,7 @@ namespace TFTV.TFTVHavenRecruitsUI
                         continue;
                     }
 
-                    Object.Destroy(child.gameObject);
+                    RecruitOverlayManagerHelpers.DetachAndDestroy(child);
                 }
             }
 

--- a/TFTV/TFTVUI/Geoscape/TFTVHavenRecruitsUI/HavenRecruitsRecruitItem.cs
+++ b/TFTV/TFTVUI/Geoscape/TFTVHavenRecruitsUI/HavenRecruitsRecruitItem.cs
@@ -1,7 +1,10 @@
 ﻿using PhoenixPoint.Common.Entities.Items;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using TFTV.TFTVUI.Common;
 using UnityEngine;
+using UnityEngine.EventSystems;
 using UnityEngine.UI;
 using static TFTV.HavenRecruitsMain;
 using static TFTV.HavenRecruitsMain.RecruitOverlayManager;
@@ -170,6 +173,14 @@ namespace TFTV.TFTVHavenRecruitsUI
                 {
                     click.OnSingle = () =>
                     {
+                        // The free cursor always reports clickCount 1, so a gamepad can never reach the
+                        // double-click path. Activating an already-selected card stands in for it there.
+                        if (ControllerNav.IsUsingController() && RecruitOverlayManager._currentSelectedCard == card)
+                        {
+                            OnCardDoubleClick?.Invoke(data.Recruit, data.Site);
+                            return;
+                        }
+
                         HavenRecruitsGeoscapeInteractions.FocusOnSite(data.Site);
                         HandleRecruitSelected(card, data);
                     };
@@ -306,6 +317,129 @@ namespace TFTV.TFTVHavenRecruitsUI
             t.color = new Color(0.85f, 0.85f, 0.9f, 0.9f);
             var rt = go.GetComponent<RectTransform>();
             rt.sizeDelta = new Vector2(0, 48);
+        }
+
+        /// <summary>
+        /// Describes one card as a left-to-right run of gamepad targets: the recruit's name first, so
+        /// moving up and down the list parks the cursor on the name, then every icon on the line that
+        /// shows a tooltip on hover. The free cursor raycasts wherever it is snapped, so landing on an
+        /// icon fires that icon's existing pointer-enter tooltip with no extra wiring.
+        /// </summary>
+        internal static List<Selectable> BuildNavigationRow(RecruitCardView cardView)
+        {
+            var row = new List<Selectable>();
+
+            try
+            {
+                if (cardView == null || cardView.gameObject == null)
+                {
+                    return row;
+                }
+
+                var card = cardView.gameObject;
+                var clickHandler = card.GetComponent<CardClickHandler>();
+
+                if (cardView.NameLabel != null)
+                {
+                    var head = EnsureNavTarget(cardView.NameLabel.gameObject, clickHandler);
+                    if (head != null)
+                    {
+                        row.Add(head);
+                    }
+                }
+
+                var icons = new List<Selectable>();
+                CollectHoverTargets(cardView.AbilityContainer, clickHandler, icons);
+                CollectHoverTargets(cardView.CostRow, clickHandler, icons);
+
+                // The two containers are positioned independently, so screen order is the only reliable
+                // way to know what sits left of what.
+                icons.Sort((a, b) => a.transform.position.x.CompareTo(b.transform.position.x));
+                row.AddRange(icons);
+
+                if (row.Count == 0)
+                {
+                    var cardButton = card.GetComponent<Button>();
+                    if (cardButton != null)
+                    {
+                        row.Add(cardButton);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                TFTVLogger.Error(ex);
+            }
+
+            return row;
+        }
+
+        private static void CollectHoverTargets(Transform container, CardClickHandler clickHandler, List<Selectable> into)
+        {
+            if (container == null || !container.gameObject.activeSelf)
+            {
+                return;
+            }
+
+            for (int i = 0; i < container.childCount; i++)
+            {
+                var child = container.GetChild(i);
+                if (child == null || !child.gameObject.activeSelf)
+                {
+                    continue;
+                }
+
+                // Search children too: an ability icon carries its tooltip trigger on the inner image,
+                // but the frame is what should be navigated to.
+                if (child.GetComponentInChildren<IPointerEnterHandler>() == null)
+                {
+                    continue;
+                }
+
+                var target = EnsureNavTarget(child.gameObject, clickHandler);
+                if (target != null)
+                {
+                    into.Add(target);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Makes one object navigable, reusing whatever Selectable it already has. A click forwarder is
+        /// only attached when this adds the Selectable itself and the object had no click behaviour of its
+        /// own, so inventory slots keep handling their own clicks exactly as they do with a mouse.
+        /// </summary>
+        private static Selectable EnsureNavTarget(GameObject go, CardClickHandler clickHandler)
+        {
+            if (go == null)
+            {
+                return null;
+            }
+
+            var existing = go.GetComponent<Selectable>();
+            if (existing != null)
+            {
+                return existing;
+            }
+
+            bool hadClickHandler = go.GetComponent<IPointerClickHandler>() != null;
+
+            var button = go.AddComponent<Button>();
+            button.transition = Selectable.Transition.None;
+
+            var graphic = go.GetComponent<Graphic>();
+            if (graphic != null)
+            {
+                button.targetGraphic = graphic;
+            }
+
+            if (!hadClickHandler && clickHandler != null)
+            {
+                var forwarder = go.GetComponent<CardClickForwarder>() ?? go.AddComponent<CardClickForwarder>();
+                forwarder.Target = clickHandler;
+            }
+
+            return button;
         }
     }
 }

--- a/TFTV/TFTVUI/Geoscape/TFTVHavenRecruitsUI/RecruitOverlayManagerHelpers.cs
+++ b/TFTV/TFTVUI/Geoscape/TFTVHavenRecruitsUI/RecruitOverlayManagerHelpers.cs
@@ -31,8 +31,25 @@ namespace TFTV
 
             for (int i = transform.childCount - 1; i >= 0; i--)
             {
-                Object.Destroy(transform.GetChild(i).gameObject);
+                DetachAndDestroy(transform.GetChild(i));
             }
+        }
+
+        /// <summary>
+        /// Unparents before destroying. Object.Destroy only takes effect at the end of the frame, so a
+        /// container cleared this way would otherwise still report its dead children for the rest of the
+        /// frame - and anything that walks the hierarchy in between (gamepad navigation builds its rows
+        /// there) would pick them up and hold references that go null a frame later.
+        /// </summary>
+        internal static void DetachAndDestroy(Transform child)
+        {
+            if (child == null)
+            {
+                return;
+            }
+
+            child.SetParent(null, false);
+            Object.Destroy(child.gameObject);
         }
 
         internal static Image MakeFixedIcon(Transform parent, Sprite sp, int px, Sprite backgroundSprite = null)

--- a/TFTV/TFTVUI/Home/NewGameOptionsNav.cs
+++ b/TFTV/TFTVUI/Home/NewGameOptionsNav.cs
@@ -1,0 +1,140 @@
+using Base.UI;
+using PhoenixPoint.Common.View.ViewControllers;
+using PhoenixPoint.Geoscape.View.ViewControllers;
+using PhoenixPoint.Home.View.ViewControllers;
+using PhoenixPoint.Home.View.ViewModules;
+using System;
+using System.Collections.Generic;
+using TFTV.TFTVUI.Common;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TFTV.TFTVUI.Home
+{
+    /// <summary>
+    /// Gamepad navigation for the rows TFTV adds to the new game settings screen.
+    ///
+    /// Every added row is either a cloned ModSettingController wrapping an
+    /// <see cref="ArrowPickerController"/>, or a cloned <see cref="GameOptionViewController"/> acting as a
+    /// collapsible section header. They all live as siblings in one container, in creation order, so a
+    /// single vertical holder covers the lot.
+    ///
+    /// Two details make this work without extra bookkeeping. The global controller reads
+    /// <c>GetComponent&lt;ArrowPickerController&gt;()</c> off whatever Selectable is currently selected and
+    /// routes the right stick to it, so an option row's Selectable has to sit on the picker's own
+    /// GameObject - then left and right change the value while up and down move between rows. And
+    /// collapsing a section only deactivates its rows; the controller's neighbour search already walks
+    /// past inactive elements, so a collapsed section is skipped with no rebuild.
+    /// </summary>
+    internal static class NewGameOptionsNav
+    {
+        private static UINavigationalElementsHolder _holder;
+
+        /// <summary>
+        /// Called at the end of the mod's own InitFullContent postfix rather than from a separate patch,
+        /// so it is guaranteed to run after every row has been created.
+        /// </summary>
+        internal static void Setup(UIModuleGameSettings module, Transform optionsContainer)
+        {
+            try
+            {
+                if (optionsContainer == null)
+                {
+                    return;
+                }
+
+                _holder = ControllerNav.EnsureHolder(optionsContainer.gameObject);
+
+                List<Selectable> rows = CollectRows(optionsContainer);
+                if (rows.Count == 0)
+                {
+                    return;
+                }
+
+                VerticalScrollRectScroller scroller =
+                    optionsContainer.GetComponentInParent<VerticalScrollRectScroller>() ?? module?.DlcScroller;
+
+                // Never loops: the global controller only offers a section switch when a link comes back
+                // null, so wrapping would trap the cursor in this list.
+                ControllerNav.Apply(
+                    _holder,
+                    rows,
+                    NavigationHolderMode.Vertical,
+                    rootPriority: ControllerNav.DefaultRootPriority,
+                    loop: false,
+                    scrollController: scroller);
+            }
+            catch (Exception ex) { TFTVLogger.Error(ex); }
+        }
+
+        /// <summary>
+        /// Walks the container in sibling order - which is the order the rows were created, and so the
+        /// order they appear on screen - and returns one navigable Selectable per row.
+        /// </summary>
+        private static List<Selectable> CollectRows(Transform container)
+        {
+            List<Selectable> rows = new List<Selectable>();
+
+            for (int i = 0; i < container.childCount; i++)
+            {
+                Transform child = container.GetChild(i);
+                if (child == null)
+                {
+                    continue;
+                }
+
+                GameOptionViewController header = child.GetComponent<GameOptionViewController>();
+                if (header != null)
+                {
+                    Selectable headerSelectable = header.SelectButton != null
+                        ? (header.SelectButton.BaseButton ?? header.SelectButton.GetComponent<Selectable>())
+                        : child.GetComponent<Selectable>();
+
+                    if (headerSelectable != null)
+                    {
+                        rows.Add(headerSelectable);
+                    }
+                    continue;
+                }
+
+                ModSettingController setting = child.GetComponent<ModSettingController>();
+                if (setting?.ListField != null)
+                {
+                    Selectable pickerSelectable = EnsurePickerSelectable(setting.ListField);
+                    if (pickerSelectable != null)
+                    {
+                        rows.Add(pickerSelectable);
+                    }
+                }
+            }
+
+            return rows;
+        }
+
+        /// <summary>
+        /// The Selectable has to live on the picker's own GameObject, because that is where the global
+        /// controller looks for the ArrowPickerController when it decides what the right stick adjusts.
+        /// </summary>
+        private static Selectable EnsurePickerSelectable(ArrowPickerController picker)
+        {
+            GameObject go = picker.gameObject;
+
+            Selectable existing = go.GetComponent<Selectable>();
+            if (existing != null)
+            {
+                return existing;
+            }
+
+            Button button = go.AddComponent<Button>();
+            button.transition = Selectable.Transition.None;
+
+            Graphic graphic = go.GetComponent<Graphic>();
+            if (graphic != null)
+            {
+                button.targetGraphic = graphic;
+            }
+
+            return button;
+        }
+    }
+}

--- a/TFTV/TFTVUI/Personnel/Loadouts.cs
+++ b/TFTV/TFTVUI/Personnel/Loadouts.cs
@@ -15,6 +15,7 @@ using PhoenixPoint.Tactical.Entities.Equipments;
 using System;
 using System.Linq;
 using System.Reflection;
+using TFTV.TFTVUI.Common;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -68,6 +69,57 @@ namespace TFTV.TFTVUI.Personnel
             SetButtonVisibility(HelmetToggle, false);
         }
 
+        /// <summary>
+        /// Adds the helmet toggle to whichever navigation holder already owns the loadout button column,
+        /// rather than registering a competing one - so it inherits the edit screen's own priority and
+        /// focus handling.
+        ///
+        /// It goes in immediately after Save Loadout, which is where it renders - last in the column. The
+        /// holder links its elements in list order, so putting it anywhere else rewires the buttons around
+        /// it and breaks their navigation too.
+        ///
+        /// While the button is hidden its wrapper is inactive, and the navigation code skips inactive
+        /// elements on its own - so there is nothing to remove when it does not apply.
+        /// </summary>
+        private static void EnsureHelmetButtonNavigation(UIModuleActorCycle uIModuleActorCycle)
+        {
+            try
+            {
+                Selectable helmetSelectable = HelmetToggle != null
+                    ? (HelmetToggle.BaseButton ?? HelmetToggle.GetComponent<Selectable>())
+                    : null;
+
+                if (helmetSelectable == null)
+                {
+                    return;
+                }
+
+                EditUnitButtonsController buttons =
+                    uIModuleActorCycle != null
+                        ? uIModuleActorCycle.GetComponentInChildren<EditUnitButtonsController>(true)
+                        : null;
+
+                Selectable anchor = buttons?.SaveLoadoutButton != null
+                    ? (buttons.SaveLoadoutButton.BaseButton ?? buttons.SaveLoadoutButton.GetComponent<Selectable>())
+                    : null;
+
+                if (anchor == null)
+                {
+                    return;
+                }
+
+                UINavigationalElementsHolder holder = ControllerNav.FindHolderContaining(anchor);
+                if (holder != null)
+                {
+                    ControllerNav.InsertIntoExistingHolder(holder, helmetSelectable, anchor);
+                }
+            }
+            catch (Exception e)
+            {
+                TFTVLogger.Error(e);
+            }
+        }
+
         public static void ShowAndHideHelmetButton(UIModuleActorCycle uIModuleActorCycle)
         {
             try
@@ -100,6 +152,8 @@ namespace TFTV.TFTVUI.Personnel
                             // Refresh icon and label now that the stored preference is available
                             ShowWithoutHelmet.SyncCustomHelmetButtonIcon();
                         }
+
+                        EnsureHelmetButtonNavigation(uIModuleActorCycle);
 
                         break;
 


### PR DESCRIPTION
None of the UI TFTV adds responded to a controller. Phoenix Point drives its gamepad UI through UIGlobalNavigationController: a panel registers a UINavigationalElementsHolder listing its Selectables, and the stick moves the virtual free cursor between them - the cursor is what actually clicks, so anything a holder does not list is unreachable once any root holder is active. Nothing the mod built registered a holder.

Adds TFTVUI/Common/ControllerNav.cs as the shared entry point, then wires each panel to it:

- Geoscape button row (new SiteManagementNav): Y now focuses Bases + Haven Recruits + Marketplace so all three can be picked, instead of opening Bases directly. Clears SupressInputEvents the way vanilla does before opening a nav-driven panel, and restores it on release.
- Base activation modal and its personnel selection panel.
- Haven Recruits: per-card rows - name first, then the icons on the line, so tooltips are reachable - plus faction tabs and sort toggles as chained sections, and Cancel closes the overlay.
- New game options: one holder over the added rows; the right stick drives each ArrowPickerController, and collapsed sections are skipped.
- Drills overlay: header and 6-column drill grid.
- Marketplace filters and incident approach icons / crew list: these join the vanilla holder that already owns the screen rather than competing with it, so they inherit its priority, scrolling and focus handling.
- Show Face toggle: spliced into the edit screen's existing holder after Save Loadout, matching where it renders.

Rows are ordered by on-screen position rather than creation order, since several panels place elements by absolute position - incident approach icons sit on the outer edge of each choice, so a fixed order sends the stick the wrong way for one of them.

Also fixes three bugs found along the way:

- Haven Recruits cleared card containers with Object.Destroy, which is deferred, so anything reading the hierarchy later in the same frame saw children that were about to disappear. Now detaches before destroying.
- The Marketplace filter guard (MarketToggleButton) was never assigned, so every UpdateVisuals stacked another four toggles on the previous set.
- Releasing a holder during level teardown threw, because the holder's OnDisable reaches for the level's navigation controller without a null check.