### PR TITLE
Stop agenda rows and geoscape visuals from going missing or stale

### DIFF
--- a/TFTV/TFTVAAAgenda/AgendaHelpers.cs
+++ b/TFTV/TFTVAAAgenda/AgendaHelpers.cs
@@ -3,13 +3,16 @@ using Base.UI;
 using PhoenixPoint.Common.Core;
 using PhoenixPoint.Common.Entities;
 using PhoenixPoint.Common.UI;
+using PhoenixPoint.Geoscape.Core;
 using PhoenixPoint.Geoscape.Entities;
 using PhoenixPoint.Geoscape.Levels;
+using PhoenixPoint.Geoscape.Levels.Factions.Archeology;
 using PhoenixPoint.Geoscape.View;
 using PhoenixPoint.Geoscape.View.ViewControllers;
 using PhoenixPoint.Geoscape.View.ViewModules;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using TFTV.TFTVBaseRework;
 using UnityEngine;
 using UnityEngine.EventSystems;
@@ -82,6 +85,182 @@ namespace TFTV.AgendaTracker
         internal static bool HasCustomSiteTracker(GeoSite site)
         {
             return GetPendingBaseAction(site).HasValue || GetActiveIncident(site) != null;
+        }
+
+        /// <summary>
+        /// Whether this site still has anything for the Agenda Tracker to report - the union of every
+        /// reason a site row is ever created, so it doubles as the row's lifetime: the row lives while
+        /// this is true and is disposed once it is not.
+        ///
+        /// A row must not be disposed on a zeroed countdown alone. An incident's countdown reaches zero
+        /// a moment before the event system's own tick completes it, and disposing on the countdown
+        /// would drop the row only for the next sweep to put it straight back.
+        /// </summary>
+        internal static bool HasAnySiteTrackerReason(GeoSite site, GeoscapeViewContext context)
+        {
+            try
+            {
+                GeoLevelController level = context != null ? context.Level : null;
+                if (site == null || level == null)
+                {
+                    return false;
+                }
+
+                if (HasCustomSiteTracker(site))
+                {
+                    return true;
+                }
+
+                if (level.PhoenixFaction != null && level.PhoenixFaction.ExcavatingSites != null)
+                {
+                    foreach (SiteExcavationState excavation in level.PhoenixFaction.ExcavatingSites)
+                    {
+                        if (excavation != null && excavation.Site == site && !excavation.IsExcavated)
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                foreach (GeoFaction faction in level.Factions)
+                {
+                    if (faction.IsViewerFaction || faction.IsEnvironmentFaction || faction.IsNeutralFaction || faction.IsInactiveFaction)
+                    {
+                        continue;
+                    }
+
+                    if (HasAttackScheduledFor(faction.AncientSiteAttackSchedule, site)
+                        || HasAttackScheduledFor(faction.PhoenixBaseAttackSchedule, site))
+                    {
+                        return true;
+                    }
+                }
+
+                if (site.Type == GeoSiteType.PhoenixBase
+                    && TFTVBaseDefenseGeoscape.PhoenixBasesUnderAttack.ContainsKey(site.SiteId))
+                {
+                    return true;
+                }
+
+                // Anything else the game hung a countdown on - haven defence timers reach the tracker
+                // through GeoscapeLog.ShowSiteDefenseTimer and are tracked by nothing else.
+                return site.ExpiringTimerAt > level.Timing.Now;
+            }
+            catch (Exception e)
+            {
+                TFTVLogger.Error(e);
+
+                // Never let a bad read take a row away.
+                return true;
+            }
+        }
+
+        private static bool HasAttackScheduledFor(IEnumerable<SiteAttackSchedule> schedules, GeoSite site)
+        {
+            if (schedules == null)
+            {
+                return false;
+            }
+
+            foreach (SiteAttackSchedule schedule in schedules)
+            {
+                if (schedule != null && schedule.HasAttackScheduled && schedule.Site == site)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Time left on whatever this site is being tracked for, in the order the reasons take
+        /// precedence. False when the site has no countdown to show, which is not the same as having
+        /// no reason to be listed - see <see cref="HasAnySiteTrackerReason"/>.
+        /// </summary>
+        internal static bool TryResolveSiteTimer(GeoSite site, GeoscapeViewContext context, out TimeUnit remaining)
+        {
+            remaining = TimeUnit.Zero;
+
+            try
+            {
+                GeoLevelController level = context != null ? context.Level : null;
+                if (site == null || level == null)
+                {
+                    return false;
+                }
+
+                TimeUnit now = level.Timing.Now;
+
+                if (GetPendingBaseAction(site).HasValue && site.ExpiringTimerAt > TimeUnit.Zero)
+                {
+                    remaining = site.ExpiringTimerAt - now;
+                    return true;
+                }
+
+                Resolution.ActiveTimedProblem incident = GetActiveIncident(site);
+                if (incident != null)
+                {
+                    remaining = incident.EndAt - now;
+                    return true;
+                }
+
+                if (site.IsArcheologySite)
+                {
+                    if (site.IsOwnedByViewer)
+                    {
+                        foreach (GeoFaction faction in level.Factions)
+                        {
+                            if (faction.IsViewerFaction || faction.IsEnvironmentFaction || faction.IsNeutralFaction || faction.IsInactiveFaction)
+                            {
+                                continue;
+                            }
+
+                            foreach (SiteAttackSchedule schedule in faction.AncientSiteAttackSchedule)
+                            {
+                                if (schedule.HasAttackScheduled && schedule.Site == site)
+                                {
+                                    remaining = schedule.ScheduledFor - now;
+                                    return true;
+                                }
+                            }
+                        }
+                    }
+                    else if (level.PhoenixFaction != null && level.PhoenixFaction.ExcavatingSites != null)
+                    {
+                        foreach (SiteExcavationState excavation in level.PhoenixFaction.ExcavatingSites)
+                        {
+                            if (excavation != null && excavation.Site == site)
+                            {
+                                remaining = excavation.ExcavationEndDate - now;
+                                return true;
+                            }
+                        }
+                    }
+                }
+
+                if (site.Type == GeoSiteType.PhoenixBase
+                    && TFTVBaseDefenseGeoscape.PhoenixBasesUnderAttack.ContainsKey(site.SiteId))
+                {
+                    TimeUnit attackAt = TimeUnit.FromSeconds(
+                        (float)(3600 * TFTVBaseDefenseGeoscape.PhoenixBasesUnderAttack[site.SiteId].First().Value));
+                    remaining = attackAt - now;
+                    return true;
+                }
+
+                if (site.ExpiringTimerAt > TimeUnit.Zero)
+                {
+                    remaining = site.ExpiringTimerAt - now;
+                    return true;
+                }
+
+                return false;
+            }
+            catch (Exception e)
+            {
+                TFTVLogger.Error(e);
+                return false;
+            }
         }
 
         #endregion
@@ -308,6 +487,14 @@ namespace TFTV.AgendaTracker
                 return;
             }
 
+            // Disposing the same element twice would queue it for removal twice and put it into the
+            // reuse pool twice - the second copy then gets handed to a new row while the first is
+            // still drawing one, and one of the two rows is lost.
+            if (AgendaConstants.IsQueuedForRemoval(tracker, element))
+            {
+                return;
+            }
+
             // Dispose() logically removes the row for this mod through PendingPurge.
             // Physical removal from vanilla's _currentTrackedElements remains deferred
             // until the next parameterless UpdateData() processes _elementsToRemove.
@@ -324,33 +511,6 @@ namespace TFTV.AgendaTracker
 
             // The postfix on parameterless UpdateData already applies custom ordering.
             AgendaConstants.UpdateData.Invoke(tracker, null);
-        }
-
-        internal static bool TryUpdateCustomSiteElement(UIFactionDataTrackerElement element, GeoSite site, GeoscapeViewContext context, out bool isExpired)
-        {
-            isExpired = false;
-
-            ApplyCustomSiteTrackerText(element, site, context?.ViewerFaction);
-
-            var pendingAction = GetPendingBaseAction(site);
-            if (pendingAction.HasValue && site.ExpiringTimerAt > TimeUnit.Zero)
-            {
-                TimeUnit remaining = site.ExpiringTimerAt - context.Level.Timing.Now;
-                element.UpdateData(remaining, true, null);
-                isExpired = remaining <= TimeUnit.Zero;
-                return true;
-            }
-
-            var incident = GetActiveIncident(site);
-            if (incident != null)
-            {
-                TimeUnit remaining = incident.EndAt - context.Level.Timing.Now;
-                element.UpdateData(remaining, true, null);
-                isExpired = remaining <= TimeUnit.Zero;
-                return true;
-            }
-
-            return false;
         }
 
         internal static void ApplyCustomSiteTrackerText(UIFactionDataTrackerElement element, GeoSite site, GeoFaction viewerFaction)

--- a/TFTV/TFTVAAAgenda/AgendaPatches.cs
+++ b/TFTV/TFTVAAAgenda/AgendaPatches.cs
@@ -274,14 +274,24 @@ namespace TFTV.AgendaTracker
                     else if (element.TrackedObject is GeoSite geoSite)
                     {
                         AgendaHelpers.WireClickEvent(element, () => ____context.View.ChaseTarget(geoSite, false));
+                        AgendaHelpers.ApplyCustomSiteTrackerText(element, geoSite, ____context?.ViewerFaction);
 
-                        if (AgendaHelpers.TryUpdateCustomSiteElement(element, geoSite, ____context, out bool customExpired))
+                        if (AgendaHelpers.TryResolveSiteTimer(geoSite, ____context, out TimeUnit remaining))
                         {
-                            __result = customExpired;
-                            return false;
+                            element.UpdateData(remaining, true, null);
                         }
 
-                        UpdateSiteTimers(element, geoSite, ____context);
+                        if (geoSite.Type == GeoSiteType.PhoenixBase
+                            && TFTVBaseDefenseGeoscape.PhoenixBasesUnderAttack.ContainsKey(geoSite.SiteId))
+                        {
+                            geoSite.RefreshVisuals();
+                        }
+
+                        // A site row lives for as long as the site has something to report, not until
+                        // its countdown hits zero: the incident that owns the countdown is completed by
+                        // the event system's own tick a moment later, and disposing on zero first would
+                        // drop the row only for the next sweep to add it straight back.
+                        __result = !AgendaHelpers.HasAnySiteTrackerReason(geoSite, ____context);
                         return false;
                     }
 
@@ -291,44 +301,6 @@ namespace TFTV.AgendaTracker
                 {
                     TFTVLogger.Error(e);
                     return true;
-                }
-            }
-
-            private static void UpdateSiteTimers(UIFactionDataTrackerElement element, GeoSite geoSite, GeoscapeViewContext context)
-            {
-                if (geoSite.IsArcheologySite)
-                {
-                    if (geoSite.IsOwnedByViewer)
-                    {
-                        foreach (GeoFaction f in context.Level.Factions)
-                        {
-                            if (f.IsViewerFaction || f.IsEnvironmentFaction || f.IsNeutralFaction || f.IsInactiveFaction) continue;
-                            foreach (var schedule in f.AncientSiteAttackSchedule)
-                            {
-                                if (schedule.HasAttackScheduled && schedule.Site == geoSite)
-                                {
-                                    TimeUnit attackTime = TimeUnit.FromHours((float)(schedule.ScheduledFor - context.Level.Timing.Now).TimeSpan.TotalHours);
-                                    element.UpdateData(attackTime, true, null);
-                                }
-                            }
-                        }
-                    }
-                    else
-                    {
-                        var excavation = geoSite.GeoLevel.PhoenixFaction.ExcavatingSites.FirstOrDefault(s => s.Site == geoSite);
-                        if (excavation != null)
-                        {
-                            TimeUnit timeLeft = TimeUnit.FromHours((float)(excavation.ExcavationEndDate - context.Level.Timing.Now).TimeSpan.TotalHours);
-                            element.UpdateData(timeLeft, true, null);
-                        }
-                    }
-                }
-                else if (geoSite.Type == GeoSiteType.PhoenixBase && TFTVBaseDefenseGeoscape.PhoenixBasesUnderAttack.ContainsKey(geoSite.SiteId))
-                {
-                    TimeUnit timer = TimeUnit.FromSeconds((float)(3600 * TFTVBaseDefenseGeoscape.PhoenixBasesUnderAttack[geoSite.SiteId].First().Value));
-                    TimeUnit attackTime = timer - context.Level.Timing.Now;
-                    element.UpdateData(attackTime, true, null);
-                    geoSite.RefreshVisuals();
                 }
             }
 
@@ -374,42 +346,128 @@ namespace TFTV.AgendaTracker
             {
                 try
                 {
-                    if (!(____faction is GeoPhoenixFaction phoenix)) return;
-
-
-                    // Recruit training sessions
-                    foreach (var session in TrainingFacilityRework.GetActiveRecruitSessions())
-                    {
-                        string text = AgendaHelpers.GetRecruitTrainingTrackerText(session.Character);
-                        var el = AgendaHelpers.AddTrackerElement(session.Character, text, AgendaHelpers.GetTrainingViewElement());
-                        AgendaHelpers.ApplyRecruitTrainingTrackerText(el, session.Character);
-                    }
-
-                    // Excavations
-                    foreach (var excavation in phoenix.ExcavatingSites.Where(s => !s.IsExcavated))
-                    {
-                        string info = $"{AgendaConstants.actionExcavating} {excavation.Site.Name}";
-                        AgendaHelpers.AddTrackerElement(excavation.Site, info, AgendaHelpers.GetGenericSiteViewElement());
-                    }
-
-                    // Custom site trackers (incidents, base activation)
-                    foreach (var site in ____context.Level.Map.AllSites.Where(s => s != null && AgendaHelpers.HasCustomSiteTracker(s)))
-                    {
-                        string info = AgendaHelpers.GetCustomSiteTrackerText(site, ____context.ViewerFaction);
-                        var el = AgendaHelpers.AddTrackerElement(site, info, AgendaHelpers.GetCustomSiteViewElement(site));
-                        AgendaHelpers.ApplyCustomSiteTrackerText(el, site, ____context.ViewerFaction);
-                    }
-
-                    // Base defense and ancient site attacks
-                    AddAttackTrackers(__instance, ____faction, ____context);
-
+                    EnsureCustomTrackers(__instance, ____faction, ____context);
                     AgendaHelpers.ReapplyResolvedTrackerTexts(__instance, ____context.ViewerFaction);
                     AgendaRefresh.TryApplyPendingRefreshAfterBaseReworkRestore();
                 }
                 catch (Exception e) { TFTVLogger.Error(e); }
             }
 
-            private static void AddAttackTrackers(UIModuleFactionAgendaTracker tracker, GeoFaction faction, GeoscapeViewContext context)
+            /// <summary>
+            /// Adds a row for every incident, pending base activation, excavation, scheduled attack and
+            /// recruit training session that does not already have one.
+            ///
+            /// Vanilla only ever builds the tracker from InitialSetup(), which runs when the player
+            /// changes geoscape selection, so a row lost between two of those - to a recycled pooled
+            /// element, a stray Dispose, or a throw part-way through the rebuild - stayed lost until the
+            /// player happened to click something. Every group here is keyed off the tracked object and
+            /// skips objects that already have a live row, so the same call is also made once a second
+            /// from UpdateData() and any gap closes on its own within a tick.
+            /// </summary>
+            internal static void EnsureCustomTrackers(UIModuleFactionAgendaTracker tracker, GeoFaction faction, GeoscapeViewContext context)
+            {
+                if (tracker == null || context == null || context.Level == null) return;
+                if (!(faction is GeoPhoenixFaction phoenix)) return;
+
+                List<UIFactionDataTrackerElement> live = AgendaConstants.GetLiveTrackedElements(tracker);
+                if (live == null) return;
+
+                List<object> tracked = new List<object>(live.Count);
+                foreach (UIFactionDataTrackerElement element in live)
+                {
+                    if (element.TrackedObject != null)
+                    {
+                        tracked.Add(element.TrackedObject);
+                    }
+                }
+
+                bool IsTracked(object trackedObject)
+                {
+                    foreach (object candidate in tracked)
+                    {
+                        if (ReferenceEquals(candidate, trackedObject)) return true;
+                    }
+                    return false;
+                }
+
+                UIFactionDataTrackerElement Add(object trackedObject, string text, ViewElementDef viewElement)
+                {
+                    if (trackedObject == null || IsTracked(trackedObject)) return null;
+
+                    UIFactionDataTrackerElement added = AgendaHelpers.AddTrackerElement(trackedObject, text, viewElement);
+                    if (added != null)
+                    {
+                        tracked.Add(trackedObject);
+                    }
+                    return added;
+                }
+
+                // Each group is guarded on its own: one bad entry must not cost the tracker every row
+                // that would have been added after it.
+                try
+                {
+                    foreach (var session in TrainingFacilityRework.GetActiveRecruitSessions())
+                    {
+                        if (session?.Character == null || IsTracked(session.Character)) continue;
+
+                        // Training that has run out its clock but has not been marked complete yet is
+                        // disposed by UpdateData as finished; adding it back here would have the row
+                        // blink in and out once a second until the session closes.
+                        if (AgendaHelpers.GetRecruitTrainingRemainingTime(session.Character, context.Level) <= TimeUnit.Zero) continue;
+
+                        UIFactionDataTrackerElement added = Add(
+                            session.Character,
+                            AgendaHelpers.GetRecruitTrainingTrackerText(session.Character),
+                            AgendaHelpers.GetTrainingViewElement());
+
+                        AgendaHelpers.ApplyRecruitTrainingTrackerText(added, session.Character);
+                    }
+                }
+                catch (Exception e) { TFTVLogger.Error(e); }
+
+                try
+                {
+                    foreach (SiteExcavationState excavation in phoenix.ExcavatingSites)
+                    {
+                        if (excavation == null || excavation.IsExcavated || excavation.Site == null) continue;
+                        if (IsTracked(excavation.Site)) continue;
+
+                        Add(
+                            excavation.Site,
+                            $"{AgendaConstants.actionExcavating} {excavation.Site.Name}",
+                            AgendaHelpers.GetGenericSiteViewElement());
+                    }
+                }
+                catch (Exception e) { TFTVLogger.Error(e); }
+
+                try
+                {
+                    foreach (GeoSite site in context.Level.Map.AllSites)
+                    {
+                        if (site == null || IsTracked(site) || !AgendaHelpers.HasCustomSiteTracker(site)) continue;
+
+                        UIFactionDataTrackerElement added = Add(
+                            site,
+                            AgendaHelpers.GetCustomSiteTrackerText(site, context.ViewerFaction),
+                            AgendaHelpers.GetCustomSiteViewElement(site));
+
+                        AgendaHelpers.ApplyCustomSiteTrackerText(added, site, context.ViewerFaction);
+                    }
+                }
+                catch (Exception e) { TFTVLogger.Error(e); }
+
+                try
+                {
+                    AddAttackTrackers(faction, context, IsTracked, Add);
+                }
+                catch (Exception e) { TFTVLogger.Error(e); }
+            }
+
+            private static void AddAttackTrackers(
+                GeoFaction faction,
+                GeoscapeViewContext context,
+                Func<object, bool> isTracked,
+                Func<object, string, ViewElementDef, UIFactionDataTrackerElement> add)
             {
                 foreach (GeoFaction geoFaction in context.Level.Factions)
                 {
@@ -428,10 +486,10 @@ namespace TFTV.AgendaTracker
                             foreach (int siteId in TFTVBaseDefenseGeoscape.PhoenixBasesUnderAttack.Keys)
                             {
                                 GeoSite pxBase = TFTVBaseDefenseGeoscape.InitAttack.FindPhoenixBase(siteId, controller);
-                                if (pxBase.HasActiveMission)
+                                if (pxBase != null && pxBase.HasActiveMission && !isTracked(pxBase))
                                 {
                                     string info = $"{geoFaction.Name.Localize().ToUpperInvariant()} {AgendaConstants.actionAttackOnPX} {pxBase.Name}";
-                                    AgendaHelpers.AddTrackerElement(pxBase, info, AgendaHelpers.GetCrabmanViewElement());
+                                    add(pxBase, info, AgendaHelpers.GetCrabmanViewElement());
                                 }
                             }
                         }
@@ -440,10 +498,10 @@ namespace TFTV.AgendaTracker
                     // Ancient site attacks
                     foreach (var schedule in geoFaction.AncientSiteAttackSchedule)
                     {
-                        if (schedule.HasAttackScheduled && schedule.Site.Owner == context.ViewerFaction)
+                        if (schedule.HasAttackScheduled && schedule.Site != null && schedule.Site.Owner == context.ViewerFaction && !isTracked(schedule.Site))
                         {
                             string info = $"{geoFaction.Name.Localize().ToUpperInvariant()} {AgendaConstants.actionAttack} {schedule.Site.Name}";
-                            AgendaHelpers.AddTrackerElement(schedule.Site, info, AgendaHelpers.GetGenericSiteViewElement());
+                            add(schedule.Site, info, AgendaHelpers.GetGenericSiteViewElement());
                         }
                     }
                 }
@@ -640,6 +698,41 @@ namespace TFTV.AgendaTracker
 
         #region Stability (prevent vanilla full-rebuild flicker + stale re-tracked rows) & ordering
 
+        // Vanilla's Dispose() puts an element straight back into the pool while still leaving it in
+        // _currentTrackedElements and queued in _elementsToRemove; the two are only reconciled at the
+        // top of the next parameterless UpdateData(). GetFreeElement() can therefore hand out an
+        // element the tracker still believes it has to delete, and that pending delete then lands on
+        // the row just built from it - the row vanishes a second or so after appearing. An element
+        // disposed twice is worse: it sits in the pool twice, so a later row is handed a GameObject a
+        // live row is already drawing with, and one of the two rows is lost.
+        //
+        // Every add path - ours and vanilla's OnResearchStarted / OnItemStartedManufacturing /
+        // OnVehicleAction / OnFacilityBuilding alike - goes through GetFreeElement(), so reconciling
+        // the recycled element here means an element handed out is always a clean slate. Safe to
+        // mutate the tracked list from here: no caller reaches GetFreeElement() while that list is
+        // being enumerated (InitialSetup's teardown loop finishes before it re-adds, and UpdateData()'s
+        // per-element loop never adds).
+        [HarmonyPatch(typeof(UIModuleFactionAgendaTracker), "GetFreeElement")]
+        public static class UIModuleFactionAgendaTracker_GetFreeElement_Patch
+        {
+            public static void Postfix(UIModuleFactionAgendaTracker __instance, UIFactionDataTrackerElement __result)
+            {
+                try
+                {
+                    if (__result == null) return;
+
+                    var pendingRemoval = AgendaConstants.GetElementsQueuedForRemoval(__instance);
+                    pendingRemoval?.RemoveAll(e => ReferenceEquals(e, __result));
+
+                    var tracked = AgendaConstants.GetTrackedElements(__instance);
+                    tracked?.RemoveAll(e => ReferenceEquals(e, __result));
+
+                    AgendaConstants.PendingPurge.Remove(__result);
+                }
+                catch (Exception e) { TFTVLogger.Error(e); }
+            }
+        }
+
         [HarmonyPatch(
      typeof(UIModuleFactionAgendaTracker),
      "Dispose",
@@ -710,7 +803,7 @@ namespace TFTV.AgendaTracker
         [HarmonyPatch(typeof(UIModuleFactionAgendaTracker), "UpdateData", new Type[] { })]
         public static class UIModuleFactionAgendaTracker_UpdateDataNoArgs_Patch
         {
-            public static void Postfix(UIModuleFactionAgendaTracker __instance, GeoFaction ____faction)
+            public static void Postfix(UIModuleFactionAgendaTracker __instance, GeoFaction ____faction, GeoscapeViewContext ____context)
             {
                 try
                 {
@@ -729,6 +822,7 @@ namespace TFTV.AgendaTracker
                     }
 
                     EnsureLiveVanillaTrackers(__instance, ____faction);
+                    UIModuleFactionAgendaTracker_InitialSetup_Patch.EnsureCustomTrackers(__instance, ____faction, ____context);
 
                     AgendaConstants.OrderElements.Invoke(__instance, null);
                 }

--- a/TFTV/TFTVAAAgenda/AgendaTracker.cs
+++ b/TFTV/TFTVAAAgenda/AgendaTracker.cs
@@ -97,6 +97,32 @@ namespace TFTV.AgendaTracker
         internal static readonly FieldInfo CurrentTrackedElementsField =
             AccessTools.Field(typeof(UIModuleFactionAgendaTracker), "_currentTrackedElements");
 
+        // Stock's queue of elements Dispose()'d but not yet taken out of _currentTrackedElements.
+        // Vanilla drains it at the top of the parameterless UpdateData(); until then an element can be
+        // in the reuse pool, in the tracked list and in here all at once.
+        internal static readonly FieldInfo ElementsToRemoveField =
+            AccessTools.Field(typeof(UIModuleFactionAgendaTracker), "_elementsToRemove");
+
+        internal static List<UIFactionDataTrackerElement> GetElementsQueuedForRemoval(UIModuleFactionAgendaTracker instance)
+        {
+            return instance != null && ElementsToRemoveField != null
+                ? ElementsToRemoveField.GetValue(instance) as List<UIFactionDataTrackerElement>
+                : null;
+        }
+
+        internal static bool IsQueuedForRemoval(UIModuleFactionAgendaTracker instance, UIFactionDataTrackerElement element)
+        {
+            List<UIFactionDataTrackerElement> queued = GetElementsQueuedForRemoval(instance);
+            if (queued == null || element == null) return false;
+
+            foreach (UIFactionDataTrackerElement queuedElement in queued)
+            {
+                if (ReferenceEquals(queuedElement, element)) return true;
+            }
+
+            return false;
+        }
+
         internal static List<UIFactionDataTrackerElement> GetTrackedElements()
         {
             return GetTrackedElements(factionTracker);

--- a/TFTV/TFTVBaseRework/BaseConstructionVisuals.cs
+++ b/TFTV/TFTVBaseRework/BaseConstructionVisuals.cs
@@ -333,10 +333,29 @@ namespace TFTV.TFTVBaseRework
         private static readonly HashSet<int> _activeSiteIdsBuffer = new HashSet<int>();
         private static readonly List<int> _staleSiteIdsBuffer = new List<int>();
 
-        // Progression ranges already pushed into each visual. SetProgression touches renderer
-        // materials, so it must only be called when the range actually changes.
-        private static readonly Dictionary<int, KeyValuePair<TimeUnit, TimeUnit>> AppliedProgression =
-            new Dictionary<int, KeyValuePair<TimeUnit, TimeUnit>>();
+        /// <summary>
+        /// The progression range already pushed into a site's visual, and the controller it was pushed
+        /// into. SetProgression touches renderer materials, so it is only called when something has
+        /// actually changed - but the controller has to be part of "something". A tactical mission
+        /// tears the geoscape down and destroys these GameObjects, so the site gets a brand new
+        /// controller on return while its pending timer is unchanged; keyed on the range alone the
+        /// refresh reads "already applied" and leaves the new controller untouched, showing the
+        /// prefab's own default material (a full red ring) instead of the shrinking orange one.
+        /// </summary>
+        private sealed class AppliedProgressionState
+        {
+            public GeoActorProgressionVisualController Controller;
+            public TimeUnit Start;
+            public TimeUnit End;
+
+            public bool Matches(GeoActorProgressionVisualController controller, TimeUnit start, TimeUnit end)
+            {
+                return ReferenceEquals(Controller, controller) && Start == start && End == end;
+            }
+        }
+
+        private static readonly Dictionary<int, AppliedProgressionState> AppliedProgression =
+            new Dictionary<int, AppliedProgressionState>();
 
         public static void RefreshPendingConstructionVisuals(GeoLevelController level)
         {
@@ -375,6 +394,12 @@ namespace TFTV.TFTVBaseRework
 
                 if (!PendingConstructionVisuals.TryGetValue(site.SiteId, out GeoActorProgressionVisualController controller) || controller == null)
                 {
+                    // The previous controller is gone (never made, or destroyed with the geoscape while
+                    // the player was in a mission), so the site is starting over: let it be logged again
+                    // and make sure nothing claims its progression is still applied.
+                    PendingVisualCreationLogged.Remove(site.SiteId);
+                    AppliedProgression.Remove(site.SiteId);
+
                     GeoVehicle vehicle = ResolveVehicleForSite(site, level);
                     GeoActorProgressionVisualController prefab = vehicle?.VehicleDef?.ExplorationVisualsPrefab
                         ?? level?.PhoenixFaction?.Vehicles?.FirstOrDefault()?.VehicleDef?.ExplorationVisualsPrefab;
@@ -414,14 +439,21 @@ namespace TFTV.TFTVBaseRework
                 float durationHours = PhoenixBaseVisitFlow.GetPendingDurationHours(site);
                 TimeUnit startAt = site.ExpiringTimerAt - TimeUnit.FromHours(durationHours);
 
-                // SetProgression writes to the renderer's material, and the controller animates
-                // itself from its own Update, so only push the range when it has actually changed.
-                if (!AppliedProgression.TryGetValue(site.SiteId, out KeyValuePair<TimeUnit, TimeUnit> applied)
-                    || applied.Key != startAt
-                    || applied.Value != site.ExpiringTimerAt)
+                // SetProgression writes to the renderer's material, and the controller animates itself
+                // from its own Update, so only push the range when this controller has not already been
+                // given it.
+                if (!AppliedProgression.TryGetValue(site.SiteId, out AppliedProgressionState applied)
+                    || applied == null
+                    || !applied.Matches(controller, startAt, site.ExpiringTimerAt))
                 {
                     controller.SetProgression(startAt, site.ExpiringTimerAt, level.Timing);
-                    AppliedProgression[site.SiteId] = new KeyValuePair<TimeUnit, TimeUnit>(startAt, site.ExpiringTimerAt);
+
+                    AppliedProgression[site.SiteId] = new AppliedProgressionState
+                    {
+                        Controller = controller,
+                        Start = startAt,
+                        End = site.ExpiringTimerAt
+                    };
                 }
 
                 if (!controller.gameObject.activeSelf)

--- a/TFTV/TFTVIncidents/Affinities.cs
+++ b/TFTV/TFTVIncidents/Affinities.cs
@@ -11,6 +11,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using TFTV.TFTVBaseRework;
+using UnityEngine;
 
 namespace TFTV.TFTVIncidents
 {
@@ -26,6 +27,55 @@ namespace TFTV.TFTVIncidents
         public static PassiveModifierAbilityDef[] Compute = new PassiveModifierAbilityDef[] { };
 
         public static SkillTagDef AffinityTag;
+
+        /// <summary>
+        /// Phoenix Project's own red-orange, which the affinity glyphs are drawn in.
+        /// </summary>
+        internal static readonly Color AffinityIconColor = new Color32(0xED, 0x6E, 0x2B, 0xFF);
+
+        /// <summary>
+        /// Loads an affinity glyph and multiplies it by <see cref="AffinityIconColor"/>.
+        ///
+        /// The source PNGs are a white glyph on a black plate, so multiplying paints the glyph and
+        /// leaves the plate black. Baking the colour into the sprite rather than tinting Image.color
+        /// at each use means every place the icon appears - our incident screens and the game's own
+        /// ability panels and tooltips alike - shows it in the same colour.
+        /// </summary>
+        internal static Sprite CreateAffinityIcon(string imageFileName)
+        {
+            try
+            {
+                Sprite sprite = Helper.CreateSpriteFromImageFile(imageFileName);
+                Texture2D texture = sprite != null ? sprite.texture : null;
+                if (texture == null)
+                {
+                    return sprite;
+                }
+
+                Color tint = AffinityIconColor;
+                Color32[] pixels = texture.GetPixels32();
+
+                for (int i = 0; i < pixels.Length; i++)
+                {
+                    Color32 pixel = pixels[i];
+                    pixels[i] = new Color32(
+                        (byte)(pixel.r * tint.r),
+                        (byte)(pixel.g * tint.g),
+                        (byte)(pixel.b * tint.b),
+                        pixel.a);
+                }
+
+                texture.SetPixels32(pixels);
+                texture.Apply();
+
+                return sprite;
+            }
+            catch (Exception e)
+            {
+                TFTVLogger.Error(e);
+                return Helper.CreateSpriteFromImageFile(imageFileName);
+            }
+        }
 
         internal class Defs
         {
@@ -134,7 +184,7 @@ namespace TFTV.TFTVIncidents
 
                         newAbility.ViewElementDef.DisplayName1.LocalizationKey = titleKeyBase + x.ToString();
                         newAbility.ViewElementDef.Description.LocalizationKey = descKeyBase + x.ToString();
-                        newAbility.ViewElementDef.LargeIcon = Helper.CreateSpriteFromImageFile($"UI_AffinityIcon_{nameToken}_0.png");//{x}.png");
+                        newAbility.ViewElementDef.LargeIcon = CreateAffinityIcon($"UI_AffinityIcon_{nameToken}_0.png");//{x}.png");
                         newAbility.ViewElementDef.SmallIcon = newAbility.ViewElementDef.LargeIcon;
 
                         newAbility.CharacterProgressionData = Helper.CreateDefFromClone(
@@ -242,6 +292,14 @@ namespace TFTV.TFTVIncidents
         {
             private const string GeoBenefitVariablePrefix = "TFTV_AFFINITY_GEO_OPTION_";
             private const string TacticalBenefitVariablePrefix = "TFTV_AFFINITY_TAC_OPTION_";
+
+            /// <summary>
+            /// Stamina every operative aboard recovers after a mission, per Psycho-Sociology rank,
+            /// for that approach's second geoscape benefit. Shared with the code that actually
+            /// grants it (AffinityGeoscapeEffects.ApplyPostMissionRecovery) so the description
+            /// and the effect cannot drift apart.
+            /// </summary>
+            internal const int PsychoSociologyStaminaPerRank = 3;
 
             private const string KeyPsychoGeoOpt1 = "KEY_AFFINITY_GEO_DESC_PSYCHO_SOCIOLOGY_OPTION_1";
             private const string KeyPsychoGeoOpt2 = "KEY_AFFINITY_GEO_DESC_PSYCHO_SOCIOLOGY_OPTION_2";
@@ -702,7 +760,7 @@ int option)
                     case LeaderSelection.AffinityApproach.PsychoSociology:
                         return option == 1
                             ? LocalizeAndFormat(KeyPsychoGeoOpt1, 15 * r)
-                            : LocalizeAndFormat(KeyPsychoGeoOpt2, 2 * r);    // 2 Stamina per rank
+                            : LocalizeAndFormat(KeyPsychoGeoOpt2, PsychoSociologyStaminaPerRank * r);
 
                     case LeaderSelection.AffinityApproach.Exploration:
                         return option == 1

--- a/TFTV/TFTVIncidents/AffinityGeoscapeEffects.cs
+++ b/TFTV/TFTVIncidents/AffinityGeoscapeEffects.cs
@@ -614,14 +614,14 @@ namespace TFTV.TFTVIncidents
 
                 // PsychoSociology option 1: handled via ResourceMissionOutcomeDef_ApplyOutcome_AffinityHavenDefenseReward_Patch
 
-                // PsychoSociology option 2: all operatives in the aircraft recover 2 Stamina after a mission
+                // PsychoSociology option 2: all operatives in the aircraft recover Stamina after a mission
                 int psychoSociologyRank = GetActiveGeoscapeRank(level, squadSoldiers, LeaderSelection.AffinityApproach.PsychoSociology, requiredOption: 2);
 
                 TFTVLogger.Always($"{DiagTag} PsychoSociology post-mission stamina recovery rank: {psychoSociologyRank}.");
 
                 if (psychoSociologyRank > 0 && squad.Soldiers != null)
                 {
-                    float staminaAmount = 2f * psychoSociologyRank;
+                    float staminaAmount = Affinities.AffinityBenefitsChoices.PsychoSociologyStaminaPerRank * psychoSociologyRank;
                     foreach (GeoCharacter soldier in squad.Soldiers)
                     {
                         soldier.Fatigue?.Stamina?.AddRestrictedToMax(staminaAmount);
@@ -1006,7 +1006,7 @@ namespace TFTV.TFTVIncidents
     GeoLevelController level,
     List<GeoCharacter> operativesInvolved)
         {
-            // PsychoSociology option 2 is now: all operatives recover 2 Stamina after a mission (handled in ApplyPostMissionRecovery).
+            // PsychoSociology option 2 is now: all operatives recover Stamina after a mission (handled in ApplyPostMissionRecovery).
             // Delirium recovery bonus has been removed. Returning 0 to neutralise the call in TFTVDelirium.RemoveDeliriumPerks.
             return 0;
 

--- a/TFTV/TFTVIncidents/ComputeMountedAbility.cs
+++ b/TFTV/TFTVIncidents/ComputeMountedAbility.cs
@@ -115,7 +115,7 @@ namespace TFTV.TFTVIncidents
                             10 * rank),
                         true);
 
-                    mountedDriverPassiveAbility.ViewElementDef.LargeIcon = Helper.CreateSpriteFromImageFile($"UI_AffinityIcon_COMPUTE_0.png");
+                    mountedDriverPassiveAbility.ViewElementDef.LargeIcon = Affinities.CreateAffinityIcon($"UI_AffinityIcon_COMPUTE_0.png");
                     mountedDriverPassiveAbility.ViewElementDef.SmallIcon = mountedDriverPassiveAbility.ViewElementDef.LargeIcon;
 
                     mountedDriverPassiveAbility.Rank = rank;

--- a/TFTV/TFTVIncidents/GeoscapeEvents.cs
+++ b/TFTV/TFTVIncidents/GeoscapeEvents.cs
@@ -788,8 +788,11 @@ namespace TFTV.TFTVIncidents
             TacCharacterDef source = DefCache.GetDef<TacCharacterDef>("S_SY_Eileen_CharacterTemplateDef");
             TacCharacterDef nahia = Helper.CreateDefFromClone(source, "{C40430EB-1A4E-4B0C-B148-F57EB9939628}", "TFTV_NahiaGrivane_CharacterDef");
 
+            // Data.Name is turned into LocalizedTextBind(Name, doNotLocalize: !LocalizeName), so the
+            // key has to stay paired with LocalizeName = true - with false the raw
+            // KEY_TFTV_NAHIA_GRIVANE is what the player reads.
             nahia.Data.Name = "KEY_TFTV_NAHIA_GRIVANE";
-            nahia.Data.LocalizeName = false;
+            nahia.Data.LocalizeName = true;
 
             List <GameTagDef> tagDefs =  nahia.Data.GameTags.ToList();
 

--- a/TFTV/TFTVIncidents/PortraitGenerator.cs
+++ b/TFTV/TFTVIncidents/PortraitGenerator.cs
@@ -1,4 +1,5 @@
 ﻿using Base.Cameras;
+using HarmonyLib;
 
 using Base.Core;
 using PhoenixPoint.Common.Core;
@@ -51,6 +52,12 @@ namespace TFTV.TFTVIncidents
 
         // Character the last request was for, so a settings change can re-render it in place.
         private static GeoCharacter _currentCharacter;
+
+        // preserveAspect as the leader Image ships it, captured the first time a portrait is
+        // applied. A rendered head needs it on; the painted event-leader artwork of every other
+        // geoscape event is authored for the slot as-is, so the flag has to go back.
+        private static bool _capturedPreserveAspect;
+        private static bool _originalPreserveAspect;
 
         // Render target is sized to the leader pic slot's on-screen size (clamped), so the
         // portrait matches the display resolution instead of a fixed 1024px.
@@ -295,6 +302,55 @@ namespace TFTV.TFTVIncidents
         }
 
         /// <summary>
+        /// Puts the encounter's leader slot back the way the game ships it.
+        ///
+        /// The slot is shared by every geoscape event, and the adjustments a rendered portrait needs
+        /// (the DisplayScale shrink and preserveAspect) are not adjustments the painted event-leader
+        /// artwork wants - left in place they follow the player into the next, unrelated encounter.
+        /// Called before each encounter is shown, so whatever that encounter then puts in the slot
+        /// starts from the vanilla state.
+        /// </summary>
+        internal static void ResetLeaderSlot(UIModuleSiteEncounters module)
+        {
+            try
+            {
+                if (module == null)
+                {
+                    return;
+                }
+
+                // Nothing in flight should paint over the encounter that is being shown now.
+                _currentRequestId = -1;
+                _currentCharacter = null;
+
+                RestoreDisplayScale(module);
+
+                if (module.EncounterLeaderImage != null)
+                {
+                    if (_capturedPreserveAspect)
+                    {
+                        module.EncounterLeaderImage.preserveAspect = _originalPreserveAspect;
+                    }
+
+                    // Only our own rendered head is cleared; artwork the game put there is left alone.
+                    if (_appliedModule == module)
+                    {
+                        module.EncounterLeaderImage.sprite = null;
+                    }
+                }
+
+                if (_appliedModule == module)
+                {
+                    _appliedModule = null;
+                }
+            }
+            catch (Exception e)
+            {
+                TFTVLogger.Error(e);
+            }
+        }
+
+        /// <summary>
         /// Clears the leader picture we put in place and hides the slot, so nothing stale is shown
         /// while the next portrait renders.
         /// </summary>
@@ -335,6 +391,13 @@ namespace TFTV.TFTVIncidents
 
             module.EncunterLeaderGroup.SetActive(true);
             module.EncunterLeaderInkGroup.SetActive(true);
+
+            if (!_capturedPreserveAspect && module.EncounterLeaderImage != null)
+            {
+                _originalPreserveAspect = module.EncounterLeaderImage.preserveAspect;
+                _capturedPreserveAspect = true;
+            }
+
             module.EncounterLeaderImage.sprite = portrait;
             module.EncounterLeaderImage.preserveAspect = true;
             ApplyDisplayScale(module);
@@ -1474,6 +1537,22 @@ namespace TFTV.TFTVIncidents
 
         private sealed class CoroutineRunner : MonoBehaviour
         {
+        }
+
+        /// <summary>
+        /// Hands every encounter a leader slot in its shipped state.
+        ///
+        /// ShowEncounter is the single entry point the game displays a geoscape event through, and it
+        /// runs before the event's own leader artwork is assigned, so resetting here neither fights
+        /// the game for the slot nor undoes the portrait an incident applies afterwards.
+        /// </summary>
+        [HarmonyPatch(typeof(UIModuleSiteEncounters), "ShowEncounter")]
+        internal static class UIModuleSiteEncounters_ShowEncounter_ResetLeaderSlot_Patch
+        {
+            public static void Prefix(UIModuleSiteEncounters __instance)
+            {
+                ResetLeaderSlot(__instance);
+            }
         }
     }
 }

--- a/TFTV/TFTVIncidents/Resolution.cs
+++ b/TFTV/TFTVIncidents/Resolution.cs
@@ -330,14 +330,26 @@ namespace TFTV.TFTVIncidents
                 return matchedNearbyHaven?.Site?.SiteId ?? -1;
             }
 
+            /// <summary>
+            /// The incident being resolved at this site, if any. The Agenda Tracker asks this of every
+            /// site it knows about once a second, so it is kept free of LINQ and its per-call closure.
+            /// </summary>
             internal static ActiveTimedProblem GetActiveTimedProblem(GeoSite site)
             {
-                if (site == null)
+                if (site == null || ActiveByTimerId.Count == 0)
                 {
                     return null;
                 }
 
-                return ActiveByTimerId.Values.FirstOrDefault(v => v.SiteId == site.SiteId);
+                foreach (ActiveTimedProblem active in ActiveByTimerId.Values)
+                {
+                    if (active != null && active.SiteId == site.SiteId)
+                    {
+                        return active;
+                    }
+                }
+
+                return null;
             }
 
 


### PR DESCRIPTION
Six incident-related fixes. Most turned out to be the same shape of problem: cached state outliving the thing it described.

## Agenda Tracker

**Rows could vanish a second after appearing.** Vanilla's `Dispose()` returns an element to `CurrentEventsPool` while *still* leaving it in `_currentTrackedElements` and queued in `_elementsToRemove`; the two are only reconciled at the top of the next parameterless `UpdateData()`. So `GetFreeElement()` can hand out an element the tracker still intends to delete, and that pending delete then lands on the row just built from it. An element disposed twice is worse — it sits in the pool twice, so a later row is handed a GameObject a live row is already drawing with.

- New `GetFreeElement` postfix reconciles the recycled element. That method is the one choke point every add path goes through, ours and vanilla's `OnResearchStarted` / `OnItemStartedManufacturing` / `OnVehicleAction` / `OnFacilityBuilding` alike, so an element handed out is always a clean slate.
- `RemoveTrackerElement` is now a no-op on an element already queued for removal, closing the double-dispose case from our side.

**Lost rows never came back.** Vanilla only builds the tracker from `InitialSetup()`, which runs on geoscape selection change, so a row lost between two of those stayed lost until the player happened to click something. The `InitialSetup` postfix body became `EnsureCustomTrackers` — keyed on the tracked object, idempotent — and now also runs once a second from `UpdateData()`, so a gap closes on its own within a tick. Each group (training / excavations / incidents + base actions / attacks) has its own `try`/`catch` so one bad entry can't cost every row after it.

**Stale rows were never disposed.** `__result` was only ever set for an expired custom timer, so finished excavations and cancelled attacks left rows frozen on screen forever. A site row's lifetime is now `HasAnySiteTrackerReason` — the union of every reason a row is created. Deliberately *not* "countdown reached zero": an incident's countdown zeroes a moment before the event system completes it, and disposing on zero would make the row blink out and back once a second.

**Haven defence rows showed a stale time.** `GeoscapeLog.ShowSiteDefenseTimer` sets `site.ExpiringTimerAt` and nothing ever read it back. `TryResolveSiteTimer` now has that fallback.

## Pending base activation drew a full red ring after a mission

Reported with a screenshot. Regression from 0fd1a86f: the `AppliedProgression` memo added there is keyed on site id and range only. A tactical mission tears the geoscape down and destroys the visual GameObjects, so on return the site correctly gets a **new** controller while its pending timer is unchanged — the memo reads "already applied" and skips `SetProgression`. That call is what assigns `_FirstColor` / `_SecondColor` from `ProgressColor` and sets `_progressMinutes`, so the mesh kept the prefab's default material and `Progression` returned a hard `0`: a full red circle that never shrinks. The memo now records the controller too.

The incident-site equivalent (`Resolution.IncidentController.RefreshSiteVisual`) calls `SetProgression` unconditionally and was already correct — no change needed there.

## Incident leader portraits leaked into other events

The `DisplayScale` shrink and `preserveAspect` were only undone from `ClearCache()`, which runs on incident intros, so they followed the player into the next unrelated encounter. Reset now happens from a prefix on `UIModuleSiteEncounters.ShowEncounter` — the single entry point for displaying any event, and it runs *before* the event's own leader art is assigned, so it neither fights the game for the slot nor undoes a portrait an incident applies afterwards.

## Nahia Grivane showed her localisation key

`Data.Name` becomes `LocalizedTextBind(Name, doNotLocalize: !LocalizeName)`, so a key paired with `LocalizeName = false` renders raw — players saw `KEY_TFTV_NAHIA_GRIVANE`. Set to `true` rather than pre-resolving the string: `_doNotLocalize` isn't serialised, so a pre-resolved literal would misbehave after save/load anyway.

## Psycho-Sociology geoscape benefit B

Gave and advertised 2 Stamina per rank instead of 3. The value now lives in one constant shared by the description and `ApplyPostMissionRecovery`, so they can't drift apart again.

## Affinity icon colour

Now Phoenix Project's red-orange (`#ED6E2B`, the tint the mod already uses for Phoenix resource text). The source PNGs are a white glyph on a black plate, so the colour is multiplied into the sprite at load rather than set per `Image.color` — that way the game's own ability panels and tooltips pick it up too, not just the incident screens.

## Notes for review

- I could not reproduce the vanishing agenda row in a log (no incident session in the available `TFTV.log`), so the `GetFreeElement` fix is a defect found by reading the decompiled `UIModuleFactionAgendaTracker`, and the per-tick sweep is the safety net for causes I may not have found.
- The per-tick sweep runs once a second over `Map.AllSites`. `GetActiveTimedProblem` was rewritten allocation-free (no LINQ closure) since it is now asked of every site on that cadence.
- `TryUpdateCustomSiteElement` and `UpdateSiteTimers` were folded into the new `HasAnySiteTrackerReason` / `TryResolveSiteTimer` helpers and removed.
- Builds clean; deployed and available for in-game testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
