### PR TITLE
Fix six geoscape and tactical bugs

### DIFF
--- a/Dist/Assets/Localization/TFTV_AircraftRework_Localization.csv
+++ b/Dist/Assets/Localization/TFTV_AircraftRework_Localization.csv
@@ -387,7 +387,7 @@ Some Dismissed operatives that have “Just a Grunt” perk, such as Mercenaries
 TUTORIAL_ADDITIONAL_BASES_TITLE0,Text,,Additional Phoenix Bases,,,,,,,,
 TUTORIAL_ADDITIONAL_BASES_TEXT0,Text,,"Bases can no longer be remotely activated. However, you can pay 30 mat and 5 tech to initiate remotely a low-quality Scan (same as the one with the Aircraft Marketplace Module, with each POI in range having a 50% of being revealed) from any Phoenix base that hasn’t been fully activated, provided you have an Aircraft that is no further than 4000Km from the base. The cost of each subsequent scan, even from a different base, will be increased by 30 mat and 5 tech. 
 
-Once you arrive at a Phoenix Base for the first time, you can Explore it. There is a chance (15% or 30%, depending on whether the base is inside the Mist) that the base might be infested, forcing you to fight a mission to clear. Upon completing the exploration you will receive some loot, the type and amount depending on difficulty level. You can override these settings on New Game start. 
+Once you arrive at a Phoenix Base for the first time, you can Explore it. There is a chance (10% or 20%, depending on whether the base is inside the Mist) that the base might be infested, forcing you to fight a mission to clear. Upon completing the exploration you will receive some loot, the type and amount depending on difficulty level. You can override these settings on New Game start. 
 
 You then have the following options:
 

--- a/TFTV/TFTV.csproj
+++ b/TFTV/TFTV.csproj
@@ -293,6 +293,7 @@
     <Compile Include="TFTVVanillaFixes\Tactical\DamageTacticalVanillaFixes.cs" />
     <Compile Include="TFTVVanillaFixes\Tactical\DecimalWPTacticalVanillaFixes.cs" />
     <Compile Include="TFTVVanillaFixes\Tactical\InventoryDupeTacticalVanillaFixes.cs" />
+    <Compile Include="TFTVVanillaFixes\Tactical\FirePathCostTacticalVanillaFixes.cs" />
     <Compile Include="TFTVVanillaFixes\Tactical\MadSkunkyFixes.cs" />
     <Compile Include="TFTVVanillaFixes\Tactical\MindControlTacticalVanillaFixes.cs" />
     <Compile Include="TFTVVanillaFixes\Tactical\OWNotTriggeringTacticalVanillaFixes.cs" />
@@ -304,6 +305,7 @@
     <Compile Include="TFTVVanillaFixes\Tactical\TurretAmmoRefillTacticalVanillaFixes.cs" />
     <Compile Include="TFTVVanillaFixes\Tactical\UICharacterSelectedVanillaFixes.cs" />
     <Compile Include="TFTVVanillaFixes\Tactical\UITacticalVanillaFixes.cs" />
+    <Compile Include="TFTVVanillaFixes\Tactical\VehicleHulkCrateTacticalVanillaFixes.cs" />
     <Compile Include="TFTVVanillaFixes\Tactical\WPtoMistLossTacticalVanillaFixes.cs" />
     <Compile Include="TFTVVanillaFixes\Tactical\XPTacticalVanillaFixes.cs" />
     <Compile Include="TFTVVehicleFixes.cs" />

--- a/TFTV/TFTVBaseRework/BaseExploration.cs
+++ b/TFTV/TFTVBaseRework/BaseExploration.cs
@@ -149,7 +149,7 @@ namespace TFTV.TFTVBaseRework
 
 
     /// <summary>
-    /// Roll the 15% infestation chance when explicit exploration completes.
+    /// Roll the infestation chance when explicit exploration completes.
     ///
     /// If the roll passes, CreatePhoenixBaseInfestationMission() is called immediately.
     /// Vanilla then marks the site visited and the UI's normal VehicleVisitedSite flow
@@ -259,7 +259,7 @@ namespace TFTV.TFTVBaseRework
     /// Disable vanilla activation-time infestation.
     ///
     /// Vanilla BaseInfestationCheck uses campaign day, mist, and base infestation
-    /// counter. This mod wants the only infestation roll to be the 15% exploration
+    /// counter. This mod wants the only infestation roll to be the exploration
     /// completion roll above.
     /// </summary>
     [HarmonyPatch(typeof(GeoPhoenixBase), nameof(GeoPhoenixBase.BaseInfestationCheck))]

--- a/TFTV/TFTVDrills/DrillsUI.Patches.cs
+++ b/TFTV/TFTVDrills/DrillsUI.Patches.cs
@@ -127,22 +127,31 @@ namespace TFTV.TFTVDrills
                     var ability = __instance.AbilityDef ?? ElementHelpers.FindSlot(__instance)?.Ability;
                     var availableImage = __instance.Available;
 
+                    if (availableImage == null)
+                    {
+                        return;
+                    }
 
                     bool shouldShowIndicator = DrillIndicator.ShouldShow(character, phoenixFaction, ability, availableImage);
+
+                    // Remember the vanilla corner triangle before it is ever swapped out. Caching
+                    // it only on the drill branch left it null whenever the first entry examined
+                    // wanted no drill indicator, and the else branch then wrote that null onto the
+                    // Image - an Image with no sprite draws as a plain flashing square.
+                    if (_originalAvailableImage == null
+                        && availableImage.sprite != null
+                        && availableImage.sprite != DrillsDefs._drillAvailable)
+                    {
+                        _originalAvailableImage = availableImage.sprite;
+                    }
 
                     if (_originalAvailableImage != null)
                     {
                         availableImage.sprite = _originalAvailableImage;
                     }
-                   
 
                     if (shouldShowIndicator)
                     {
-                        if (_originalAvailableImage == null)
-                        {
-                            _originalAvailableImage = availableImage.sprite;
-                        }
-
                         availableImage.sprite = DrillsDefs._drillAvailable;
                         availableImage.gameObject.SetActive(true);
                         __instance.AvailableSkill = true;
@@ -153,7 +162,6 @@ namespace TFTV.TFTVDrills
                     {
                         availableImage.gameObject.SetActive(isAvailable && isBuyable);
                         __instance.AvailableSkill = isAvailable;
-                        availableImage.sprite = _originalAvailableImage;
                         // TFTVLogger.Always($"should show indicator for ability {ability?.name} false");
                     }
 

--- a/TFTV/TFTVVanillaFixes/Geoscape/TemporaryGeoscapeVanillaFixes.cs
+++ b/TFTV/TFTVVanillaFixes/Geoscape/TemporaryGeoscapeVanillaFixes.cs
@@ -2,6 +2,7 @@
 using Base.Utils;
 using HarmonyLib;
 using PhoenixPoint.Common.Entities;
+using PhoenixPoint.Common.Entities.Items;
 using PhoenixPoint.Common.View.ViewControllers.Inventory;
 using PhoenixPoint.Geoscape.Entities;
 using PhoenixPoint.Geoscape.Entities.Sites;
@@ -124,6 +125,65 @@ namespace TFTV.TFTVVanillaFixes.Geoscape
                 }
 
                 return false;
+            }
+        }
+
+        /// <summary>
+        /// GeoCharacter.GetMissingLoadoutItems() decides what "Equip loadout" still has to
+        /// find for an operative, and it miscounts duplicates.
+        ///
+        /// It tallies the equipped items and the saved loadout items into one shared counter
+        /// per ItemDef and then reports an item as missing only when that combined tally is
+        /// exactly 1. That reads correctly only while no ItemDef appears more than once in
+        /// either list. An operative whose saved loadout holds two of the same item - two
+        /// deployable turrets in the ready slots, say - tallies 2 with nothing equipped at
+        /// all, so the item is never reported missing. Nothing is then gathered from outside
+        /// the squad and nothing is manufactured, and the loadout silently stays unequipped.
+        ///
+        /// Replaced with a plain multiset difference: every saved item that has no equipped
+        /// counterpart left to pair off with is missing.
+        /// </summary>
+        [HarmonyPatch(typeof(GeoCharacter), nameof(GeoCharacter.GetMissingLoadoutItems))]
+        internal static class GetMissingLoadoutItemsDuplicateCountPatch
+        {
+            private static bool Prefix(GeoCharacter __instance, ref List<GeoItem> __result)
+            {
+                List<GeoItem> missing = new List<GeoItem>();
+                AddMissingItems(__instance.ArmourItems, __instance.ArmourLoadoutItems, missing);
+                AddMissingItems(__instance.EquipmentItems, __instance.EquipmentLoadoutItems, missing);
+                AddMissingItems(__instance.InventoryItems, __instance.InventoryLoadoutItems, missing);
+                __result = missing;
+
+                // Skip the original combined-tally implementation.
+                return false;
+            }
+
+            private static void AddMissingItems(
+                IReadOnlyList<GeoItem> equippedItems,
+                IReadOnlyList<GeoItem> savedLoadoutItems,
+                List<GeoItem> missing)
+            {
+                Dictionary<ItemDef, int> unmatchedEquipped = new Dictionary<ItemDef, int>();
+                foreach (GeoItem equippedItem in equippedItems)
+                {
+                    int count;
+                    unmatchedEquipped.TryGetValue(equippedItem.ItemDef, out count);
+                    unmatchedEquipped[equippedItem.ItemDef] = count + 1;
+                }
+
+                foreach (GeoItem savedItem in savedLoadoutItems)
+                {
+                    int count;
+                    if (unmatchedEquipped.TryGetValue(savedItem.ItemDef, out count) && count > 0)
+                    {
+                        // This saved copy is already covered by an equipped one.
+                        unmatchedEquipped[savedItem.ItemDef] = count - 1;
+                    }
+                    else
+                    {
+                        missing.Add(savedItem);
+                    }
+                }
             }
         }
 

--- a/TFTV/TFTVVanillaFixes/Tactical/FirePathCostTacticalVanillaFixes.cs
+++ b/TFTV/TFTVVanillaFixes/Tactical/FirePathCostTacticalVanillaFixes.cs
@@ -1,0 +1,52 @@
+using HarmonyLib;
+using PhoenixPoint.Tactical.Levels;
+using System;
+
+namespace TFTV.TFTVVanillaFixes.Tactical
+{
+    /// <summary>
+    /// Bounds how far a unit will walk to keep off a burning tile.
+    ///
+    /// TacticalNavCostFactorFuncs prices a fire tile at a multiple of a normal tile equal to
+    /// the fire's damage number - Fire_DamageEffectDef, which TFTV raises to 50 for the
+    /// Mephistopheles module. That multiplier is exactly the detour the pathfinder is willing
+    /// to make: it takes the way round whenever the detour is shorter than 50 tiles, which is
+    /// where the absurd walkabouts around a single burning tile come from.
+    ///
+    /// The cap below stays far above any unit's movement budget - the fastest are well under
+    /// 25 tiles in a turn - so fire remains as impassable as it was, while the worst-case
+    /// detour halves and pathing no longer moves whenever the fire damage number is retuned.
+    /// </summary>
+    internal static class FirePathCostTacticalVanillaFixes
+    {
+        internal const float MaxFirePathCostFactor = 25f;
+
+        [HarmonyPatch(typeof(TacticalNavCostFactorFuncs), nameof(TacticalNavCostFactorFuncs.CostFactorFunc))]
+        internal static class TacticalNavCostFactorFuncs_CostFactorFunc_Patch
+        {
+            private static void Postfix(ref float __result)
+            {
+                if (__result > MaxFirePathCostFactor)
+                {
+                    __result = MaxFirePathCostFactor;
+                }
+            }
+        }
+
+        /// <summary>
+        /// The search budget is the path length multiplied by this, so it has to move with the
+        /// cap above or the pathfinder keeps exploring routes it can no longer price.
+        /// </summary>
+        [HarmonyPatch(typeof(TacticalNavCostFactorFuncs), nameof(TacticalNavCostFactorFuncs.MaxCostFactorFunc))]
+        internal static class TacticalNavCostFactorFuncs_MaxCostFactorFunc_Patch
+        {
+            private static void Postfix(ref float __result)
+            {
+                if (__result > MaxFirePathCostFactor)
+                {
+                    __result = MaxFirePathCostFactor;
+                }
+            }
+        }
+    }
+}

--- a/TFTV/TFTVVanillaFixes/Tactical/VehicleHulkCrateTacticalVanillaFixes.cs
+++ b/TFTV/TFTVVanillaFixes/Tactical/VehicleHulkCrateTacticalVanillaFixes.cs
@@ -1,0 +1,87 @@
+using HarmonyLib;
+using PhoenixPoint.Tactical.Entities.Equipments;
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace TFTV.TFTVVanillaFixes.Tactical
+{
+    /// <summary>
+    /// Destroyed vehicles leave a hulk that doubles as a lootable crate, but the hulk's
+    /// Animator has no "open" bool parameter. CrateComponent.Open() therefore never gets
+    /// its OnCrateOpenAnim() animation event and IsOpen() keeps returning false, with two
+    /// consequences:
+    ///
+    ///  * OpenCrateAbility spins on "while (crate.IsOpening)" until CrateOpenTimeout expires,
+    ///    holding the game in UIStateWaiting for a full 10 seconds. The UI is dead and the
+    ///    actor stands frozen in its idle animation for the duration.
+    ///  * Because the hulk never counts as open, every subsequent move next to it re-fires
+    ///    the ability, re-awarding the crate's Will Points bonus and popping the inventory.
+    ///
+    /// Both follow from the animator refusing the flag, so both are fixed by noticing that
+    /// Open() failed to take and recording the open state on the mod's side instead.
+    /// </summary>
+    internal static class VehicleHulkCrateTacticalVanillaFixes
+    {
+        private static readonly ConditionalWeakTable<CrateComponent, object> OpenedWithoutAnimator =
+            new ConditionalWeakTable<CrateComponent, object>();
+
+        private static readonly MethodInfo IsOpeningSetter =
+            AccessTools.PropertySetter(typeof(CrateComponent), nameof(CrateComponent.IsOpening));
+
+        [HarmonyPatch(typeof(CrateComponent), nameof(CrateComponent.Open))]
+        internal static class CrateComponent_Open_NoOpenAnimation_Patch
+        {
+            private static void Postfix(CrateComponent __instance)
+            {
+                try
+                {
+                    if (__instance == null)
+                    {
+                        return;
+                    }
+
+                    object marker;
+                    if (!OpenedWithoutAnimator.TryGetValue(__instance, out marker))
+                    {
+                        // A crate whose animator accepted the flag reports itself open right away.
+                        // Ask before the crate is marked, so IsOpen() still reflects the animator.
+                        if (__instance.IsOpen())
+                        {
+                            return;
+                        }
+
+                        OpenedWithoutAnimator.Add(__instance, null);
+                    }
+
+                    // There is no open animation to wait for, so stop waiting on it.
+                    IsOpeningSetter?.Invoke(__instance, new object[] { false });
+                }
+                catch (Exception e)
+                {
+                    TFTVLogger.Error(e);
+                }
+            }
+        }
+
+        [HarmonyPatch(typeof(CrateComponent), nameof(CrateComponent.IsOpen))]
+        internal static class CrateComponent_IsOpen_NoOpenAnimation_Patch
+        {
+            private static void Postfix(CrateComponent __instance, ref bool __result)
+            {
+                try
+                {
+                    object marker;
+                    if (!__result && __instance != null && OpenedWithoutAnimator.TryGetValue(__instance, out marker))
+                    {
+                        __result = true;
+                    }
+                }
+                catch (Exception e)
+                {
+                    TFTVLogger.Error(e);
+                }
+            }
+        }
+    }
+}

--- a/TFTV/Vehicles/Abilities/ExtendedEnterVehicle.cs
+++ b/TFTV/Vehicles/Abilities/ExtendedEnterVehicle.cs
@@ -26,38 +26,92 @@ namespace TFTVVehicleRework.Abilities
         {
             get
             {
-                if (base.ShouldDisplay)
-                {
-                    IEnumerable<TacticalAbilityTarget> targets = base.GetTargets();
-                    foreach (TacticalAbilityTarget tacticalAbilityTarget in targets)
-                    {
-                        VehicleComponent vehicle = tacticalAbilityTarget.Actor.Vehicle;
-                        AdjustAccessCostStatus AdjustAccessCost = vehicle.TacticalActorBase.Status.GetStatus<AdjustAccessCostStatus>();
-                        if (!AdjustAccessCost.IsDefaultValue() && AdjustAccessCost.AdjustAccessCostStatusDef.AccessDirection == AdjustAccessCostStatusDef.Direction.Entry)
-                        {
-                            if(this.APCostModification == null)
-                            {   
-                                this.APCostModification = AdjustAccessCost.AdjustAccessCostStatusDef.AccessCostModification;
-                                this.TacticalActor.AddAbilityCostModification(this.APCostModification);
-                            }
-                        }
-                    }
-                }
-                else
-                {
-                    if (this.APCostModification != null)
-                    {
-                        this.TacticalActor.RemoveAbilityCostModification(this.APCostModification);
-                        this.APCostModification = null;
-                    }
-                }
+                this.UpdateAccessCostModification();
                 return base.ShouldDisplay;
             }
+        }
+
+        /// <summary>
+        /// Registers the entry AP discount granted by a vehicle module (the Armadillo's
+        /// Lightweight Alloy, for one) on the operative.
+        ///
+        /// This can't wait for ShouldDisplay to become true. EnterVehicleAbility.ShouldDisplay
+        /// only turns true once the operative already stands on the vehicle's entry point,
+        /// whereas the entry tile marker is drawn earlier: TacUtil filters the operative's move
+        /// targets through TacticalActor.GetMaxMoveAndActRange(), which prices this ability from
+        /// the cost modifications registered on the operative at that moment. With the discount
+        /// still unregistered the ability was priced at its full cost, so an operative with less
+        /// than 1 AP got no marker on a tile they could in fact board from.
+        /// </summary>
+        private void UpdateAccessCostModification()
+        {
+            TacticalActor actor = this.TacticalActor;
+            if (actor == null)
+            {
+                return;
+            }
+
+            TacticalAbilityCostModification modification = actor.IsMounted ? null : this.FindEntryCostModification();
+            if (modification == this.APCostModification)
+            {
+                return;
+            }
+
+            if (this.APCostModification != null)
+            {
+                actor.RemoveAbilityCostModification(this.APCostModification);
+                this.APCostModification = null;
+            }
+
+            if (modification != null)
+            {
+                this.APCostModification = modification;
+                actor.AddAbilityCostModification(modification);
+            }
+        }
+
+        /// <summary>
+        /// The entry discount of the first boardable friendly vehicle that grants one, or null.
+        /// </summary>
+        private TacticalAbilityCostModification FindEntryCostModification()
+        {
+            TacticalFaction faction = this.TacticalActorBase.TacticalFaction;
+            if (faction == null)
+            {
+                return null;
+            }
+
+            foreach (TacticalActor vehicleActor in faction.TacticalActors)
+            {
+                VehicleComponent vehicle = (vehicleActor != null) ? vehicleActor.Vehicle : null;
+                if (vehicle == null || vehicle.IsFull || !vehicleActor.IsAlive)
+                {
+                    continue;
+                }
+
+                foreach (AdjustAccessCostStatus adjustAccessCost in vehicleActor.Status.GetStatuses<AdjustAccessCostStatus>())
+                {
+                    if (adjustAccessCost.IsDefaultValue()
+                        || adjustAccessCost.AdjustAccessCostStatusDef.AccessDirection != AdjustAccessCostStatusDef.Direction.Entry)
+                    {
+                        continue;
+                    }
+
+                    return adjustAccessCost.AdjustAccessCostStatusDef.AccessCostModification;
+                }
+            }
+
+            return null;
         }
 
         public override void Activate(object parameter = null)
         {
             base.Activate(parameter);
+            if (this.APCostModification != null)
+            {
+                this.TacticalActor.RemoveAbilityCostModification(this.APCostModification);
+                this.APCostModification = null;
+            }
             if (this.ExtendedEnterVehicleAbilityDef.StealthStatus != null)
             {
                 this.TacticalActor.Status.ApplyStatus(this.ExtendedEnterVehicleAbilityDef.StealthStatus);


### PR DESCRIPTION
> **Note:** follow-up review of the vehicle entry fix (section a) landed after this PR merged, in a separate PR. This description reflects what was merged here.

Six unrelated bug fixes — three in Geoscape, three in Tactical. Each is independent; the shared context is that they were investigated together.

## Geoscape

### 1. Base exploration ambush chance text said 15% / 30%

`PhoenixBaseExplorationConfig.InfestationChancePercent` is `10`, doubled inside the Mist. The tutorial text in `TFTV_AircraftRework_Localization.csv` claimed 15% / 30%. Corrected to 10% / 20%, along with two doc comments in `BaseExploration.cs` that still said "the 15% exploration roll".

Text only — no behaviour change.

### 2. "Equip loadout" silently does nothing when a saved loadout holds duplicates

Vanilla `GeoCharacter.GetMissingLoadoutItems()` tallies the *equipped* items and the *saved loadout* items into one shared per-`ItemDef` counter, then reports an item missing only when that combined tally is exactly `1`. That reads correctly only while no `ItemDef` appears more than once in either list.

A technician whose saved loadout holds two deployable turrets tallies `2` **with nothing equipped at all**, so the turrets are never reported missing. `TryGatheringEquipmentFromOutsideOfSquad` then returns "all satisfied", nothing is gathered from operatives outside the squad, `tryToManufacture` stays false, and the loadout is silently left unequipped.

Replaced with a plain multiset difference: every saved item with no equipped counterpart left to pair off with is missing.

### 3. Flashing square instead of the corner triangle in the ability track

Ours, in `DrillsUI.Patches.cs`. The static `_originalAvailableImage` was only ever assigned inside the "show drill indicator" branch, but the `else` branch assigned that field onto the `Image` unconditionally. If the first entry element examined wanted no drill indicator, the Image received a **null sprite** — which Unity draws as a plain quad, and the vanilla `AbilityTrackSkillEntryElement.LateUpdate` colour-lerp then pulses. Hence a flashing square where the triangle should be, and only sometimes, depending on which entry was processed first.

The sprite is now captured before anything overwrites it (and never captured *as* the drill sprite), and is never written back as null.

## Tactical

### a. Entry tile not highlighted for operatives under 1 AP when boarding is free

`ExtendedEnterVehicleAbility.ShouldDisplay` registered the vehicle module's entry AP discount as a side effect of `base.ShouldDisplay`. But `EnterVehicleAbility.ShouldDisplay` only turns true once the operative is *already standing on* the vehicle's entry point.

The entry tile marker is drawn earlier than that: `TacUtil.UpdateActionMarkersForAbilities` filters move targets through `TacticalActor.GetMaxMoveAndActRange()`, which prices the ability from the cost modifications registered on the operative at that moment. With the discount still unregistered the ability was priced at its full cost, so an operative with less than 1 AP got no marker on a tile they could in fact board from — the boarding itself worked, only the highlight was missing.

The discount is now registered whenever a boardable friendly vehicle grants one, and dropped on mount and on activation (matching `ExtendedExitVehicleAbility`). Also handles a vehicle carrying more than one `AdjustAccessCostStatus`.

### b. 10-second UI and animation freeze near a destroyed vehicle

Diagnosed from the attached `Player.log`. `KS_Buggy_1` dies at frame 49470 into `VEH_KS_Death_Buggy_Hulk_Ready_20`. Each `OpenCrate` on that hulk (frames 62140, 67405, 68329) is followed by ~594 frames — **10.02 s each** — stuck in `UIStateWaiting`.

The hulk's Animator has no `"open"` bool parameter, so `CrateComponent.Open()`'s `SetBool` is a no-op, the `OnCrateOpenAnim` animation event never fires, and `OpenCrateAbility` spins on `while (crate.IsOpening)` until the full 10 second `CrateOpenTimeout` — with the game held in `UIStateWaiting`, so the UI is dead and the actor stands frozen in its idle animation.

The same cause explains the repeats visible in the log: because `IsOpen()` keeps returning false, every subsequent move next to the wreck re-fires the ability, re-awarding the crate's Will Points bonus and re-popping the inventory.

New patch detects that the animator refused the flag (the crate does not report itself open right after `Open()`) and records the open state mod-side, clearing `IsOpening` immediately.

### c. Impossibly long enemy detours around fire

**Reviewer input wanted on the constant.** This one is a tuning knob rather than a defect, and the trade-off is worth knowing.

`TacticalNavCostFactorFuncs.CostFactorFunc` prices a fire tile at a multiple of a normal tile *equal to the fire's damage number*, and that multiplier **is** the detour distance: the pathfinder takes the way round whenever the way round is shorter than that many tiles.

Vanilla `Fire_DamageEffectDef` is 40. `Vehicles/Armadillo/Mephistopheles.cs:73` raises that **global** def to 50 while configuring the Armadillo flamethrower, so a pandoran will currently walk up to 50 tiles around a single burning tile.

Capped the pathing factor at `MaxFirePathCostFactor = 25`, which:

- stays above every unit's tiles-per-turn, so fire remains exactly as impassable as it was — that same number is what makes fire impassable, since a unit crosses it only when the cost fits its move budget;
- halves the worst-case detour;
- decouples pathing from the fire damage number, so retuning fire damage no longer moves enemy pathing.

The cap cannot go much lower without changing what fire *is*. At ~10 fire becomes crossable at the price of a turn's movement — a real balance change, not a bug fix. Happy to pick a different number.

## Separately worth a look (not changed here)

`Vehicles/Armadillo/Mephistopheles.cs:73` edits the shared `Fire_DamageEffectDef` (40 → 50 min and max), so it also raises fire's damage-per-turn *everywhere in the game*, not just the module's own burn. Left alone since it is balance and may be deliberate.

## Testing

Builds clean (0 errors). The fixes are behavioural and were verified by reading the decompiled game code and the attached `Player.log` frame timings rather than by playing; in-game confirmation would be welcome, particularly (a), (b) and (c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
