### PR TITLE
Keep the Fast Entry discount on the vehicle that grants it

### DIFF
--- a/TFTV/Vehicles/Abilities/ExtendedEnterVehicle.cs
+++ b/TFTV/Vehicles/Abilities/ExtendedEnterVehicle.cs
@@ -14,6 +14,16 @@ namespace TFTVVehicleRework.Abilities
 
         private TacticalAbilityCostModification APCostModification;
 
+        // While an activation is in flight the boarding target is known, so the target-based
+        // decision made in Activate() must not be overwritten by the position-based one.
+        private bool _resolvingActivation;
+
+        /// <summary>The discount currently registered on the operative by this ability, or null.</summary>
+        internal TacticalAbilityCostModification RegisteredAccessCostModification
+        {
+            get { return this.APCostModification; }
+        }
+
         public ExtendedEnterVehicleAbilityDef ExtendedEnterVehicleAbilityDef
         {
             get
@@ -26,7 +36,15 @@ namespace TFTVVehicleRework.Abilities
         {
             get
             {
-                this.UpdateAccessCostModification();
+                // Activating fires events that refresh the ability bar, which lands back here.
+                // ActionPointCost is read live when ApplyCosts() runs, so re-registering by
+                // position at that moment would silently undo Activate()'s target-based choice
+                // and hand the operative a free boarding of whatever else is parked alongside.
+                if (!this._resolvingActivation)
+                {
+                    this.UpdateAccessCostModification();
+                }
+
                 return base.ShouldDisplay;
             }
         }
@@ -127,12 +145,20 @@ namespace TFTVVehicleRework.Abilities
             // actually being boarded first. One tile can be an entry point for two vehicles,
             // and the cost modification carries no target that could tell them apart.
             TacticalAbilityTarget target = parameter as TacticalAbilityTarget;
-            this.SetAccessCostModification(
-                (target != null) ? GetEntryCostModification(target.Actor) : null);
 
-            base.Activate(parameter);
+            this._resolvingActivation = true;
+            try
+            {
+                this.SetAccessCostModification(
+                    (target != null) ? GetEntryCostModification(target.Actor) : null);
 
-            this.SetAccessCostModification(null);
+                base.Activate(parameter);
+            }
+            finally
+            {
+                this._resolvingActivation = false;
+                this.SetAccessCostModification(null);
+            }
             if (this.ExtendedEnterVehicleAbilityDef.StealthStatus != null)
             {
                 this.TacticalActor.Status.ApplyStatus(this.ExtendedEnterVehicleAbilityDef.StealthStatus);

--- a/TFTV/Vehicles/HarmonyPatches/MoveAbilityTargetData_Patches.cs
+++ b/TFTV/Vehicles/HarmonyPatches/MoveAbilityTargetData_Patches.cs
@@ -44,30 +44,50 @@ namespace TFTVVehicleRework.HarmonyPatches
                     return true;
                 }
 
-                // GetTargetsAt() casts for line of sight, and this runs once per candidate
-                // tile, so only ask about tiles close enough to a vehicle to be one of its
-                // entry points.
-                if (!IsNearAVehicle(actor, __instance.Position))
+                // What ShouldDisplay has put on the operative reflects where they stand right
+                // now, not this candidate tile. Once they are parked on a discounted vehicle's
+                // entry point that registration prices every other tile too, which is what lit
+                // up the neighbouring Armadillo's entry tile as if boarding it were free.
+                TacticalAbilityCostModification registered = enterVehicle.RegisteredAccessCostModification;
+
+                // GetTargetsAt() casts for line of sight and this runs once per candidate tile,
+                // so only ask about tiles close enough to a vehicle to be one of its entry points.
+                TacticalAbilityCostModification atTile = IsNearAVehicle(actor, __instance.Position)
+                    ? enterVehicle.GetEntryCostModificationAt(__instance.Position)
+                    : null;
+
+                if (atTile == registered)
                 {
+                    // The operative already carries exactly what this tile grants, so vanilla
+                    // prices it correctly on its own.
                     return true;
                 }
 
-                TacticalAbilityCostModification modification =
-                    enterVehicle.GetEntryCostModificationAt(__instance.Position);
-
-                if (modification == null)
+                if (registered != null)
                 {
-                    return true;
+                    actor.RemoveAbilityCostModification(registered);
                 }
 
-                actor.AddAbilityCostModification(modification);
+                if (atTile != null)
+                {
+                    actor.AddAbilityCostModification(atTile);
+                }
+
                 try
                 {
                     __result = __instance.IsPositionInRange(actor.GetMaxMoveAndActRange(ability));
                 }
                 finally
                 {
-                    actor.RemoveAbilityCostModification(modification);
+                    if (atTile != null)
+                    {
+                        actor.RemoveAbilityCostModification(atTile);
+                    }
+
+                    if (registered != null)
+                    {
+                        actor.AddAbilityCostModification(registered);
+                    }
                 }
 
                 return false;


### PR DESCRIPTION
Follow-up to #60. Two defects in the Armadillo Fast Entry work, both found in play with two Armadillos parked side by side where only one carries Lightweight Alloy.

Both come from the same root: the AP discount is a `TacticalAbilityCostModification`, which `AbilityQualifies()` matches on skill tags alone — it carries no target. Registering it on the operative at all is a workaround for `GetMaxMoveAndActRange()` having no target parameter, and in both cases below a registration outlived the moment it was meant for.

## 1. The wrong vehicle's entry tile lit up

**Symptom:** while the operative is anywhere else, only the discounted Armadillo's entry tile is highlighted — correct. The moment the operative steps *onto* that tile, the neighbouring Armadillo's entry tile lights up too.

**Cause:** `ShouldDisplay` registers the discount for wherever the operative currently stands. The marker filter in `MoveAbilityTargetData_IsActorInActionRange_Patch` only ever *added* a tile's discount; when a candidate tile granted none it returned `true` and let vanilla price the tile — using the registration already sitting on the operative. So standing on the discounted vehicle priced every other candidate tile at 0 AP as well.

**Fix:** the filter now installs exactly what the candidate tile grants, removing an inapplicable registration for the duration of the evaluation and restoring it afterwards. When the tile's discount and the registered one are already the same instance it short-circuits to vanilla, so the common case costs nothing extra.

## 2. Boarding the neighbouring Armadillo was free

**Symptom:** move to the other Armadillo's entry tile, get the prompt, board it for 0 AP.

**Cause:** `Activate()` does settle the discount against the actual boarding target before calling `base.Activate()` — but that is not sufficient, because the cost is not captured at that point. `ApplyCosts()` reads `ActionPointCost` live:

```csharp
base.Activate(parameter);   // fires events -> ability bar refresh -> ShouldDisplay -> re-registers by position
IncrementUsesThisTurn();
ApplyAbilityTraits();
ApplyCosts(parameter);      // ActionPointCost read here, live
```

`ActionPointCost` is `TacticalActor.CalcActionPointCost(FractActionPointCost)`, evaluated inside `ApplyCosts`. Anything touching `ShouldDisplay` in between re-registers by position and wins. With the two vehicles adjacent, the operative's tile still had the discounted one boardable, so the discount came straight back before the charge was read.

**Fix:** `ShouldDisplay` leaves the registration alone while an activation is in flight (`_resolvingActivation`, cleared in a `finally`), so the target-based decision is what `ApplyCosts()` sees.

## Reviewer notes

- **Reference semantics.** The swap logic depends on it, so I checked: `TacticalAbilityCostModification` is a `class` with no `Equals`/`==`/`IEquatable` overrides. The identity comparisons and `List.Remove` calls here are therefore reference-based, and two lookups of the same vehicle's discount return the same instance (both read `AdjustAccessCostStatusDef.AccessCostModification` off the shared def). That is what makes the short-circuit correct rather than merely an optimisation.
- **Known gap, unchanged.** If a single tile is an entry point for *both* vehicles, the marker there is priced with the discount — correct for boarding the discounted one, optimistic for the other. The charge is target-correct either way after this change.
- **Honest note.** This is the second correction to this feature; both times an actor-wide registration outlived its moment. The invariant now is: the registration reflects the operative's own tile, the marker filter overrides it per candidate tile, and activation overrides it per target and holds that override until the cost has been charged.
- **Testing.** Builds clean (0 errors). Diagnosed from the decompiled game code against the reported repro; worth confirming in play that the neighbouring entry tile no longer highlights while standing on the discounted one, that boarding the neighbour charges the normal AP, and that boarding the discounted Armadillo is still free at under 1 AP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
