### PR TITLE
Clear deployment UI mode when leaving the deploy screen

### DIFF
--- a/TFTV/TFTVVanillaFixes/Geoscape/UIGeoscapeVanillaFixes.cs
+++ b/TFTV/TFTVVanillaFixes/Geoscape/UIGeoscapeVanillaFixes.cs
@@ -5,6 +5,7 @@ using PhoenixPoint.Common.Core;
 using PhoenixPoint.Common.Entities;
 using PhoenixPoint.Geoscape.Entities;
 using PhoenixPoint.Geoscape.Levels;
+using PhoenixPoint.Geoscape.View;
 using PhoenixPoint.Geoscape.View.ViewModules;
 using PhoenixPoint.Geoscape.View.ViewStates;
 using PhoenixPoint.Tactical.Entities.Equipments;
@@ -154,6 +155,57 @@ namespace TFTV.TFTVVanillaFixes.Geoscape
                     module.CommitStatChanges();
 
                     TFTVLogger.Always($"[EditSoldier] Committed pending stat purchase for {____currentCharacter.DisplayName} before the progression panel refreshed.");
+                }
+                catch (Exception e)
+                {
+                    TFTVLogger.Error(e);
+                }
+            }
+        }
+
+
+        /// <summary>
+        /// Vanilla bug: backing out of a deployment screen leaves the geoscape stuck in
+        /// "deployment mode", after which the Bases / Personnel / Air Force row stops responding
+        /// to clicks and then disappears.
+        ///
+        /// GeoscapeView.ToDeploymentState() sets SetUiInDeploymentMode, and the only place that
+        /// ever clears it is GeoscapeView.ResetViewState(). UIStateRosterDeployment's single exit
+        /// point, ToPreviousScreen(), calls ResetViewState() only on its shouldResetStateOnReturn
+        /// branch; the other branch calls SwitchToPreviousState() and leaves the flag standing.
+        /// Two vanilla callers take that branch - HavenFacilityController.OnInfiltrateBriefResult()
+        /// and StealAircraftAbility - so opening a deployment that way and leaving without
+        /// deploying strands the flag for the rest of the session.
+        ///
+        /// Everything that draws the section bar keys off it. UIStateVehicleSelected.EnterState()
+        /// first calls Show(true), which activates SectionsRoot, and then ShowTabModules(), which
+        /// sets that bar's CanvasGroup to interactable = false, alpha = 0 and blocksRaycasts = false
+        /// - the row is present but dead. UIStateRosterDeployment.ExitState() calls
+        /// Show(!SetUiInDeploymentMode), which deactivates SectionsRoot outright, so the row later
+        /// vanishes on whichever state redraws it next. No exception is thrown anywhere, which is
+        /// why nothing shows up in the logs.
+        ///
+        /// Deployment mode is over whichever way the screen is left, so clear it on the way out.
+        /// Running before the original also means ExitState() sees the cleared flag and restores
+        /// the bar itself.
+        /// </summary>
+        [HarmonyPatch(typeof(UIStateRosterDeployment), "ToPreviousScreen")]
+        public static class Patch_UIStateRosterDeployment_ToPreviousScreen_ClearDeploymentUiMode
+        {
+            public static void Prefix()
+            {
+                try
+                {
+                    GeoscapeView view = GameUtl.CurrentLevel()?.GetComponent<GeoLevelController>()?.View;
+
+                    if (view == null || !view.SetUiInDeploymentMode)
+                    {
+                        return;
+                    }
+
+                    view.SetUiInDeploymentMode = false;
+
+                    TFTVLogger.Always("[RosterDeployment] Cleared SetUiInDeploymentMode on leaving the deployment screen, so the geoscape section bar comes back.");
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
Fixes a reproducible geoscape UI lockup: open a deployment screen, leave it without deploying, and the Bases / Personnel / Air Force row along the bottom stops responding to clicks — then disappears entirely the next time something redraws it, for example switching aircraft.

This is a **vanilla** bug, not something the mod introduced. It throws no exception, which is why nothing appears in `Player.log` or `TFTV.log`.

## Cause

`GeoscapeView.ToDeploymentState()` sets `SetUiInDeploymentMode`, and the only place in the game that ever clears it is `GeoscapeView.ResetViewState()`.

`UIStateRosterDeployment` has a single exit point — `ToPreviousScreen()`, which the Close button, the Back button and Cancel all route through:

```csharp
_mission.Cancel();
if (_shouldResetStateOnReturn) { Context.View.ResetViewState(); }   // clears the flag
else                           { SwitchToPreviousState(); }          // leaves it set
Context.View.FinishQueriedState();
```

Two vanilla callers pass `shouldResetStateOnReturn: false`:

- `HavenFacilityController.OnInfiltrateBriefResult()` — deploying to a haven mission from the haven screen
- `StealAircraftAbility`

Enter a deployment either of those ways, back out without deploying, and the flag stays set for the rest of the session.

## Why that breaks the section bar

Every path that draws the bar keys off the flag, which accounts for both symptoms and the order they appear in:

| Where | What it does |
|---|---|
| `UIStateVehicleSelected.EnterState()` line 204 | `Show(true)` — activates `SectionsRoot`, so the row is **visible** |
| `UIStateVehicleSelected.EnterState()` line 222 | `ShowTabModules()` — sets the bar's CanvasGroup to `interactable = false`, `alpha = 0`, `blocksRaycasts = false`; **present but dead** |
| `UIStateRosterDeployment.ExitState()` line 205 | `Show(!SetUiInDeploymentMode)` → `Show(false)` → `SectionsRoot.SetActive(false)`; the row **vanishes** |

`UIStateBionics`, `UIStateEditSoldier`, `UIStateGeoRoster`, `UIStateNothingSelected`, `UIStateVehicleRoster` and several others read the same flag, so the damage follows you across screens until something happens to call `ResetViewState()`.

## The fix

A prefix on `UIStateRosterDeployment.ToPreviousScreen` clears the flag on the way out. Deployment mode is over whichever way the screen is left, so both branches want it cleared — the `shouldResetStateOnReturn` branch already sets it false a moment later via `ResetViewState()`, so this only changes the other one.

Running *before* the original matters: `ExitState()` reads the flag while the state switch is still in flight, so it now sees the cleared value and calls `Show(true)`, restoring the bar itself rather than leaving it for a later screen to repair.

## Reviewer notes

- **Not caused by recent mod work.** I checked rather than assumed: TFTV never reads or writes `SetUiInDeploymentMode` anywhere, never calls `ToDeploymentState`, and has no patch on `HavenFacilityController`. The only mod patch on the deployment exit path is a long-standing `ExitState` postfix in `MissionDeployment.cs` that clears mission-name text.
- **Scope.** `ToPreviousScreen` is the sole exit for leaving *without* deploying, so this does not touch the actual deploy path (`OnDeploySquad` → tactical), where the geoscape view is rebuilt on return anyway.
- **Testing.** Builds clean (0 errors). Diagnosed from the decompiled game code against the reported repro; worth confirming in play that the row survives opening a haven deployment and backing out, and that a normal deploy still behaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
