### PR TITLE
Add tactical controller support and fix base defense widget

### DIFF
--- a/TFTV/TFTV.csproj
+++ b/TFTV/TFTV.csproj
@@ -281,6 +281,7 @@
     <Compile Include="TFTVUI\Tactical\MeleeRangePrediction.cs" />
     <Compile Include="TFTVUI\Tactical\OpposingHumanoidForceWidget.cs" />
     <Compile Include="TFTVUI\Tactical\SecondaryObjectives.cs" />
+    <Compile Include="TFTVUI\Tactical\TacticalTooltipCycler.cs" />
     <Compile Include="TFTVUI\Tactical\TargetIcons.cs" />
     <Compile Include="TFTVUI\Tactical\Various.cs" />
     <Compile Include="TFTVVanillaFixes\Geoscape\GeoscapeVanillaFixes.cs" />

--- a/TFTV/TFTVBaseDefenseTactical.cs
+++ b/TFTV/TFTVBaseDefenseTactical.cs
@@ -3263,6 +3263,10 @@ namespace TFTV
 
                         StratToBeImplemented = 0;
                         TFTVLogger.Always($"Strat to be implemented now {StratToBeImplemented}, should be 0");
+
+                        // The widget reads StratToBeImplemented, so clearing it without a refresh leaves
+                        // the strat that just fired on screen until something else happens to update it.
+                        ActivateUpdateBaseDefenseWidget();
                     }
                 }
                 catch (Exception e)

--- a/TFTV/TFTVDefsInjectedOnlyOnce.cs
+++ b/TFTV/TFTVDefsInjectedOnlyOnce.cs
@@ -748,11 +748,167 @@ namespace TFTV
             }
         }
 
+        /// <summary>
+        /// Creates the rebindable action that cycles the mod's tactical HUD tooltips.
+        ///
+        /// The gamepad default is chosen by scanning every existing binding for joystick buttons already
+        /// in use and taking the first one that is free, so it cannot silently steal a vanilla control on
+        /// any pad layout. It is registered as a normal action, so it shows up in Options and the player
+        /// can rebind it.
+        /// </summary>
+        private static void CreateTacticalTooltipHotkey()
+        {
+            try
+            {
+                InputMapDef inputMapDef = DefCache.GetDef<InputMapDef>("PhoenixInput");
+
+                // Every input set that drives tactical play, identified by content rather than by asset
+                // name so this does not depend on knowing what they are called.
+                List<InputSetDef> tacticalSets = new List<InputSetDef>();
+                HashSet<string> tacticalActionNames = new HashSet<string>();
+
+                foreach (InputSetDef inputSetDef in Repo.GetAllDefs<InputSetDef>())
+                {
+                    if (inputSetDef?.ActionNames == null || !inputSetDef.ActionNames.Contains("EndTurn"))
+                    {
+                        continue;
+                    }
+
+                    tacticalSets.Add(inputSetDef);
+                    foreach (string actionName in inputSetDef.ActionNames)
+                    {
+                        tacticalActionNames.Add(actionName);
+                    }
+                }
+
+                // Bindings are copied wholesale from keys the game already uses, never invented. A key is
+                // identified by Name (InputCache rewrites Hash from a name lookup, inventing a hash for
+                // an unknown name), but Hash also has to be a real one: RefreshActions indexes a key
+                // value array by it, so a placeholder throws IndexOutOfRange the moment keybindings are
+                // reapplied. Copying an existing key gives a matching, in-range pair.
+                //
+                // Values only, never InputKey references: InputKey overloads == and dereferences both
+                // sides without a null check, so any comparison against null throws.
+                Dictionary<string, int> knownKeyboardKeys = new Dictionary<string, int>();
+                HashSet<string> keysUsedInTactical = new HashSet<string>();
+
+                foreach (InputAction action in inputMapDef.Actions)
+                {
+                    bool actionIsTactical = tacticalActionNames.Contains(action?.Name);
+
+                    foreach (InputChord chord in action?.Chords ?? new InputChord[0])
+                    {
+                        foreach (InputKey key in chord?.Keys ?? new InputKey[0])
+                        {
+                            if (ReferenceEquals(key, null)
+                                || key.InputSource != InputSource.Key
+                                || key.Hash < 0
+                                || key.GetInputType() == InputType.Joystick)
+                            {
+                                continue;
+                            }
+
+                            knownKeyboardKeys[key.Name] = key.Hash;
+
+                            if (actionIsTactical)
+                            {
+                                keysUsedInTactical.Add(key.Name);
+                            }
+                        }
+                    }
+                }
+
+                // Keyboard only. A mod-added gamepad chord was tried and never fired on any button, and a
+                // binding that does nothing is not harmless here: chords are added as OverridingHidden,
+                // so a stray one can shadow a real action. The pad reaches the tooltips through
+                // TacticalTooltipCycler instead, which cycles on B when there is nothing to cancel.
+                string keyboardKeyName = FindFreeKey(knownKeyboardKeys, keysUsedInTactical);
+
+                List<InputChord> chords = new List<InputChord>();
+
+                if (!string.IsNullOrEmpty(keyboardKeyName))
+                {
+                    chords.Add(MakeChord(keyboardKeyName, knownKeyboardKeys[keyboardKeyName]));
+                }
+
+                if (chords.Count == 0)
+                {
+                    TFTVLogger.Always("[TacticalTooltips] No unused key found; cycle action not created.");
+                    return;
+                }
+
+                InputAction inputAction = new InputAction
+                {
+                    Name = TFTVUI.Tactical.TacticalTooltipCycler.ActionName,
+                    ActionSection = InputAction.ActionCategory.Tactical,
+                    ActionDisplayText = new LocalizedTextBind(),
+                    Chords = chords.ToArray(),
+                    // InputCache assigns hashes by position, so the action's hash is its index.
+                    Hash = inputMapDef.Actions.Length
+                };
+
+                inputMapDef.Actions = inputMapDef.Actions.AddToArray(inputAction);
+
+                foreach (InputSetDef inputSetDef in tacticalSets)
+                {
+                    if (!inputSetDef.ActionNames.Contains(inputAction.Name))
+                    {
+                        inputSetDef.ActionNames = inputSetDef.ActionNames.AddToArray(inputAction.Name);
+                    }
+                }
+
+                TFTVLogger.Always($"[TacticalTooltips] Cycle action hash {inputAction.Hash}, " +
+                    $"key '{keyboardKeyName ?? "none"}', added to {tacticalSets.Count} tactical set(s). " +
+                    $"Gamepad uses Cancel when nothing else consumes it.");
+            }
+            catch (Exception e)
+            {
+                TFTVLogger.Error(e);
+            }
+        }
+
+        /// <summary>Returns the first key in <paramref name="candidates"/> that tactical does not use.</summary>
+        private static string FindFreeKey(Dictionary<string, int> candidates, HashSet<string> used)
+        {
+            foreach (KeyValuePair<string, int> candidate in candidates)
+            {
+                if (!used.Contains(candidate.Key))
+                {
+                    return candidate.Key;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Builds a single-key chord from a name and hash copied off an existing binding, so both halves
+        /// are values the input system already knows.
+        /// </summary>
+        private static InputChord MakeChord(string keyName, int keyHash)
+        {
+            return new InputChord
+            {
+                OverridingBehavior = InputChord.ActionOverriding.OverridingHidden,
+                Keys = new InputKey[]
+                {
+                    new InputKey
+                    {
+                        Name = keyName,
+                        Hash = keyHash,
+                        InputSource = InputSource.Key,
+                        DeadzoneOverride = -1.0f
+                    }
+                }
+            };
+        }
+
         private static void CreateHotkeys()
         {
             try
             {
                 CreateAircraftHotkeys();
+                CreateTacticalTooltipHotkey();
 
                 InputMapDef inputMapDef = DefCache.GetDef<InputMapDef>("PhoenixInput");
 

--- a/TFTV/TFTVUI/Tactical/Ancients.cs
+++ b/TFTV/TFTVUI/Tactical/Ancients.cs
@@ -215,6 +215,10 @@ namespace TFTV.TFTVUI.Tactical
                     hoverTrigger.triggers.Add(pointerExit);
 
                     tooltipObj.SetActive(false);
+
+                    // Gamepads cannot hover the tactical HUD, so the cycler drives this same trigger.
+                    GameObject hoverTarget = backgroundImage;
+                    TacticalTooltipCycler.Register("Ancients", () => hoverTarget);
                 }
                 catch (Exception e)
                 {

--- a/TFTV/TFTVUI/Tactical/Data.cs
+++ b/TFTV/TFTVUI/Tactical/Data.cs
@@ -86,6 +86,7 @@ namespace TFTV.TFTVUI.Tactical
                 SecondaryObjectivesTactical.ClearDataOnGameLoadAndStateChange();
                 OpposingHumanoidForceWidget.ClearData();
                 Ancients.ClearData();
+                TacticalTooltipCycler.Reset();
             }
             catch (Exception e)
             {
@@ -102,6 +103,7 @@ namespace TFTV.TFTVUI.Tactical
                 CaptureTacticalWidget.ClearData();
                 OpposingHumanoidForceWidget.ClearData();
                 Ancients.ClearData();
+                TacticalTooltipCycler.Reset();
             }
             catch (Exception e)
             {

--- a/TFTV/TFTVUI/Tactical/DeliriumWidget.cs
+++ b/TFTV/TFTVUI/Tactical/DeliriumWidget.cs
@@ -406,7 +406,8 @@ namespace TFTV.TFTVUI.Tactical
                     entryExit.callback.AddListener((_) => HideTooltip());
                     trigger.triggers.Add(entryExit);
 
-
+                    // Gamepads cannot hover the tactical HUD, so the cycler drives this same trigger.
+                    TacticalTooltipCycler.Register("Delirium", () => _uIElement);
                 }
                 catch (Exception e)
                 {

--- a/TFTV/TFTVUI/Tactical/OpposingHumanoidForceWidget.cs
+++ b/TFTV/TFTVUI/Tactical/OpposingHumanoidForceWidget.cs
@@ -137,7 +137,8 @@ namespace TFTV.TFTVUI.Tactical
                     entryExit.callback.AddListener((_) => HideTooltip());
                     trigger.triggers.Add(entryExit);
 
-
+                    // Gamepads cannot hover the tactical HUD, so the cycler drives this same trigger.
+                    TacticalTooltipCycler.Register("HumanEnemies", () => _uIElement);
                 }
                 catch (Exception e)
                 {

--- a/TFTV/TFTVUI/Tactical/TacticalTooltipCycler.cs
+++ b/TFTV/TFTVUI/Tactical/TacticalTooltipCycler.cs
@@ -1,0 +1,261 @@
+using Base.Core;
+using Base.Input;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using PhoenixPoint.Tactical.Levels;
+using UnityEngine.EventSystems;
+
+namespace TFTV.TFTVUI.Tactical
+{
+    /// <summary>
+    /// Makes the mod's tactical HUD widgets readable with a gamepad.
+    ///
+    /// The widgets show their detail on hover, and hover is unreachable there: unlike the geoscape, the
+    /// main tactical view runs no free cursor - it is only used on the inventory screen - so a controller
+    /// has no pointer to put over them. Rather than restructure each widget, this drives them with the
+    /// same pointer enter/exit events the mouse would send. Both mechanisms the widgets use
+    /// (<see cref="EventTrigger"/> and <c>UITooltipText</c>) implement the pointer handler interfaces, so
+    /// one synthetic event works for all of them and their existing mouse behaviour is untouched.
+    ///
+    /// One press advances through the registered widgets and a further press past the last one hides
+    /// everything, so a single button reaches them all and always has a way back to a clean HUD.
+    /// </summary>
+    internal static class TacticalTooltipCycler
+    {
+        /// <summary>Name of the rebindable action, created in TFTVDefsInjectedOnlyOnce.</summary>
+        internal const string ActionName = "TFTVCycleTacticalTooltips";
+
+        private sealed class Target
+        {
+            public string Name;
+            public Func<GameObject> Resolve;
+        }
+
+        private static readonly List<Target> _targets = new List<Target>();
+
+        private static int _current = -1;
+        private static GameObject _shown;
+        private static InputController _input;
+
+        /// <summary>
+        /// Registers a widget's hover target. The target is resolved through a delegate rather than stored
+        /// directly, because the widgets are rebuilt during a mission and a captured reference would go
+        /// stale. Registering the same name twice replaces the previous entry, so widgets can call this
+        /// every time they are built. Order of registration is the cycle order.
+        /// </summary>
+        internal static void Register(string name, Func<GameObject> resolve)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(name) || resolve == null)
+                {
+                    return;
+                }
+
+                for (int i = 0; i < _targets.Count; i++)
+                {
+                    if (_targets[i].Name == name)
+                    {
+                        _targets[i].Resolve = resolve;
+                        EnsureInputHandler();
+                        return;
+                    }
+                }
+
+                _targets.Add(new Target { Name = name, Resolve = resolve });
+                EnsureInputHandler();
+            }
+            catch (Exception e) { TFTVLogger.Error(e); }
+        }
+
+        /// <summary>Called when the tactical UI data is cleared, so nothing survives into a new mission.</summary>
+        internal static void Reset()
+        {
+            try
+            {
+                HideCurrent();
+                _targets.Clear();
+                _current = -1;
+            }
+            catch (Exception e) { TFTVLogger.Error(e); }
+        }
+
+        private static void EnsureInputHandler()
+        {
+            try
+            {
+                if (_input != null)
+                {
+                    return;
+                }
+
+                _input = GameUtl.GameComponent<InputController>();
+                if (_input == null)
+                {
+                    return;
+                }
+
+                // Ahead of everything, so the dedicated key always wins.
+                _input.EventHandlers.AddUnique(HandleInput, -110);
+
+                // Behind the view state (which registers at the default priority of 0), so B only reaches
+                // us when nothing else consumed it. The tactical states return true from Cancel exactly
+                // when they actually cancelled something - closing a contextual menu, dropping a targeting
+                // mode - so arriving here already means "there was nothing to cancel".
+                _input.EventHandlers.AddUnique(HandleUnhandledCancel, 50);
+            }
+            catch (Exception e) { TFTVLogger.Error(e); }
+        }
+
+        private static bool HandleInput(InputEvent ev)
+        {
+            try
+            {
+                if (ev.Type != InputEventType.Pressed || ev.Name != ActionName || _targets.Count == 0)
+                {
+                    return false;
+                }
+
+                Advance();
+                return true;
+            }
+            catch (Exception e)
+            {
+                TFTVLogger.Error(e);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Cycles on B when the gamepad has nothing else to cancel. The custom action exists as a
+        /// keyboard binding, but a mod-added gamepad binding never resolves to a physical button here, so
+        /// the pad reuses Cancel instead of claiming one.
+        ///
+        /// Gated on the event's own InputType rather than the controller's current mode, matching how the
+        /// tactical states themselves separate B from Escape - so Escape keeps its normal meaning.
+        /// </summary>
+        private static bool HandleUnhandledCancel(InputEvent ev)
+        {
+            try
+            {
+                if (ev.Type != InputEventType.Pressed
+                    || ev.Name != "Cancel"
+                    || ev.InputType != InputType.Joystick
+                    || _targets.Count == 0)
+                {
+                    return false;
+                }
+
+                // Targets are cleared between missions, but be certain this is a live tactical map before
+                // taking a button that means something everywhere else.
+                if (GameUtl.CurrentLevel()?.GetComponent<TacticalLevelController>() == null)
+                {
+                    return false;
+                }
+
+                Advance();
+                return true;
+            }
+            catch (Exception e)
+            {
+                TFTVLogger.Error(e);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Moves to the next widget that is actually on screen, then past the last one to showing nothing.
+        /// Widgets come and go during a mission - the Ancients widget only exists on those missions - so
+        /// unresolvable entries are skipped rather than costing the player a press on nothing.
+        /// </summary>
+        private static void Advance()
+        {
+            HideCurrent();
+
+            for (int step = 0; step < _targets.Count; step++)
+            {
+                _current++;
+
+                if (_current >= _targets.Count)
+                {
+                    // Past the end: everything hidden, next press starts the cycle again.
+                    _current = -1;
+                    return;
+                }
+
+                GameObject target = Resolve(_targets[_current]);
+                if (target != null)
+                {
+                    SendPointerEvent(target, ExecuteEvents.pointerEnterHandler);
+                    _shown = target;
+                    return;
+                }
+            }
+
+            _current = -1;
+        }
+
+        private static void HideCurrent()
+        {
+            if (_shown != null)
+            {
+                SendPointerEvent(_shown, ExecuteEvents.pointerExitHandler);
+            }
+
+            _shown = null;
+        }
+
+        private static GameObject Resolve(Target target)
+        {
+            try
+            {
+                GameObject go = target.Resolve();
+                return go != null && go.activeInHierarchy ? go : null;
+            }
+            catch (Exception e)
+            {
+                TFTVLogger.Error(e);
+                return null;
+            }
+        }
+
+        private static void SendPointerEvent(
+            GameObject target,
+            ExecuteEvents.EventFunction<IPointerEnterHandler> handler)
+        {
+            SendPointerEventInternal(target, (go, data) => ExecuteEvents.Execute(go, data, handler));
+        }
+
+        private static void SendPointerEvent(
+            GameObject target,
+            ExecuteEvents.EventFunction<IPointerExitHandler> handler)
+        {
+            SendPointerEventInternal(target, (go, data) => ExecuteEvents.Execute(go, data, handler));
+        }
+
+        private static void SendPointerEventInternal(
+            GameObject target,
+            Action<GameObject, PointerEventData> execute)
+        {
+            try
+            {
+                if (target == null)
+                {
+                    return;
+                }
+
+                // The widgets position their tooltips from values captured when they were built rather
+                // than from the event, so a pointer position is not needed - but one is supplied anyway
+                // for anything that reads it.
+                PointerEventData data = new PointerEventData(EventSystem.current)
+                {
+                    position = target.transform.position
+                };
+
+                execute(target, data);
+            }
+            catch (Exception e) { TFTVLogger.Error(e); }
+        }
+    }
+}


### PR DESCRIPTION
Three things, all in the tactical layer.

Tactical HUD tooltips on a gamepad. The Delirium, Human Enemies and Ancients widgets only show their detail on hover, and hover is unreachable with a pad: unlike the geoscape, the main tactical view runs no free cursor - it is only used on the inventory screen - so there is no pointer to put over them.

Rather than restructure three widgets, TacticalTooltipCycler drives them with the same pointer enter/exit events the mouse would send. Both mechanisms in use (EventTrigger and UITooltipText) implement the pointer handler interfaces, so one synthetic event works for all of them and their mouse behaviour is untouched. One press advances through the widgets and a further press past the last hides everything; widgets that are not on screen are skipped rather than costing a press.

The keyboard gets a proper rebindable action, with its default key chosen by scanning existing bindings for one tactical does not already use. The gamepad reuses Cancel instead of claiming a button: the handler registers behind the view state, and the tactical states return true from Cancel only when they actually cancelled something - so reaching our handler already means there was nothing to cancel. Gated on the event's own InputType so Escape keeps its normal meaning, and on a live TacticalLevelController so B is never taken outside a mission.

A gamepad chord on the custom action was tried first and never fired on any button. It is deliberately not included: chords register as OverridingHidden, so a binding that does nothing can still shadow a real action.

Two notes on the input API, both of which cost a crash to find:
- InputKey overloads == and dereferences both sides without a null check, so key == null and key != null both throw. This code holds names and hashes rather than InputKey references.
- A key is identified by Name (InputCache rewrites Hash from a name lookup, inventing a hash for an unknown name), but Hash must also be real and in range, because RefreshActions indexes a key value array by it. Both halves are copied off an existing binding.

Base defense widget. StratImplementer cleared StratToBeImplemented after a strat fired but never refreshed the widget, so the strat that had just executed stayed on screen until something else happened to update it. The venting path was already correct - it clears and refreshes - so what looked like venting failing to clear was the executed strat lingering.