### PR TITLE
Let the boarding marker past the ability-enabled gate

### DIFF
--- a/TFTV/TFTV.csproj
+++ b/TFTV/TFTV.csproj
@@ -430,6 +430,7 @@
     <Compile Include="Vehicles\Effects\AddedRotationParticleEffectDef.cs" />
     <Compile Include="Vehicles\HarmonyPatches\GeoCharacter_Patches.cs" />
     <Compile Include="Vehicles\HarmonyPatches\MoveAbilityTargetData_Patches.cs" />
+    <Compile Include="Vehicles\HarmonyPatches\SceneViewElement_Patches.cs" />
     <Compile Include="Vehicles\HarmonyPatches\SwitchStanceAbility_Patches.cs" />
     <Compile Include="Vehicles\HarmonyPatches\TacticalAbility_Patches.cs" />
     <Compile Include="Vehicles\HarmonyPatches\TacticalActor_Patches.cs" />

--- a/TFTV/Vehicles/Abilities/ExtendedEnterVehicle.cs
+++ b/TFTV/Vehicles/Abilities/ExtendedEnterVehicle.cs
@@ -115,6 +115,39 @@ namespace TFTVVehicleRework.Abilities
         }
 
         /// <summary>
+        /// True when any boardable friendly vehicle grants an entry discount, wherever it stands.
+        ///
+        /// Deliberately not position-aware: this answers only "is there somewhere worth walking
+        /// to", which is what SceneViewElement.IsValid() needs in order to let the marker pass
+        /// run at all. Which tiles actually light up is decided per tile afterwards, by
+        /// MoveAbilityTargetData_IsActorInActionRange_Patch.
+        /// </summary>
+        internal bool HasEntryDiscountSomewhere()
+        {
+            TacticalActor actor = this.TacticalActor;
+            if (actor == null || actor.IsMounted)
+            {
+                return false;
+            }
+
+            TacticalFaction faction = this.TacticalActorBase.TacticalFaction;
+            if (faction == null)
+            {
+                return false;
+            }
+
+            foreach (TacticalActor vehicleActor in faction.TacticalActors)
+            {
+                if (GetEntryCostModification(vehicleActor) != null)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// The entry discount granted by one vehicle, or null.
         /// </summary>
         private static TacticalAbilityCostModification GetEntryCostModification(TacticalActorBase vehicleActorBase)

--- a/TFTV/Vehicles/HarmonyPatches/SceneViewElement_Patches.cs
+++ b/TFTV/Vehicles/HarmonyPatches/SceneViewElement_Patches.cs
@@ -1,0 +1,54 @@
+using HarmonyLib;
+using PhoenixPoint.Tactical.UI;
+using System;
+using TFTVVehicleRework.Abilities;
+
+namespace TFTVVehicleRework.HarmonyPatches
+{
+    /// <summary>
+    /// Lets the boarding marker survive the gate that runs before any tile is looked at.
+    ///
+    /// SceneViewElement.GetPositionMarkers() opens with "if (validMoves == null || !IsValid())
+    /// return false", and IsValid() rejects an ability that
+    /// Ability.IsEnabled(IgnoreNoValidTargetsFilter) reports as disabled. That filter ignores
+    /// NoValidTarget but not NotEnoughActionPoints, and the entry discount is only registered on
+    /// the operative while they stand where it applies. So an operative with less than the full
+    /// entry cost, standing anywhere other than the entry tile itself, failed the gate and got no
+    /// boarding marker at all - the per-tile pricing never even ran, because it is evaluated
+    /// lazily inside a call that had already returned.
+    ///
+    /// Relaxing the gate is safe because nothing downstream trusts it. The per-tile filter still
+    /// prices each candidate tile against exactly the discount that tile grants, and
+    /// GetPositionMarkers() still only emits a marker where GetTargetsAt(tile) finds a vehicle to
+    /// board. All this does is let those two run.
+    /// </summary>
+    [HarmonyPatch(typeof(SceneViewElement), "IsValid")]
+    internal static class SceneViewElement_IsValid_EnterVehicleMarkers_Patch
+    {
+        private static void Postfix(SceneViewElement __instance, ref bool __result)
+        {
+            try
+            {
+                // Def == null is the other reason IsValid() says no, and GetPositionMarkers()
+                // dereferences Def straight away, so that one has to keep saying no.
+                if (__result || __instance == null || __instance.Def == null)
+                {
+                    return;
+                }
+
+                ExtendedEnterVehicleAbility enterVehicle = __instance.Ability as ExtendedEnterVehicleAbility;
+
+                if (enterVehicle == null || !enterVehicle.HasEntryDiscountSomewhere())
+                {
+                    return;
+                }
+
+                __result = true;
+            }
+            catch (Exception e)
+            {
+                TFTV.TFTVLogger.Error(e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #62. One more defect in the Armadillo Fast Entry marker, found in play.

**Repro:** walk an operative with under 1 AP onto the discounted Armadillo's entry tile, then walk them off again while leaving enough AP to walk back. The entry tile stops highlighting, even though the operative can still reach it and board for free.

## Cause

A gate upstream of everything the previous PRs touched. `SceneViewElement.GetPositionMarkers()` opens with:

```csharp
if (validMoves == null || !IsValid()) return false;
```

and `SceneViewElement.IsValid()` is:

```csharp
if (Def == null) return false;
if (!Ability.IsEnabled(IgnoredAbilityDisabledStatesFilter.IgnoreNoValidTargetsFilter)) return false;
return true;
```

That filter ignores `NoValidTarget` but **not** `NotEnoughActionPoints`. The entry discount is only registered on the operative while they stand where it applies, so an operative below the full entry cost, standing anywhere other than the entry tile itself, reads as disabled and fails the gate — `GetPositionMarkers` returns before looking at a single tile.

The per-tile pricing added in #62 never ran at all in that case: it lives in a `Where` lambda passed *into* `GetPositionMarkers`, so it is evaluated lazily inside a call that had already returned.

That explains the exact shape of the repro. Stepping **onto** the tile is what registers the discount; stepping **off** is what removes it again. Before ever stepping on, the operative still had enough AP to clear the gate unaided, which is why it looked correct up to that point.

## Fix

Relax the gate for this ability only, via a postfix on `SceneViewElement.IsValid`. The gate is only being asked "is there somewhere worth walking to", which `HasEntryDiscountSomewhere()` answers without reference to position.

This is safe because nothing downstream trusts the gate:

- the per-tile filter still prices every candidate tile against exactly the discount that tile grants, suppressing an inapplicable registration for the duration of the evaluation (#62);
- `GetPositionMarkers()` still emits a marker only where `GetTargetsAt(tile)` finds a vehicle to board;
- `Activate()` still resolves the discount from the actual boarding target and holds that decision until `ApplyCosts()` has charged (#62).

## Reviewer notes

- **`Def == null` still returns false.** It is the other reason `IsValid()` says no, and `GetPositionMarkers()` dereferences `Def` on the next line, so the postfix deliberately leaves that case alone.
- **Patching the base is enough.** `MoveAbilitySceneViewElement` is the only override of `IsValid()` in the assembly, and that belongs to `MoveAbility`, so this reaches the enter-vehicle element without touching movement markers.
- **Scope of the relaxation.** `IsValid()` also gates `StartDrawing` and the hover-marker path. Those draw from `Ability.GetTargets()`, which is evaluated at the operative's current position and comes back empty when they are not on an entry point — so nothing extra is drawn there.
- **Running total on this feature.** Three corrections now, each an actor-wide registration or an affordability check outliving the moment it was meant for. The invariant to check first if a fourth appears: the registration reflects the operative's own tile; the marker gate asks only whether a discount exists anywhere; the per-tile filter overrides per candidate tile; activation overrides per target and holds until the cost is charged.
- **Testing.** Builds clean (0 errors). Diagnosed from the decompiled game code against the reported repro; worth confirming in play that the entry tile still highlights after stepping onto it and off again at low AP, and that the earlier fixes still hold — the neighbouring Armadillo's tile stays unhighlighted, and boarding it charges the normal AP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
