### PR TITLE
Scope the Armadillo Fast Entry discount to the vehicle being boarded

### DIFF
--- a/TFTV/TFTV.csproj
+++ b/TFTV/TFTV.csproj
@@ -429,6 +429,7 @@
     <Compile Include="Vehicles\Effects\AddedRotationParticleEffect.cs" />
     <Compile Include="Vehicles\Effects\AddedRotationParticleEffectDef.cs" />
     <Compile Include="Vehicles\HarmonyPatches\GeoCharacter_Patches.cs" />
+    <Compile Include="Vehicles\HarmonyPatches\MoveAbilityTargetData_Patches.cs" />
     <Compile Include="Vehicles\HarmonyPatches\SwitchStanceAbility_Patches.cs" />
     <Compile Include="Vehicles\HarmonyPatches\TacticalAbility_Patches.cs" />
     <Compile Include="Vehicles\HarmonyPatches\TacticalActor_Patches.cs" />

--- a/TFTV/Vehicles/Abilities/ExtendedEnterVehicle.cs
+++ b/TFTV/Vehicles/Abilities/ExtendedEnterVehicle.cs
@@ -4,7 +4,7 @@ using Base.Serialization.General;
 using PhoenixPoint.Tactical.Entities;
 using PhoenixPoint.Tactical.Entities.Abilities;
 using PhoenixPoint.Tactical.Levels;
-using System.Collections.Generic;
+using UnityEngine;
 
 namespace TFTVVehicleRework.Abilities 
 {
@@ -32,16 +32,17 @@ namespace TFTVVehicleRework.Abilities
         }
 
         /// <summary>
-        /// Registers the entry AP discount granted by a vehicle module (the Armadillo's
-        /// Lightweight Alloy, for one) on the operative.
+        /// Registers the entry AP discount granted by the vehicle the operative is in position
+        /// to board (the Armadillo's Lightweight Alloy, for one).
         ///
-        /// This can't wait for ShouldDisplay to become true. EnterVehicleAbility.ShouldDisplay
-        /// only turns true once the operative already stands on the vehicle's entry point,
-        /// whereas the entry tile marker is drawn earlier: TacUtil filters the operative's move
-        /// targets through TacticalActor.GetMaxMoveAndActRange(), which prices this ability from
-        /// the cost modifications registered on the operative at that moment. With the discount
-        /// still unregistered the ability was priced at its full cost, so an operative with less
-        /// than 1 AP got no marker on a tile they could in fact board from.
+        /// A TacticalAbilityCostModification carries no target of its own - AbilityQualifies()
+        /// matches on the ability's skill tags - so any registered discount applies to every
+        /// vehicle the operative boards. Keeping it tied to what is boardable from the
+        /// operative's own tile is therefore the only thing stopping a second, module-less
+        /// vehicle from being boarded for free.
+        ///
+        /// The entry tile marker is priced before the operative is in position and is handled
+        /// separately, per candidate tile, by MoveAbilityTargetData_IsActorInActionRange_Patch.
         /// </summary>
         private void UpdateAccessCostModification()
         {
@@ -51,8 +52,14 @@ namespace TFTVVehicleRework.Abilities
                 return;
             }
 
-            TacticalAbilityCostModification modification = actor.IsMounted ? null : this.FindEntryCostModification();
-            if (modification == this.APCostModification)
+            this.SetAccessCostModification(
+                actor.IsMounted ? null : this.GetEntryCostModificationAt(actor.Pos));
+        }
+
+        private void SetAccessCostModification(TacticalAbilityCostModification modification)
+        {
+            TacticalActor actor = this.TacticalActor;
+            if (actor == null || modification == this.APCostModification)
             {
                 return;
             }
@@ -71,51 +78,15 @@ namespace TFTVVehicleRework.Abilities
         }
 
         /// <summary>
-        /// The entry discount that currently applies to this operative, or null.
-        ///
-        /// A TacticalAbilityCostModification carries no target of its own - AbilityQualifies()
-        /// matches on the ability's skill tags - so once registered it discounts boarding any
-        /// vehicle. The discount belongs to the vehicle carrying the module ("Entering the
-        /// vehicle does not cost any Action Points"), which forces two regimes.
+        /// The entry discount granted by a vehicle boardable from <paramref name="position"/>,
+        /// or null. Only vehicles this operative could actually board from that exact tile are
+        /// consulted, so the discount never reaches a vehicle without the module.
         /// </summary>
-        private TacticalAbilityCostModification FindEntryCostModification()
+        internal TacticalAbilityCostModification GetEntryCostModificationAt(Vector3 position)
         {
-            // Standing on an entry point: the boarding target is settled, so price the exact
-            // vehicle being boarded. This is the regime that governs whether the ability is
-            // affordable and what Activate() actually charges, so a second vehicle parked
-            // nearby never gets boarded on the Armadillo's discount.
-            bool atEntryPoint = false;
-            foreach (TacticalAbilityTarget target in base.GetTargets())
+            foreach (TacticalAbilityTarget target in base.GetTargetsAt(position))
             {
-                atEntryPoint = true;
-
                 TacticalAbilityCostModification modification = GetEntryCostModification(target.Actor);
-                if (modification != null)
-                {
-                    return modification;
-                }
-            }
-
-            if (atEntryPoint)
-            {
-                return null;
-            }
-
-            // Out of position, so no boarding target exists yet. The entry tile marker is
-            // priced right now - TacUtil runs the operative's move targets through
-            // GetMaxMoveAndActRange(), which knows the ability but not the destination - so
-            // the discount has to be registered for any boardable vehicle that grants one or
-            // the tile is never highlighted at all. Planning only: by the time the operative
-            // reaches an entry point the exact regime above takes over.
-            TacticalFaction faction = this.TacticalActorBase.TacticalFaction;
-            if (faction == null)
-            {
-                return null;
-            }
-
-            foreach (TacticalActor vehicleActor in faction.TacticalActors)
-            {
-                TacticalAbilityCostModification modification = GetEntryCostModification(vehicleActor);
                 if (modification != null)
                 {
                     return modification;
@@ -126,7 +97,7 @@ namespace TFTVVehicleRework.Abilities
         }
 
         /// <summary>
-        /// The entry discount granted by one boardable vehicle, or null.
+        /// The entry discount granted by one vehicle, or null.
         /// </summary>
         private static TacticalAbilityCostModification GetEntryCostModification(TacticalActorBase vehicleActorBase)
         {
@@ -152,12 +123,16 @@ namespace TFTVVehicleRework.Abilities
 
         public override void Activate(object parameter = null)
         {
+            // base.Activate() charges the AP, so settle the discount against the vehicle
+            // actually being boarded first. One tile can be an entry point for two vehicles,
+            // and the cost modification carries no target that could tell them apart.
+            TacticalAbilityTarget target = parameter as TacticalAbilityTarget;
+            this.SetAccessCostModification(
+                (target != null) ? GetEntryCostModification(target.Actor) : null);
+
             base.Activate(parameter);
-            if (this.APCostModification != null)
-            {
-                this.TacticalActor.RemoveAbilityCostModification(this.APCostModification);
-                this.APCostModification = null;
-            }
+
+            this.SetAccessCostModification(null);
             if (this.ExtendedEnterVehicleAbilityDef.StealthStatus != null)
             {
                 this.TacticalActor.Status.ApplyStatus(this.ExtendedEnterVehicleAbilityDef.StealthStatus);

--- a/TFTV/Vehicles/Abilities/ExtendedEnterVehicle.cs
+++ b/TFTV/Vehicles/Abilities/ExtendedEnterVehicle.cs
@@ -71,10 +71,42 @@ namespace TFTVVehicleRework.Abilities
         }
 
         /// <summary>
-        /// The entry discount of the first boardable friendly vehicle that grants one, or null.
+        /// The entry discount that currently applies to this operative, or null.
+        ///
+        /// A TacticalAbilityCostModification carries no target of its own - AbilityQualifies()
+        /// matches on the ability's skill tags - so once registered it discounts boarding any
+        /// vehicle. The discount belongs to the vehicle carrying the module ("Entering the
+        /// vehicle does not cost any Action Points"), which forces two regimes.
         /// </summary>
         private TacticalAbilityCostModification FindEntryCostModification()
         {
+            // Standing on an entry point: the boarding target is settled, so price the exact
+            // vehicle being boarded. This is the regime that governs whether the ability is
+            // affordable and what Activate() actually charges, so a second vehicle parked
+            // nearby never gets boarded on the Armadillo's discount.
+            bool atEntryPoint = false;
+            foreach (TacticalAbilityTarget target in base.GetTargets())
+            {
+                atEntryPoint = true;
+
+                TacticalAbilityCostModification modification = GetEntryCostModification(target.Actor);
+                if (modification != null)
+                {
+                    return modification;
+                }
+            }
+
+            if (atEntryPoint)
+            {
+                return null;
+            }
+
+            // Out of position, so no boarding target exists yet. The entry tile marker is
+            // priced right now - TacUtil runs the operative's move targets through
+            // GetMaxMoveAndActRange(), which knows the ability but not the destination - so
+            // the discount has to be registered for any boardable vehicle that grants one or
+            // the tile is never highlighted at all. Planning only: by the time the operative
+            // reaches an entry point the exact regime above takes over.
             TacticalFaction faction = this.TacticalActorBase.TacticalFaction;
             if (faction == null)
             {
@@ -83,22 +115,36 @@ namespace TFTVVehicleRework.Abilities
 
             foreach (TacticalActor vehicleActor in faction.TacticalActors)
             {
-                VehicleComponent vehicle = (vehicleActor != null) ? vehicleActor.Vehicle : null;
-                if (vehicle == null || vehicle.IsFull || !vehicleActor.IsAlive)
+                TacticalAbilityCostModification modification = GetEntryCostModification(vehicleActor);
+                if (modification != null)
+                {
+                    return modification;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// The entry discount granted by one boardable vehicle, or null.
+        /// </summary>
+        private static TacticalAbilityCostModification GetEntryCostModification(TacticalActorBase vehicleActorBase)
+        {
+            VehicleComponent vehicle = (vehicleActorBase != null) ? vehicleActorBase.Vehicle : null;
+            if (vehicle == null || vehicle.IsFull || !vehicleActorBase.IsAlive)
+            {
+                return null;
+            }
+
+            foreach (AdjustAccessCostStatus adjustAccessCost in vehicleActorBase.Status.GetStatuses<AdjustAccessCostStatus>())
+            {
+                if (adjustAccessCost.IsDefaultValue()
+                    || adjustAccessCost.AdjustAccessCostStatusDef.AccessDirection != AdjustAccessCostStatusDef.Direction.Entry)
                 {
                     continue;
                 }
 
-                foreach (AdjustAccessCostStatus adjustAccessCost in vehicleActor.Status.GetStatuses<AdjustAccessCostStatus>())
-                {
-                    if (adjustAccessCost.IsDefaultValue()
-                        || adjustAccessCost.AdjustAccessCostStatusDef.AccessDirection != AdjustAccessCostStatusDef.Direction.Entry)
-                    {
-                        continue;
-                    }
-
-                    return adjustAccessCost.AdjustAccessCostStatusDef.AccessCostModification;
-                }
+                return adjustAccessCost.AdjustAccessCostStatusDef.AccessCostModification;
             }
 
             return null;

--- a/TFTV/Vehicles/HarmonyPatches/MoveAbilityTargetData_Patches.cs
+++ b/TFTV/Vehicles/HarmonyPatches/MoveAbilityTargetData_Patches.cs
@@ -1,0 +1,109 @@
+using HarmonyLib;
+using PhoenixPoint.Tactical.Entities;
+using PhoenixPoint.Tactical.Entities.Abilities;
+using PhoenixPoint.Tactical.Levels;
+using System;
+using TFTVVehicleRework.Abilities;
+using UnityEngine;
+
+namespace TFTVVehicleRework.HarmonyPatches
+{
+    /// <summary>
+    /// Prices the boarding marker against the vehicle that would actually be boarded.
+    ///
+    /// TacUtil draws an ability's ground markers by running the operative's move targets
+    /// through MoveAbilityTargetData.IsActorInActionRange(actor, ability) and handing the
+    /// survivors to SceneViewElement.GetPositionMarkers(), which keeps only tiles where
+    /// GetTargetsAt() finds something to board. So the marker is already correct about
+    /// "can this operative board from here" - the filter above it is what was wrong.
+    ///
+    /// That filter prices the ability through GetMaxMoveAndActRange(), which knows the
+    /// ability but not the destination, so it read the entry cost from whatever discount
+    /// happened to be registered on the operative. Registering the discount up front made
+    /// the marker appear but let it apply to any vehicle; not registering it priced boarding
+    /// at full cost and hid the marker from an operative with less than 1 AP.
+    ///
+    /// The destination is known here, so the discount granted by the vehicles boardable from
+    /// that exact tile is registered just for this one evaluation.
+    /// </summary>
+    [HarmonyPatch(typeof(MoveAbilityTargetData), nameof(MoveAbilityTargetData.IsActorInActionRange),
+        new Type[] { typeof(TacticalActor), typeof(TacticalAbility) })]
+    internal static class MoveAbilityTargetData_IsActorInActionRange_Patch
+    {
+        private static bool Prefix(
+            MoveAbilityTargetData __instance,
+            TacticalActor actor,
+            TacticalAbility ability,
+            ref bool __result)
+        {
+            try
+            {
+                ExtendedEnterVehicleAbility enterVehicle = ability as ExtendedEnterVehicleAbility;
+                if (enterVehicle == null || actor == null || actor.IsMounted)
+                {
+                    return true;
+                }
+
+                // GetTargetsAt() casts for line of sight, and this runs once per candidate
+                // tile, so only ask about tiles close enough to a vehicle to be one of its
+                // entry points.
+                if (!IsNearAVehicle(actor, __instance.Position))
+                {
+                    return true;
+                }
+
+                TacticalAbilityCostModification modification =
+                    enterVehicle.GetEntryCostModificationAt(__instance.Position);
+
+                if (modification == null)
+                {
+                    return true;
+                }
+
+                actor.AddAbilityCostModification(modification);
+                try
+                {
+                    __result = __instance.IsPositionInRange(actor.GetMaxMoveAndActRange(ability));
+                }
+                finally
+                {
+                    actor.RemoveAbilityCostModification(modification);
+                }
+
+                return false;
+            }
+            catch (Exception e)
+            {
+                TFTV.TFTVLogger.Error(e);
+                return true;
+            }
+        }
+
+        private const float MaxEntryPointDistance = 6f;
+
+        private static bool IsNearAVehicle(TacticalActor actor, Vector3 position)
+        {
+            TacticalFaction faction = actor.TacticalFaction;
+            if (faction == null)
+            {
+                return false;
+            }
+
+            foreach (TacticalActor vehicleActor in faction.TacticalActors)
+            {
+                if (vehicleActor == null || vehicleActor.Vehicle == null)
+                {
+                    continue;
+                }
+
+                if ((vehicleActor.Pos - position).sqrMagnitude
+                    <= MaxEntryPointDistance * MaxEntryPointDistance)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #59, which merged before these two commits landed on the branch. Refines one part of that PR — the Armadillo Fast Entry marker fix — after review found it too permissive. Nothing else from #59 is touched.

## The problem with what merged

#59 fixed a missing entry-tile marker: an operative with less than 1 AP got no highlight on a tile they could board from for free, because `ExtendedEnterVehicleAbility.ShouldDisplay` only registered the module's AP discount once the operative was *already standing on* the entry point, while the marker is priced well before that. The fix registered the discount whenever a discounted vehicle existed anywhere in the mission.

That is too broad. `TacticalAbilityCostModification.AbilityQualifies()` matches on skill tags, ability cull filter and equipment tag — **there is no target anywhere in it**. A discount registered on the operative therefore applies to *every* enter-vehicle activation. With a non-full Armadillo carrying Fast Entry and a second friendly vehicle in the same mission, the operative could board the second vehicle for 0 AP as well, while `NJ_LIGHTWEIGHT_DESC` (`Vehicles.csv:65`) describes the benefit as "Entering **the vehicle** does not cost any Action Points".

For the record, the leak pre-dated #59 — the original code registered the same actor-wide modification, just from a narrower scan (`base.GetTargets()`, vehicles boardable from the operative's current tile), so it only leaked when two vehicles' entry points overlapped. #59 widened the trigger. A real regression in precision, not a new hole.

## Where the marker actually comes from

`SceneViewElement.GetPositionMarkers()` already emits a marker only for tiles where `Ability.GetTargetsAt(tile)` finds something to board, so the marker logic was never the broken part. The broken part is the filter above it: `TacUtil.UpdateActionMarkersForAbilities` runs each move target through `MoveAbilityTargetData.IsActorInActionRange(actor, ability)`, which prices the ability via `GetMaxMoveAndActRange()` — a method that knows the ability but **not the destination**, and so reads the entry cost from whatever discount happens to be registered on the operative.

This is why gating purely on the selected boarding target cannot work on its own: at marker time no target exists yet, and gating there simply reinstates the original missing-marker bug.

## The fix

**Marker** — new patch on `MoveAbilityTargetData.IsActorInActionRange(TacticalActor, TacticalAbility)`. That filter runs per tile and *does* have the destination, so it registers the discount granted by the vehicles boardable from that exact tile, lets vanilla compute the range, and removes it again:

- the Armadillo's entry tile prices at 0 AP and highlights below 1 AP;
- a module-less vehicle's entry tile prices at full cost and highlights only when the operative can genuinely afford to board from it.

`AddAbilityCostModification` / `RemoveAbilityCostModification` are plain `List.Add` / `List.Remove` with no events or other side effects, so the temporary registration is safe, and it is removed in a `finally`.

**Charge** — with the marker handled per tile, `ShouldDisplay` no longer needs the map-wide scan and registers only what is boardable from the operative's own tile. `Activate()` then settles the discount against the vehicle actually being boarded before `base.Activate()` runs `ApplyCosts()`. That last step also covers a single tile serving as an entry point for two adjacent vehicles — given the cost modification carries no target, activation is the only point at which the two can be told apart, and it happens before the AP is charged.

Also handles a vehicle carrying more than one `AdjustAccessCostStatus` (`GetStatuses<T>()` rather than `GetStatus<T>()`).

## Reviewer notes

- **Performance.** `GetTargetsAt()` casts for line of sight and the patched filter runs once per candidate move tile (a few hundred). Tiles further than 6 units from any friendly vehicle skip the check entirely, so in practice only a handful of tiles near a vehicle pay for it. Worth a sanity check on a large map with a vehicle present.
- **Known residual.** In the two-vehicles-sharing-one-entry-tile case, the ability bar's displayed cost is whatever `ShouldDisplay` registered, so the label can read 0 AP while boarding the module-less vehicle correctly charges the normal cost. Per-target cost display is not something the ability bar supports. The charge is right; only the label can be optimistic, in that one geometry.
- **Testing.** Builds clean (0 errors). Verified against the decompiled game code rather than in play; in-game confirmation of the marker at <1 AP, and of the full charge when boarding a second vehicle, would be welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
