### PR TITLE
Rank worker placements by effective output; prompt boarding at 0 AP

### DIFF
--- a/TFTV/TFTVBaseRework/Data.cs
+++ b/TFTV/TFTVBaseRework/Data.cs
@@ -888,7 +888,13 @@ namespace TFTV.TFTVBaseRework
         /// reaches the highest total available: specialists claim their own field first, the flat-4
         /// affinities take what is left, and nobody is ever seated somewhere that costs another
         /// Personnel a better slot, because a displaced specialist is worth no more than a regular
-        /// worker anywhere but their own field. Checked against exhaustive search.
+        /// worker anywhere but their own field.
+        ///
+        /// Values come from GetEffectiveWorkerOutput, not the raw table, so the comparison is made
+        /// on the scale the player actually receives - Void Omen 6 multiplies the whole research
+        /// bonus by 1.5, which can make a Biotech in Research worth more than a Machinery in
+        /// Manufacturing despite the raw figures tying. Checked against exhaustive search with and
+        /// without that multiplier.
         ///
         /// Ties keep roster order and prefer Research, so an unchanged roster always produces the
         /// same answer and nobody is reseated for nothing.
@@ -915,7 +921,7 @@ namespace TFTV.TFTVBaseRework
                 {
                     if (freeResearch > 0)
                     {
-                        float research = ResearchAndManufacturing.GetWorkerOutput(person.Character, ResourceType.Research);
+                        float research = ResearchAndManufacturing.GetEffectiveWorkerOutput(person.Character, ResourceType.Research);
                         if (research > bestOutput)
                         {
                             bestOutput = research;
@@ -926,7 +932,7 @@ namespace TFTV.TFTVBaseRework
 
                     if (freeManufacturing > 0)
                     {
-                        float manufacturing = ResearchAndManufacturing.GetWorkerOutput(person.Character, ResourceType.Production);
+                        float manufacturing = ResearchAndManufacturing.GetEffectiveWorkerOutput(person.Character, ResourceType.Production);
                         if (manufacturing > bestOutput)
                         {
                             bestOutput = manufacturing;

--- a/TFTV/TFTVBaseRework/ResearchAndManufacturing.cs
+++ b/TFTV/TFTVBaseRework/ResearchAndManufacturing.cs
@@ -1,4 +1,4 @@
-using HarmonyLib;
+﻿using HarmonyLib;
 using PhoenixPoint.Common.Core;
 using PhoenixPoint.Common.Entities;
 using PhoenixPoint.Geoscape.Entities;
@@ -112,10 +112,7 @@ namespace TFTV.TFTVBaseRework
             researchBonus = GetAssignedBonus(faction, PersonnelAssignment.Research, snapshot.ResearchCapacity, ResourceType.Research)
                 + GetIdleSlotBonus(faction, snapshot.ResearchCapacity, snapshot.ResearchAssigned, ResourceType.Research);
 
-            if (TFTVVoidOmens.VoidOmensCheck[6])
-            {
-                researchBonus *= 1.5f;
-            }
+            researchBonus *= GetResearchOutputMultiplier();
 
             productionBonus = GetAssignedBonus(faction, PersonnelAssignment.Manufacturing, snapshot.ManufacturingCapacity, ResourceType.Production)
                 + GetIdleSlotBonus(faction, snapshot.ManufacturingCapacity, snapshot.ManufacturingAssigned, ResourceType.Production);
@@ -188,6 +185,31 @@ namespace TFTV.TFTVBaseRework
                 .ThenBy(person => person.Id)
                 .Take(capacity)
                 .Sum(person => GetWorkerOutput(person.Character, resourceType));
+        }
+
+        internal const float VoidOmen6ResearchMultiplier = 1.5f;
+
+        /// <summary>
+        /// What the research bonus is multiplied by before it reaches the player. Anything ranking
+        /// worker placements has to apply this too, or it compares research against manufacturing
+        /// on the wrong scale.
+        /// </summary>
+        internal static float GetResearchOutputMultiplier()
+        {
+            return TFTVVoidOmens.VoidOmensCheck[6] ? VoidOmen6ResearchMultiplier : 1f;
+        }
+
+        /// <summary>
+        /// Worker output as it actually reaches the player, after the modifiers GetOutputBonuses
+        /// applies. Use this to compare placements; GetWorkerOutput alone is the unmodified figure.
+        /// </summary>
+        internal static float GetEffectiveWorkerOutput(GeoCharacter character, ResourceType resourceType)
+        {
+            float output = GetWorkerOutput(character, resourceType);
+
+            return resourceType == ResourceType.Research
+                ? output * GetResearchOutputMultiplier()
+                : output;
         }
 
         internal static float GetWorkerOutput(GeoCharacter character, ResourceType resourceType)

--- a/TFTV/Vehicles/Abilities/ExtendedEnterVehicle.cs
+++ b/TFTV/Vehicles/Abilities/ExtendedEnterVehicle.cs
@@ -1,4 +1,4 @@
-using Base;
+﻿using Base;
 using Base.Defs;
 using Base.Serialization.General;
 using PhoenixPoint.Tactical.Entities;
@@ -30,6 +30,51 @@ namespace TFTVVehicleRework.Abilities
             {
                 return this.Def<ExtendedEnterVehicleAbilityDef>();
             }
+        }
+
+        public override void AbilityAdded()
+        {
+            base.AbilityAdded();
+
+            if (this.TacticalActor != null)
+            {
+                this.TacticalActor.AbilityExecutedEvent += this.OnActorAbilityExecuted;
+            }
+        }
+
+        public override void AbilityRemovingStart()
+        {
+            base.AbilityRemovingStart();
+
+            if (this.TacticalActor != null)
+            {
+                this.TacticalActor.AbilityExecutedEvent -= this.OnActorAbilityExecuted;
+            }
+        }
+
+        /// <summary>
+        /// Keeps the discount registered as soon as the operative arrives, rather than waiting for
+        /// the UI to ask.
+        ///
+        /// Registration is a side effect of ShouldDisplay, which only the UI drives. When a move
+        /// finishes, TacticalView.OnAbilityExecuted asks IsEnabled() whether to offer the "enter
+        /// vehicle" prompt, and nothing has queried ShouldDisplay at the new tile by then - so an
+        /// operative who spent their last action point walking onto the entry point was still
+        /// priced at the full entry cost, failed that check, and got no prompt; boarding worked but
+        /// only by selecting the ability by hand.
+        ///
+        /// TacticalAbility raises the actor's event from OnAbilityExecuteFinished immediately
+        /// before handing the same ability to TacticalLevel.AbilityExecuted, which is what the
+        /// prompt is built from, so refreshing here lands in time.
+        /// </summary>
+        private void OnActorAbilityExecuted(TacticalAbility ability)
+        {
+            if (!(ability is IMoveAbility) || this._resolvingActivation)
+            {
+                return;
+            }
+
+            this.UpdateAccessCostModification();
         }
 
         public override bool ShouldDisplay


### PR DESCRIPTION
Follow-up to #65. Two review points on that PR, plus one issue from play. A third review point turned out not to hold and is explained below rather than changed.

---

## 1. Auto-assign ignored the Void Omen 6 research multiplier — fixed

`ResearchAndManufacturing.GetOutputBonuses()` multiplies the **whole** research bonus, worker output included, when Void Omen 6 is active:

```csharp
researchBonus = GetAssignedBonus(...Research...) + GetIdleSlotBonus(...);
if (TFTVVoidOmens.VoidOmensCheck[6]) { researchBonus *= 1.5f; }
productionBonus = GetAssignedBonus(...Manufacturing...) + GetIdleSlotBonus(...);
```

The new assignment routine ranked **raw** worker values, so under that omen it was comparing the two sides on different scales. With one available worker position, one slot of each kind, a lower-Id Machinery worker and a Biotech worker, the raw 6-to-6 tie seated Machinery in Manufacturing for 6 output where seating the Biotech in Research was worth 9.

Placements are now compared through a new `GetEffectiveWorkerOutput`, which applies the multiplier, and `GetOutputBonuses` reads that multiplier from the same `GetResearchOutputMultiplier()` helper — so the ranking and the income cannot drift apart if the omen is retuned.

**Re-verified, because scaling one column changes the matrix and greedy is not optimal for arbitrary matrices.** Exhaustive search over both value tables:

| Research multiplier | Rosters | Mismatches |
|---|---|---|
| 1.0 | 30,000 | 0 |
| 1.5 (Void Omen 6) | 30,000 | 0 |

The specific case above now returns 9.

## 2. No prompt to board after spending the last action point — fixed

Walk an operative onto a vehicle's entry point using their last AP and no "enter vehicle" prompt appeared; boarding still worked, but only by selecting the ability by hand.

The discount that makes boarding free is registered as a side effect of `ShouldDisplay`, which only the UI drives. When a move finishes, `TacticalView.OnAbilityExecuted` asks `IsEnabled()` whether to offer the prompt — and nothing has queried `ShouldDisplay` at the new tile by then, so the ability was still priced at the full entry cost and failed the check.

The ability now refreshes its registration from the actor's `AbilityExecutedEvent`. The ordering was checked rather than assumed — `TacticalAbility` raises the actor event immediately before handing the same ability to the level event the prompt is built from:

```csharp
tacticalActor.OnAbilityExecuteFinished(this, action.Param);   // raises the actor event -> refresh lands here
component.TacticalLevel.AbilityExecuted(this, action.Param);  // raises the event TacticalView builds the prompt from
```

This is also the pattern vanilla's own `OpenCrateAbility` uses for move-triggered work.

## 3. Marketplace easter egg — no change, the concern does not apply

The review asked to "only suppress the vanilla completion copy, or render the filters without blanking mod-supplied text". That is already what #65 does.

`UIModuleTheMarketplace` has four distinct `Text` fields, and vanilla `UpdateVisuals()` routes them differently:

```csharp
MissionDescriptionText.text       = Loca_AllMissionsFinishedDesc.Localize();  // easter egg lands here
MissionRewardDescriptionText.text = Loca_MissionRewardDesc.Localize();        // what the mod blanks
```

`CheckSecretMPCounter()` and the `OnChoiceSelected` postfix both set **`Loca_AllMissionsFinishedDesc`**, which renders into `MissionDescriptionText`. The blanking touches only `MissionRewardHeaderText` and `MissionRewardDescriptionText` — a grep of every mod write to those four objects confirms nothing mod-supplied goes to the two that are cleared; they carry only `Loca_MissionRewardDesc`, the vanilla completion copy. The conversation after purchases 20–41 still appears.

## Reviewer notes

- **Pattern worth naming.** This is the fourth fix to the Fast Entry discount, and all four have been the same shape: the registration existing only where `ShouldDisplay` happened to have run. Deriving the discount on demand instead of registering it on the actor would close the category outright, but that is a larger change than this PR; flagging it as the structural follow-up if a fifth appears.
- **Testing.** Builds clean (0 errors). The assignment change is covered by the exhaustive search above; the prompt and marketplace findings came from the decompiled game code. Worth confirming in play that the prompt now appears on arriving with no AP left, that auto-assign favours Research under Void Omen 6, and that the marketplace conversation still triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
