### PR TITLE
Keep Cyclops damage resistance across a mid-mission save load

### DIFF
--- a/TFTV/TFTVAncients.cs
+++ b/TFTV/TFTVAncients.cs
@@ -1612,23 +1612,23 @@ namespace TFTV
                                   baseMultiplier = 0.25f; //adjusted on 22/12 from 0.0f
                               }*/
 
-                            IEnumerable<TacticalActor> allHoplites = from x in controller.Map.GetActors<TacticalActor>()
-                                                                     where x.HasGameTag(hopliteTag)
-                                                                     where x.IsAlive
-                                                                     select x;
+                            // Every hoplite the map knows about, the dead included: the resistance is
+                            // the proportion of the squad that is still standing, so filtering the
+                            // dead out here would leave nothing to count them from. Dead actors stay
+                            // on the map after a mid-mission load - the game's own graveyard seeds
+                            // itself from exactly this query - so the roster survives a save/load.
+                            List<TacticalActor> allHoplites = controller.Map.GetActors<TacticalActor>()
+                                .Where(x => x.HasGameTag(hopliteTag))
+                                .ToList();
 
+                            int deadHoplites = allHoplites.Count(h => h.IsDead);
 
-
-                            int deadHoplites = allHoplites.Where(h => h.IsDead).Count();
-                            float proportion = ((float)deadHoplites / (float)(allHoplites.Count()));
-
-                            if (allHoplites.Count() == 0)
-                            {
-                                proportion = 1;
-                            }
+                            float proportion = allHoplites.Count > 0
+                                ? (float)deadHoplites / allHoplites.Count
+                                : 1f;
 
                             CyclopsDefenseStatus.Multiplier = baseMultiplier + proportion * 0.5f; //+ HoplitesKilled * 0.1f;
-                            TFTVLogger.Always($"There are {allHoplites.Count()} hoplites in total, {deadHoplites} are dead. Proportion is {proportion} and base multiplier is {baseMultiplier}. Cyclops Defense level is {CyclopsDefenseStatus.Multiplier}");
+                            TFTVLogger.Always($"There are {allHoplites.Count} hoplites in total, {deadHoplites} are dead. Proportion is {proportion} and base multiplier is {baseMultiplier}. Cyclops Defense level is {CyclopsDefenseStatus.Multiplier}");
                         }
                     }
                     catch (Exception e)


### PR DESCRIPTION
Fixes a reported bug: the Cyclops' damage resistance snaps back to 50% when you reload a mid-mission save, even with a single hoplite left alive. Reported at 7% before saving, 50% after.

## Cause

`ResetCyclopsDefense` scales the resistance by the proportion of hoplites killed, but built its roster with a `where x.IsAlive` clause and then counted `h.IsDead` **inside that same set**:

```csharp
IEnumerable<TacticalActor> allHoplites = from x in controller.Map.GetActors<TacticalActor>()
                                         where x.HasGameTag(hopliteTag)
                                         where x.IsAlive          // ← only the living
                                         select x;

int deadHoplites = allHoplites.Where(h => h.IsDead).Count();   // ← therefore always 0
```

`proportion` was always `0`, so the multiplier was always `0.5 + 0` — 50% resistance, regardless of how many hoplites had died. The one exception: when *every* hoplite is dead the set goes empty and the zero-guard forces `proportion = 1`, dropping resistance straight to 0%. So it was effectively binary — 50% until the last one falls.

During the fight the displayed value is correct because the kill handler `ReduceCyclopsResistance` uses a different, unfiltered query (`actor.TacticalFaction.TacticalActors`) that does include the dead. `ResetCyclopsDefense` runs from `OnTacticalStart`, which fires on loading a mid-mission save as well as on a fresh start — so the reload recomputed 50% over the correctly-earned value.

The reporter's numbers line up exactly. The widget shows `Ceil((1 - Multiplier) * 100)`, so 7% is multiplier 0.9375 — 7 of 8 hoplites dead (`0.5 + 0.875 × 0.5`). The old code gave a flat `0.5` → 50%.

## Fix

- Drop the `IsAlive` filter so the dead can actually be counted.
- Materialise the query once instead of re-running the map scan four times.
- Fold the empty-roster guard into the ratio — it previously evaluated `0/0` to `NaN` and then overwrote it.

## Verification of the save/load assumption

The fix depends on dead actors still being present in `Map.GetActors<TacticalActor>()` after a load, so I checked rather than assumed. Vanilla's own `TacticalLevelGraveyard.CollectDeadTacticalActors()` seeds itself from that exact query filtered on `IsDead`, and the graveyard is constructed immediately before `ModManager.OnTacticalStart` — so the full roster, dead included, is in place by the time this runs.

The widget also refreshes on the first faction turn after a load (`UpdateAncientsWidget` sits outside the `IsLoadingSavedGame` guard), so the displayed number follows the corrected multiplier without further changes.

## Notes for review

- **Not changed, but worth a look at some point:** the reset queries the whole map (`controller.Map.GetActors`) while the kill handler queries only the dying actor's faction (`actor.TacticalFaction.TacticalActors`). On a normal Ancient mission both see the same hoplites, but `AdjustAncientsOnDeployment` suggests hoplites can sit on the player faction after Automata research, where the two would disagree. That needs a gameplay decision about which roster is authoritative rather than a code fix, so I left it alone.
- Unrelated to the incident work in #75; branched off master after that merged.
- Builds clean; deployed and tested-ready. To verify in game: kill some hoplites, save, reload — resistance should come back at the value you left it at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
