### PR TITLE
Narrow the boarding-marker gate, and split the personnel tutorial panel

### DIFF
--- a/Dist/Assets/Localization/TFTV_AircraftRework_Localization.csv
+++ b/Dist/Assets/Localization/TFTV_AircraftRework_Localization.csv
@@ -1,4 +1,4 @@
-Key,Type,Desc,English,Chinese (Simplified),French,German,Italian,Polish,Russian,Spanish,UI_Tester
+﻿Key,Type,Desc,English,Chinese (Simplified),French,German,Italian,Polish,Russian,Spanish,UI_Tester
 TFTV_CAPTURE_DRONES_MODULE_NAME,Text,,Salvage Drones,,Drones de récupération,Bergungsdrohnen,,Drony odzysku,Грузовые Дроны,Drones de Salvamento,
 TFTV_CAPTURE_DRONES_MODULE_DESCRIPTION,Text,,"A pack of autonomous retrieval drones that scour the battlefield, securing all items even when the area remains contested. All items left on the ground are collected on mission end.",,"Un groupe de drones de récupération autonomes qui parcourent le champ de bataille, récupérant tous les objets même si la zone reste contestée. Tous les objets laissés au sol sont collectés à la fin de la mission.","Ein Schwarm autonomer Bergungsdrohnen, der das Schlachtfeld absucht und alle Gegenstände sichert – auch in umkämpften Gebieten.
 <b>Alle am Boden verbliebenen Gegenstände werden am Missionsende eingesammelt.</b>",,"Pakiet autonomicznych dronów odzyskujących, które przeczesują pole walki i zabezpieczają wszystkie przedmioty nawet wtedy, gdy obszar pozostaje sporny. Wszystkie przedmioty pozostawione na ziemi są zbierane po zakończeniu misji.","Несколько дронов с захватами для сбора трофеев с боля боя, даже с незачищенной территории. В конце миссии все, что лежит на земле, будет подобрано!","Una bandada de drones autónomos que registran el campo de batalla, asegurando todos los objetos incluso cuando el área aún está en conflicto. Todos los objetos no asegurados se recogen al final de la misión.",
@@ -363,17 +363,7 @@ Psycho-Sociology Personnel are trained administrators: they count as 3 Personnel
 
 Personnel can also be deployed as regular Level 1 Operatives of the Class of your choosing. 
 
-If you have a Training Facility you can train Personnel up to Level 4 before deploying them. Compute and Occult Personnel can be trained up to Level 5, and Exploration Personnel up to Level 6. They will gain +2 Strength, + 1 Willpower and + 1 Speed per level trained. Training costs 10 Faction SP per final level trained. Training takes time, which can be shortened by acquiring certain Technologies, and can be terminated early, in which case you will be refunded the corresponding SP. 
-
-You start the game with some Personnel, the number depending on difficulty (2 on Legend, 6 on Rookie). 
-
-You gain new Personnel by resolving Incidents; special timed events that occur from time to time at previously visited havens. If the Operative leading the Incident has Rank 2 in an Affinity, one of the Personnel gained will have that same Affinity at Rank 1; if the leader has Rank 3, a second Personnel will also gain a different, randomly chosen Affinity at Rank 1. 
-
-On Hero difficulty and lower you also gain new Personnel periodically (1 on Hero, 3 on Rookie). You can override this setting on New Game start.
-
-You can also dismiss Operatives to add them to the Personnel pool. Previously Dismissed Operatives can be redeployed to the field, but you have to pay 10 Faction SP for each level of the Character above 1. They can also be trained before redeploying. 
-
-Some Dismissed operatives that have “Just a Grunt” perk, such as Mercenaries, can't be assigned to Research or Manufacturing.",,,,,,,,
+If you have a Training Facility you can train Personnel up to Level 4 before deploying them. Compute and Occult Personnel can be trained up to Level 5, and Exploration Personnel up to Level 6. They will gain +2 Strength, + 1 Willpower and + 1 Speed per level trained. Training costs 10 Faction SP per final level trained. Training takes time, which can be shortened by acquiring certain Technologies, and can be terminated early, in which case you will be refunded the corresponding SP. ",,,,,,,,
 TUTORIAL_PERSONNEL_TITLE1,Text,,Acquiring New Personnel,,,,,,,,
 TUTORIAL_PERSONNEL_TEXT1,Text,,"You start the game with some Personnel, the number depending on difficulty (2 on Legend, 6 on Rookie). 
 

--- a/TFTV/TFTVHints.cs
+++ b/TFTV/TFTVHints.cs
@@ -751,6 +751,120 @@ namespace TFTV
         {
             internal static Sprite CustomGeoHintImage;
 
+            /// <summary>One panel of a custom geoscape hint.</summary>
+            internal class CustomHintPanel
+            {
+                public readonly string TitleKey;
+                public readonly string TextKey;
+                public readonly string ImageFile;
+
+                public CustomHintPanel(string titleKey, string textKey, string imageFile)
+                {
+                    TitleKey = titleKey;
+                    TextKey = textKey;
+                    ImageFile = imageFile;
+                }
+            }
+
+            /// <summary>
+            /// Panels still to show after the one currently on screen. Custom hints all share a
+            /// single slot on GeoscapeTutorialStepsDef, so a multi-panel hint cannot be built up
+            /// front - each panel has to be written into the slot as its turn comes.
+            /// </summary>
+            private static readonly Queue<CustomHintPanel> PendingCustomHintPanels = new Queue<CustomHintPanel>();
+
+            /// <summary>
+            /// Set only while a sequence is putting up one of its own panels. Any other custom
+            /// hint clears whatever is queued, so a sequence abandoned half way - the geoscape
+            /// unloaded before the second panel was reached, say - cannot later chain itself onto
+            /// an unrelated hint.
+            /// </summary>
+            private static bool _advancingCustomHintSequence;
+
+            /// <summary>
+            /// Shows the panels in order, one per confirm click.
+            ///
+            /// GeoscapeView queues tutorial steps through QueryStateSwitch rather than showing
+            /// them outright, so asking for the next panel while the current one is closing is
+            /// enough to have it presented straight after.
+            /// </summary>
+            internal static void PlayCustomGeoHintSequence(GeoLevelController controller, params CustomHintPanel[] panels)
+            {
+                try
+                {
+                    PendingCustomHintPanels.Clear();
+
+                    if (panels == null || panels.Length == 0)
+                    {
+                        return;
+                    }
+
+                    for (int i = 1; i < panels.Length; i++)
+                    {
+                        PendingCustomHintPanels.Enqueue(panels[i]);
+                    }
+
+                    ShowSequencePanel(controller, panels[0]);
+                }
+                catch (Exception e)
+                {
+                    TFTVLogger.Error(e);
+                }
+            }
+
+            private static void ShowSequencePanel(GeoLevelController controller, CustomHintPanel panel)
+            {
+                _advancingCustomHintSequence = true;
+                try
+                {
+                    CreateCustomGeoHint(panel.TitleKey, panel.TextKey, panel.ImageFile);
+                    PlayCustomGeoHint(controller, forceShow: true);
+                }
+                finally
+                {
+                    _advancingCustomHintSequence = false;
+                }
+            }
+
+            /// <summary>
+            /// Advances a multi-panel custom hint when its OK button is clicked.
+            /// </summary>
+            [HarmonyPatch(typeof(UIModuleTutorialModal), "ConfirmClicked")]
+            internal static class UIModuleTutorialModal_ConfirmClicked_CustomHintSequence_Patch
+            {
+                private static void Postfix(GeoscapeTutorialStep ____currentStep)
+                {
+                    try
+                    {
+                        if (PendingCustomHintPanels.Count == 0)
+                        {
+                            return;
+                        }
+
+                        // Only our own hints chain; every other tutorial modal is left alone.
+                        if (____currentStep == null
+                            || ____currentStep.StepType != GeoscapeTutorialStepType.AlienReconRaid)
+                        {
+                            return;
+                        }
+
+                        GeoLevelController controller = GameUtl.CurrentLevel()?.GetComponent<GeoLevelController>();
+
+                        if (controller == null)
+                        {
+                            PendingCustomHintPanels.Clear();
+                            return;
+                        }
+
+                        ShowSequencePanel(controller, PendingCustomHintPanels.Dequeue());
+                    }
+                    catch (Exception e)
+                    {
+                        TFTVLogger.Error(e);
+                    }
+                }
+            }
+
             public static void TriggerBaseDefenseHint(GeoLevelController controller)
             {
                 try
@@ -812,6 +926,11 @@ namespace TFTV
             {
                 try
                 {
+                    if (!_advancingCustomHintSequence)
+                    {
+                        PendingCustomHintPanels.Clear();
+                    }
+
                     GeoscapeTutorialStepType stepType = GeoscapeTutorialStepType.AlienReconRaid;
                     GeoscapeTutorial geoscapeTutorial = controller.Tutorial;
 
@@ -1320,8 +1439,12 @@ namespace TFTV
 
                     if (eventSystem.GetVariable(VarPersonnel) > 0) return;
 
-                    GeoscapeHints.CreateCustomGeoHint("TUTORIAL_PERSONNEL_TITLE0", "TUTORIAL_PERSONNEL_TEXT0", null);
-                    GeoscapeHints.PlayCustomGeoHint(controller, forceShow: true);
+                    // Two panels: assigning Personnel to base duty, then where new ones come from.
+                    GeoscapeHints.PlayCustomGeoHintSequence(
+                        controller,
+                        new GeoscapeHints.CustomHintPanel("TUTORIAL_PERSONNEL_TITLE0", "TUTORIAL_PERSONNEL_TEXT0", null),
+                        new GeoscapeHints.CustomHintPanel("TUTORIAL_PERSONNEL_TITLE1", "TUTORIAL_PERSONNEL_TEXT1", null));
+
                     eventSystem.SetVariable(VarPersonnel, 1);
                 }
                 catch (Exception e) { TFTVLogger.Error(e); }

--- a/TFTV/Vehicles/HarmonyPatches/SceneViewElement_Patches.cs
+++ b/TFTV/Vehicles/HarmonyPatches/SceneViewElement_Patches.cs
@@ -1,4 +1,5 @@
 using HarmonyLib;
+using PhoenixPoint.Common.Entities;
 using PhoenixPoint.Tactical.UI;
 using System;
 using TFTVVehicleRework.Abilities;
@@ -25,6 +26,22 @@ namespace TFTVVehicleRework.HarmonyPatches
     [HarmonyPatch(typeof(SceneViewElement), "IsValid")]
     internal static class SceneViewElement_IsValid_EnterVehicleMarkers_Patch
     {
+        /// <summary>
+        /// Action points, and having nothing to board from where the operative happens to stand,
+        /// are the only two objections worth overriding here. Every other one is real.
+        ///
+        /// Reading GetDisabledState() and comparing it against NotEnoughActionPoints would not be
+        /// enough: GetDisabledStateDefaults() returns the *first* failing check, and
+        /// NotEnoughActionPoints is evaluated ahead of RequirementsNotMet, OffMap, ActorStunned
+        /// and BlockedByStatus. An operative who is stunned or status-blocked *and* short on AP
+        /// reports NotEnoughActionPoints, and would slip through. Asking whether the ability is
+        /// enabled once both are ignored is order-independent: anything else still says no.
+        /// </summary>
+        private static readonly IgnoredAbilityDisabledStatesFilter IgnoreNoTargetAndActionPoints =
+            new IgnoredAbilityDisabledStatesFilter(
+                IgnoredAbilityDisabledStatesFilter.IgnoreNoValidTargetsFilter,
+                AbilityDisabledState.NotEnoughActionPoints);
+
         private static void Postfix(SceneViewElement __instance, ref bool __result)
         {
             try
@@ -38,7 +55,20 @@ namespace TFTVVehicleRework.HarmonyPatches
 
                 ExtendedEnterVehicleAbility enterVehicle = __instance.Ability as ExtendedEnterVehicleAbility;
 
-                if (enterVehicle == null || !enterVehicle.HasEntryDiscountSomewhere())
+                if (enterVehicle == null)
+                {
+                    return;
+                }
+
+                // Disabled for a reason that has nothing to do with action points - the operative
+                // is stunned, blocked by a status, off map, missing a requirement. Vanilla means
+                // it, so leave the gate shut.
+                if (!enterVehicle.IsEnabled(IgnoreNoTargetAndActionPoints))
+                {
+                    return;
+                }
+
+                if (!enterVehicle.HasEntryDiscountSomewhere())
                 {
                     return;
                 }


### PR DESCRIPTION
Two independent changes. They share a branch only because they were done back to back; either can be reverted without touching the other.

---

# 1. Narrow the boarding-marker gate to action-point rejections

Review follow-up to #63, which relaxed `SceneViewElement.IsValid()` so an operative below the full entry cost still gets a boarding marker.

**Problem:** it relaxed the gate unconditionally. Whenever any discounted friendly vehicle existed anywhere in the mission, `__result` was forced true regardless of *why* the ability was disabled — so an operative who is stunned, blocked by a status, off map, disabled, or missing a requirement would still be shown boarding markers and hover interactions that vanilla suppresses on purpose.

**Fix:** relax only when action points — and having nothing boardable from where the operative currently stands — are the sole objections.

Worth noting for review, because the obvious implementation does not work: comparing `GetDisabledState()` against `NotEnoughActionPoints` is **not** sufficient. `GetDisabledStateDefaults()` returns the *first* failing check, and the order is

```
ActorIsDisabled → NotEnoughHands → EquipmentIsDisabled → … → NotEnoughActionPoints
  → NotEnoughWillPoints → RequirementsNotMet → NoValidTarget → OffMap → ActorStunned → BlockedByStatus
```

`NotEnoughActionPoints` is evaluated *ahead of* `RequirementsNotMet`, `OffMap`, `ActorStunned` and `BlockedByStatus`. An operative who is stunned or status-blocked **and** short on AP reports `NotEnoughActionPoints` as the first failure, and would still slip through. That check would have fixed `ActorIsDisabled` (which precedes AP) while leaving the others broken.

So the gate instead asks whether the ability is enabled once both states are ignored, which is order-independent — any other objection keeps it shut:

```csharp
private static readonly IgnoredAbilityDisabledStatesFilter IgnoreNoTargetAndActionPoints =
    new IgnoredAbilityDisabledStatesFilter(
        IgnoredAbilityDisabledStatesFilter.IgnoreNoValidTargetsFilter,
        AbilityDisabledState.NotEnoughActionPoints);
```

The `NoValidTarget` check short-circuits on `IsStateIgnored` before evaluating `HasValidTargets`, so this stays cheap. `Def == null` still returns false, since `GetPositionMarkers()` dereferences `Def` immediately.

---

# 2. Split the over-long personnel tutorial panel

The Personnel Management hint on the assignment screen (`UIStateRosterRecruits`) runs long enough to overflow its panel. Now two panels, second shown on confirming the first.

**The text needed no rewriting.** `TUTORIAL_PERSONNEL_TITLE1` ("Acquiring New Personnel") and `TEXT1` were already in the localization file and already held the second half **verbatim** — `TEXT0` simply repeated all of it after the training-facility paragraph, and nothing ever displayed `TEXT1`. `TEXT0` is trimmed at that seam and `TEXT1` becomes panel two. No wording changed.

- Panel 1 (1509 chars): assigning Personnel to base duty — Research/Manufacturing output, Affinity bonuses, Psycho-Sociology administrators, deploying and training.
- Panel 2 (1000 chars): where new Personnel come from — starting count, Incidents, periodic gains, dismissal.

**Chaining needs a queue.** Every custom geoscape hint shares a single slot on `GeoscapeTutorialStepsDef` (`Hints[27]`), which `CreateCustomGeoHint` overwrites, so a multi-panel hint cannot be assembled up front — each panel has to be written into that slot as its turn comes. `GeoscapeView.OnShowTutorialStep` queues steps via `_viewSwichQuery.QueryStateSwitch(...)` rather than showing them outright, so requesting the next panel from the confirm handler is enough for it to be presented as the current one closes; no coroutine or frame deferral is involved.

`PlayCustomGeoHintSequence(controller, params CustomHintPanel[])` is general, so any other over-long hint can be split the same way.

## Reviewer notes

- **CSV integrity.** I closed a multi-line quoted field by hand, so I re-parsed the file afterwards: every row still has 12 columns and the four affected keys resolve to the expected lengths.
- **Two guards on the static queue.** The confirm postfix only acts on the custom step type (`AlienReconRaid`), leaving every other tutorial modal alone; and `PlayCustomGeoHint` clears any queued panels unless a sequence is what called it, so a sequence abandoned half way — geoscape unloaded before panel 2 — cannot later chain its leftover panel onto an unrelated hint such as the base-defense one.
- **Testing.** Builds clean (0 errors). Both diagnosed against the decompiled game code. Worth confirming in play: for (1) that boarding markers still appear at low AP but not for a stunned or panicked operative; for (2) that the personnel hint now shows two panels in order and that other custom hints (base defense, behemoth, affinities) still show exactly one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
