### PR TITLE
Fix marketplace filters, trim two incident hints, optimise personnel auto-assign

### DIFF
--- a/Dist/Assets/Localization/TFTV_AircraftRework_Localization.csv
+++ b/Dist/Assets/Localization/TFTV_AircraftRework_Localization.csv
@@ -389,8 +389,6 @@ Personnel with the Psycho-Sociology Affinity are trained administrators and coun
 TUTORIAL_INCIDENTS_TITLE0,Text,,Incidents,,,,,,,,
 TUTORIAL_INCIDENTS_TEXT0,Text,,"Incidents are Geoscape Events that take time to resolve and are the primary way of securing new Personnel. You will get at least 2 Personnel for resolving an Incident successfully (among other rewards, such as Resources, Characters, Improved attitude from Faction and/or Haven Leader), and 1 Personnel if you attempt it but then move the Aircraft away before it is completed. 
 
-If the Operative leading the Incident has Rank 2 in an Affinity, one of the Personnel gained will have that same Affinity at Rank 1. If the leader has Rank 3, a second Personnel will also gain a different, randomly chosen Affinity at Rank 1. 
-
 Every 4-6 days, an Incident will occur at a previously visited haven, inviting you to resolve it within the next 5 days.
 
 To initiate the Incident, you must travel to the haven with an Aircraft with at least one Operative without the “Just a Grunt” perk.",,,,,,,,
@@ -412,8 +410,7 @@ TUTORIAL_AFFINITIES_TEXT0,Text,,"- Affinities are gained and advanced in rank by
 - Affinity bonuses do not stack — only the highest-ranked specialist’s bonus applies.
 - Geoscape benefits apply to the Aircraft on which the Character is currently a passenger, Benefits in Tactical grant an ability to the Character with the Affinity.
 - Each Character can have only one Affinity.
-- Affinities also matter on base duty. They determine how much Research or Manufacturing a Personnel generates when assigned to a worker slot (Biotech 6 Research, Machinery 6 Manufacturing, Compute / Occult / Psycho-Sociology 4 of either, everyone else 2), how far they can be trained (Compute and Occult to Level 5, Exploration to Level 6), and how many Personnel they count as when spent on an Outpost or a Base activation (Psycho-Sociology counts as 3).
-- Unlike the Geoscape and Tactical benefits, these base duty benefits are always active and do not scale with the Affinity’s rank.
+- Affinities also decide how useful a Personnel is on base duty; the ASSIGNMENTS screen explains that in full.
 - Resolving an Incident with a leader of Rank 2 gives one of the Personnel gained the leader’s Affinity at Rank 1; with a leader of Rank 3, a second Personnel gains a different, randomly chosen Affinity at Rank 1.",,,,,,,,
 KEY_BASE_EXPLORE_FIRST,Text,,Explore the base first to unlock these options.,,,,,,,,
 KEY_BASE_PERSONNEL_SELECT_TITLE,Text,,ASSIGN PERSONNEL,,,,,,,,

--- a/TFTV/TFTVBaseRework/Data.cs
+++ b/TFTV/TFTVBaseRework/Data.cs
@@ -721,51 +721,6 @@ namespace TFTV.TFTVBaseRework
             TryAutoAssignUnassignedPersonnel(character.Faction as GeoPhoenixFaction, "AttachCharacter");
         }
 
-        private static IEnumerable<PersonnelInfo> GetAutoAssignablePersonnel(GeoPhoenixFaction faction)
-        {
-            return _assignments.Values
-                .Where(person => person?.Character != null && person.Character.Faction == faction)
-                .Where(person => person.Assignment == PersonnelAssignment.Unassigned)
-                .Where(person => PersonnelRestrictions.CanBeAssignedToManufacturingOrResearch(person.Character))
-                .OrderBy(person => person.Id);
-        }
-
-        private static bool TryAssignUnassignedWorkerToSlot(PersonnelInfo person, GeoPhoenixFaction faction, FacilitySlotType slotType)
-        {
-            if (person?.Character == null || faction == null)
-            {
-                return false;
-            }
-
-            if (person.Assignment != PersonnelAssignment.Unassigned)
-            {
-                return false;
-            }
-
-            // Block assignment if living quarters are full.
-            if (IsLivingCapacityFull(faction))
-            {
-                return false;
-            }
-
-            // Assign before reserving the slot: reserving refreshes the info bar, which recalculates
-            // income from these records and would not yet see this person.
-            person.Assignment = slotType == FacilitySlotType.Research
-                ? PersonnelAssignment.Research
-                : PersonnelAssignment.Manufacturing;
-
-            if (!ResearchManufacturingSlotsManager.IncrementUsedSlot(faction, slotType))
-            {
-                person.Assignment = PersonnelAssignment.Unassigned;
-                return false;
-            }
-
-            person.TrainingSpec = null;
-
-            TFTVLogger.Always($"{LogPrefix} Auto-assigned {person.Character.DisplayName} to {person.Assignment}.");
-            return true;
-        }
-
         private const string AutoAssignEnabledVariableName = "TFTV_BaseRework_AutoAssignEnabled";
         private const string AutoAssignInitializedVariableName = "TFTV_BaseRework_AutoAssignInitialized";
 
@@ -831,55 +786,152 @@ namespace TFTV.TFTVBaseRework
 
             ResearchManufacturingSlotsManager.RecalculateSlots(faction);
 
-            int assignedResearch = 0;
-            int assignedManufacturing = 0;
+            // Everyone is fair game this pass: those already working can be reseated, not just the
+            // idle. Training is a deliberate choice with a duration attached, so it is left alone,
+            // and so is anyone the restrictions bar from base duty - if such a person somehow holds
+            // a slot, that slot counts as taken rather than being emptied under them.
+            List<PersonnelInfo> movable = new List<PersonnelInfo>();
+            int lockedResearch = 0;
+            int lockedManufacturing = 0;
 
-            // Filling every Research slot first and only then Manufacturing ignored what each
-            // Personnel is actually good at: with two slots of each kind and two Machinery plus
-            // two Biotech waiting, it could seat both Machinery in Research and both Biotech in
-            // Manufacturing - 2 output apiece where 6 was available.
-            //
-            // Take instead, repeatedly, the best remaining pairing of a Personnel with a kind of
-            // slot. Against this mod's output table - a specialist makes 6 in their own field and
-            // the regular 2 anywhere else, Compute/Occult/Psycho-Sociology make 4 in either, and
-            // everyone else 2 - that reaches the highest total available: specialists claim their
-            // own field first, the flat-4 affinities take what is left, and nobody is ever seated
-            // somewhere that costs another Personnel a better slot, because a displaced specialist
-            // is worth no more than a regular worker anywhere but their own field.
-            List<PersonnelInfo> pool = GetAutoAssignablePersonnel(faction).ToList();
+            foreach (PersonnelInfo person in _assignments.Values
+                .Where(candidate => candidate?.Character != null && candidate.Character.Faction == faction)
+                .OrderBy(candidate => candidate.Id))
+            {
+                if (person.Assignment == PersonnelAssignment.Training)
+                {
+                    continue;
+                }
 
-            bool researchExhausted = false;
-            bool manufacturingExhausted = false;
+                if (!PersonnelRestrictions.CanBeAssignedToManufacturingOrResearch(person.Character))
+                {
+                    if (person.Assignment == PersonnelAssignment.Research)
+                    {
+                        lockedResearch++;
+                    }
+                    else if (person.Assignment == PersonnelAssignment.Manufacturing)
+                    {
+                        lockedManufacturing++;
+                    }
 
-            while (pool.Count > 0 && (!researchExhausted || !manufacturingExhausted))
+                    continue;
+                }
+
+                movable.Add(person);
+            }
+
+            if (movable.Count == 0)
+            {
+                return;
+            }
+
+            FacilitySlotPools slotPools = ResearchManufacturingSlotsManager.GetOrCreatePools(faction);
+            int freeResearch = Math.Max(0, slotPools.Research.ProvidedSlots - lockedResearch);
+            int freeManufacturing = Math.Max(0, slotPools.Manufacturing.ProvidedSlots - lockedManufacturing);
+
+            // Living space counts assigned Personnel only, so reseating costs nothing and only
+            // putting more of them to work does. Whatever headroom is left is what the working
+            // roster may grow by.
+            int alreadyWorking = movable.Count(person => person.Assignment != PersonnelAssignment.Unassigned);
+            int livingHeadroom = Math.Max(0, faction.SoldierCapacity - FoodAndLivingSpacePolicy.GetTotalLivingSpaceUsed(faction));
+            int workerBudget = alreadyWorking + livingHeadroom;
+
+            Dictionary<int, PersonnelAssignment> target = BuildBestAssignment(
+                movable, freeResearch, freeManufacturing, workerBudget);
+
+            List<PersonnelInfo> moved = movable
+                .Where(person => target[person.Id] != person.Assignment)
+                .ToList();
+
+            if (moved.Count == 0)
+            {
+                return;
+            }
+
+            foreach (PersonnelInfo person in moved)
+            {
+                person.Assignment = target[person.Id];
+
+                if (person.Assignment != PersonnelAssignment.Unassigned)
+                {
+                    person.TrainingSpec = null;
+                }
+            }
+
+            // Rebuild both counters from the records in one go rather than tracking every move: the
+            // setters refresh the info bar, which recalculates income from these same records.
+            ResearchManufacturingSlotsManager.SetUsedSlots(faction, FacilitySlotType.Research,
+                CountAssignedForFaction(faction, PersonnelAssignment.Research));
+            ResearchManufacturingSlotsManager.SetUsedSlots(faction, FacilitySlotType.Manufacturing,
+                CountAssignedForFaction(faction, PersonnelAssignment.Manufacturing));
+
+            FacilitySlotPools pools = ResearchManufacturingSlotsManager.GetOrCreatePools(faction);
+            TFTVLogger.Always(
+                $"{LogPrefix} Auto-assignment from {source}: {moved.Count} Personnel reseated. " +
+                $"Research {pools.Research.UsedSlots}/{pools.Research.ProvidedSlots}, " +
+                $"Manufacturing {pools.Manufacturing.UsedSlots}/{pools.Manufacturing.ProvidedSlots}");
+        }
+
+        private static int CountAssignedForFaction(GeoPhoenixFaction faction, PersonnelAssignment assignment)
+        {
+            return _assignments.Values.Count(person => person?.Character != null
+                && person.Character.Faction == faction
+                && person.Assignment == assignment);
+        }
+
+        /// <summary>
+        /// Works out where each Personnel should sit to get the most out of the roster.
+        ///
+        /// Repeatedly takes the best remaining pairing of a Personnel with a kind of slot. Against
+        /// this mod's output table - a specialist makes 6 in their own field and the regular 2
+        /// anywhere else, Compute/Occult/Psycho-Sociology make 4 in either, everyone else 2 - that
+        /// reaches the highest total available: specialists claim their own field first, the flat-4
+        /// affinities take what is left, and nobody is ever seated somewhere that costs another
+        /// Personnel a better slot, because a displaced specialist is worth no more than a regular
+        /// worker anywhere but their own field. Checked against exhaustive search.
+        ///
+        /// Ties keep roster order and prefer Research, so an unchanged roster always produces the
+        /// same answer and nobody is reseated for nothing.
+        /// </summary>
+        private static Dictionary<int, PersonnelAssignment> BuildBestAssignment(
+            List<PersonnelInfo> movable, int freeResearch, int freeManufacturing, int workerBudget)
+        {
+            Dictionary<int, PersonnelAssignment> target = new Dictionary<int, PersonnelAssignment>();
+            foreach (PersonnelInfo person in movable)
+            {
+                target[person.Id] = PersonnelAssignment.Unassigned;
+            }
+
+            List<PersonnelInfo> pool = new List<PersonnelInfo>(movable);
+            int seated = 0;
+
+            while (pool.Count > 0 && seated < workerBudget && (freeResearch > 0 || freeManufacturing > 0))
             {
                 PersonnelInfo bestPerson = null;
-                FacilitySlotType bestSlot = FacilitySlotType.Research;
+                PersonnelAssignment bestSlot = PersonnelAssignment.Research;
                 float bestOutput = float.NegativeInfinity;
 
-                // Ties keep the order GetAutoAssignablePersonnel returns, and prefer Research, so
-                // the same roster always produces the same assignment.
                 foreach (PersonnelInfo person in pool)
                 {
-                    if (!researchExhausted)
+                    if (freeResearch > 0)
                     {
                         float research = ResearchAndManufacturing.GetWorkerOutput(person.Character, ResourceType.Research);
                         if (research > bestOutput)
                         {
                             bestOutput = research;
                             bestPerson = person;
-                            bestSlot = FacilitySlotType.Research;
+                            bestSlot = PersonnelAssignment.Research;
                         }
                     }
 
-                    if (!manufacturingExhausted)
+                    if (freeManufacturing > 0)
                     {
                         float manufacturing = ResearchAndManufacturing.GetWorkerOutput(person.Character, ResourceType.Production);
                         if (manufacturing > bestOutput)
                         {
                             bestOutput = manufacturing;
                             bestPerson = person;
-                            bestSlot = FacilitySlotType.Manufacturing;
+                            bestSlot = PersonnelAssignment.Manufacturing;
                         }
                     }
                 }
@@ -889,43 +941,21 @@ namespace TFTV.TFTVBaseRework
                     break;
                 }
 
-                if (!TryAssignUnassignedWorkerToSlot(bestPerson, faction, bestSlot))
-                {
-                    // That pool just ran out of slots - or living quarters are full, in which case
-                    // the other kind fails next time round and the loop ends.
-                    if (bestSlot == FacilitySlotType.Research)
-                    {
-                        researchExhausted = true;
-                    }
-                    else
-                    {
-                        manufacturingExhausted = true;
-                    }
-
-                    continue;
-                }
-
+                target[bestPerson.Id] = bestSlot;
                 pool.Remove(bestPerson);
+                seated++;
 
-                if (bestSlot == FacilitySlotType.Research)
+                if (bestSlot == PersonnelAssignment.Research)
                 {
-                    assignedResearch++;
+                    freeResearch--;
                 }
                 else
                 {
-                    assignedManufacturing++;
+                    freeManufacturing--;
                 }
             }
 
-            if (assignedResearch > 0 || assignedManufacturing > 0)
-            {
-                FacilitySlotPools pools = ResearchManufacturingSlotsManager.GetOrCreatePools(faction);
-                TFTVLogger.Always(
-                    $"{LogPrefix} Auto-assignment from {source}: " +
-                    $"Research +{assignedResearch}, Manufacturing +{assignedManufacturing}. " +
-                    $"Research {pools.Research.UsedSlots}/{pools.Research.ProvidedSlots}, " +
-                    $"Manufacturing {pools.Manufacturing.UsedSlots}/{pools.Manufacturing.ProvidedSlots}");
-            }
+            return target;
         }
         internal static void RemovePersonnel(GeoPhoenixFaction faction, PersonnelInfo person)
         {

--- a/TFTV/TFTVBaseRework/Data.cs
+++ b/TFTV/TFTVBaseRework/Data.cs
@@ -832,25 +832,89 @@ namespace TFTV.TFTVBaseRework
             ResearchManufacturingSlotsManager.RecalculateSlots(faction);
 
             int assignedResearch = 0;
-            foreach (PersonnelInfo person in GetAutoAssignablePersonnel(faction).ToList())
-            {
-                if (!TryAssignUnassignedWorkerToSlot(person, faction, FacilitySlotType.Research))
-                {
-                    break;
-                }
-
-                assignedResearch++;
-            }
-
             int assignedManufacturing = 0;
-            foreach (PersonnelInfo person in GetAutoAssignablePersonnel(faction).ToList())
+
+            // Filling every Research slot first and only then Manufacturing ignored what each
+            // Personnel is actually good at: with two slots of each kind and two Machinery plus
+            // two Biotech waiting, it could seat both Machinery in Research and both Biotech in
+            // Manufacturing - 2 output apiece where 6 was available.
+            //
+            // Take instead, repeatedly, the best remaining pairing of a Personnel with a kind of
+            // slot. Against this mod's output table - a specialist makes 6 in their own field and
+            // the regular 2 anywhere else, Compute/Occult/Psycho-Sociology make 4 in either, and
+            // everyone else 2 - that reaches the highest total available: specialists claim their
+            // own field first, the flat-4 affinities take what is left, and nobody is ever seated
+            // somewhere that costs another Personnel a better slot, because a displaced specialist
+            // is worth no more than a regular worker anywhere but their own field.
+            List<PersonnelInfo> pool = GetAutoAssignablePersonnel(faction).ToList();
+
+            bool researchExhausted = false;
+            bool manufacturingExhausted = false;
+
+            while (pool.Count > 0 && (!researchExhausted || !manufacturingExhausted))
             {
-                if (!TryAssignUnassignedWorkerToSlot(person, faction, FacilitySlotType.Manufacturing))
+                PersonnelInfo bestPerson = null;
+                FacilitySlotType bestSlot = FacilitySlotType.Research;
+                float bestOutput = float.NegativeInfinity;
+
+                // Ties keep the order GetAutoAssignablePersonnel returns, and prefer Research, so
+                // the same roster always produces the same assignment.
+                foreach (PersonnelInfo person in pool)
+                {
+                    if (!researchExhausted)
+                    {
+                        float research = ResearchAndManufacturing.GetWorkerOutput(person.Character, ResourceType.Research);
+                        if (research > bestOutput)
+                        {
+                            bestOutput = research;
+                            bestPerson = person;
+                            bestSlot = FacilitySlotType.Research;
+                        }
+                    }
+
+                    if (!manufacturingExhausted)
+                    {
+                        float manufacturing = ResearchAndManufacturing.GetWorkerOutput(person.Character, ResourceType.Production);
+                        if (manufacturing > bestOutput)
+                        {
+                            bestOutput = manufacturing;
+                            bestPerson = person;
+                            bestSlot = FacilitySlotType.Manufacturing;
+                        }
+                    }
+                }
+
+                if (bestPerson == null)
                 {
                     break;
                 }
 
-                assignedManufacturing++;
+                if (!TryAssignUnassignedWorkerToSlot(bestPerson, faction, bestSlot))
+                {
+                    // That pool just ran out of slots - or living quarters are full, in which case
+                    // the other kind fails next time round and the loop ends.
+                    if (bestSlot == FacilitySlotType.Research)
+                    {
+                        researchExhausted = true;
+                    }
+                    else
+                    {
+                        manufacturingExhausted = true;
+                    }
+
+                    continue;
+                }
+
+                pool.Remove(bestPerson);
+
+                if (bestSlot == FacilitySlotType.Research)
+                {
+                    assignedResearch++;
+                }
+                else
+                {
+                    assignedManufacturing++;
+                }
             }
 
             if (assignedResearch > 0 || assignedManufacturing > 0)

--- a/TFTV/TFTVMarketplace/TFTVMarketPlaceUI.cs
+++ b/TFTV/TFTVMarketplace/TFTVMarketPlaceUI.cs
@@ -304,17 +304,22 @@ namespace TFTV
             {
                 try
                 {
+                    UIModuleTheMarketplace marketplaceUI = GameUtl.CurrentLevel().GetComponent<GeoLevelController>().View.GeoscapeModules.TheMarketplaceModule;
+
+                    // The filter toggles are parented under MissionRewardDescriptionText, and vanilla
+                    // UpdateVisuals() deactivates that object - along with MissionRewardHeaderText -
+                    // whenever every marketplace mission is done, then rewrites their text otherwise.
+                    // Both have to be reclaimed on every refresh rather than only when the toggles are
+                    // first built: skipping it on later openings left the toggles alive but parented to
+                    // a deactivated object, which is why they were there once and gone afterwards.
+                    marketplaceUI.MissionRewardHeaderText.gameObject.SetActive(true);
+                    marketplaceUI.MissionRewardDescriptionText.gameObject.SetActive(true);
+
+                    marketplaceUI.MissionRewardHeaderText.text = "";
+                    marketplaceUI.MissionRewardDescriptionText.text = "";
+
                     if (MarketToggleButton == null)
                     {
-
-                        UIModuleTheMarketplace marketplaceUI = GameUtl.CurrentLevel().GetComponent<GeoLevelController>().View.GeoscapeModules.TheMarketplaceModule;
-
-                        marketplaceUI.MissionRewardHeaderText.gameObject.SetActive(true);
-                        marketplaceUI.MissionRewardDescriptionText.gameObject.SetActive(true);
-
-                        marketplaceUI.MissionRewardHeaderText.text = "";
-                        marketplaceUI.MissionRewardDescriptionText.text = "";
-
                         Resolution resolution = Screen.currentResolution;
 
 


### PR DESCRIPTION
Four issues found in play, plus a follow-up that widened the last one on request.

---

## 1. Marketplace filter toggles vanished after the first opening

Open the Marketplace, close it, open it again and the four filter toggles were gone.

They are parented under `UIModuleTheMarketplace.MissionRewardDescriptionText`, and vanilla `UpdateVisuals()` does:

```csharp
MissionRewardHeaderText.gameObject.SetActive(!_geoMarketplace.AllMissionsCompleted);
MissionRewardDescriptionText.gameObject.SetActive(!_geoMarketplace.AllMissionsCompleted);
```

TFTV reclaimed both objects — activating them and blanking their text — only *inside* the `if (MarketToggleButton == null)` guard that builds the toggles. So it ran once, on first build. On every later opening the toggles were still alive but parented to a deactivated object.

Reclaiming them on every refresh fixes it, and also stops vanilla's mission-reward text reappearing behind the toggles, which was the same one-shot problem.

## 2 & 3. Two over-long hint panels around the first Incident

Both were carrying material that belongs to — and is already stated in — another panel, so these cuts remove duplication rather than information:

| Hint | Removed | Chars |
|---|---|---|
| Incidents (on the first Incident) | The paragraph on a Rank 2/3 leader shaping the Personnel gained. The Affinities panel states it, as its closing bullet. | 876 → 632 |
| Affinities (inside the Incident) | The two bullets on base duty — worker output per affinity, training caps, Psycho-Sociology counting as 3 — all of which the Personnel Management panel already gives in full. A one-line pointer to the ASSIGNMENTS screen replaces them. | 1680 → 1203 |

## 4. Auto-assign now maximises output, across the whole roster

**As found:** it filled every Research slot before starting on Manufacturing, took Personnel in Id order, and ignored what each was good at. With two slots of each kind and two Machinery plus two Biotech waiting, it could seat both Machinery in Research and both Biotech in Manufacturing — 2 output apiece where 6 was available, 8 total instead of 24.

**First pass** replaced that with a greedy that repeatedly takes the best remaining pairing of a Personnel with a kind of slot, reading values from `ResearchAndManufacturing.GetWorkerOutput` rather than hardcoding 6/4/2, so it stays correct if the output table is retuned.

**Second pass**, on request, widened it from "place the idle" to "reseat everyone". Previously a Biotech arriving after a plain worker had taken the last Research slot stayed idle at 6 output while the slot earned 2.

Left alone: anyone in **Training**, which is a deliberate choice with a duration attached, and anyone the restrictions bar from base duty — if such a person somehow holds a slot, it counts as taken rather than being emptied under them.

Two constraints the old per-person path enforced one assignment at a time, preserved now that the whole layout is computed at once:

- **Living quarters.** `FoodAndLivingSpacePolicy` runs in `FieldOperativesAndAssignedPersonnel` mode, so living space counts *assigned* Personnel only. Reseating is therefore free and only growing the working headcount costs; the roster may grow by whatever headroom is left against `SoldierCapacity`, which is the same limit `IsLivingCapacityFull` was applying.
- **Slot counters.** Rather than tracking each move through increment/decrement, the target is applied and both counters rebuilt from the records via `SetUsedSlots`, which refreshes the info bar.

**No churn.** This runs hourly, so the target is computed first and applied only where it differs. An already-optimal roster changes nothing and logs nothing.

`TryAssignUnassignedWorkerToSlot` and `GetAutoAssignablePersonnel` had no callers left and are removed.

## Reviewer notes

- **Optimality is checked, not asserted.** The doc comment claims the greedy reaches the maximum, so I brute-forced it against exhaustive search over the mod's value table. First pass: 20000 random rosters and capacities, no mismatches. After adding the worker budget — which changes the problem from slot caps alone to slot caps *plus* a cardinality cap, where greedy is not optimal in general — I re-ran it: 30000 rosters, 11838 with a budget tighter than the available slots, still no mismatches. Ties keep roster order and prefer Research, so an unchanged roster always produces the same answer.
- **CSV integrity.** The two hint edits cut inside multi-line quoted fields, so I re-parsed the file afterwards: 237 rows, all 12 columns, and the typographic characters (curly quotes, `×`, em dash) intact.
- **Known behaviour change worth a decision.** Because reoptimisation is unconditional while the toggle is on, it will also undo a *deliberate* manual placement that is not output-optimal — put a Biotech in Manufacturing on purpose and the next hourly pass moves them back. Pinning manual placements would need a per-person "placed by hand" flag; happy to add one if that is wanted.
- **Testing.** Builds clean (0 errors). The UI and localization changes were diagnosed from the decompiled game code and the localization file; worth confirming in play that the marketplace filters survive repeated openings, that both incident panels now fit, and that auto-assign settles on a sensible layout without reshuffling every hour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
