### PR TITLE
Fire the Cyclops failsafe on death, keep exotic counters, publish restored unlocks

### DIFF
--- a/TFTV/TFTVAchievements.cs
+++ b/TFTV/TFTVAchievements.cs
@@ -1009,6 +1009,15 @@ namespace TFTV
                             TFTVLogger.Always(LogPrefix + $"{achievement.Id}: platform reconcile left {before} entries, {after} after restoring from our own copy.");
                         }
                     }
+
+                    // Also from here, for two reasons. The platform's achievement list arrives
+                    // asynchronously and can land after this mod has loaded, in which case the push
+                    // attempted during reconciliation found Achievements still null and returned
+                    // without doing anything - this is the only callback that runs afterwards. And
+                    // the restore just above can itself be what completes a checklist, which leaves
+                    // _OldNormalizedProgress equal to NormalizedProgress and so invisible to the
+                    // tracker's own publish.
+                    PushCompletedAchievementsToPlatform(__instance);
                 }
                 catch (Exception e)
                 {

--- a/TFTV/TFTVAncients.cs
+++ b/TFTV/TFTVAncients.cs
@@ -1710,6 +1710,17 @@ namespace TFTV
                                     HoplitesAbilities.HoplitesAutoRepair.ApplyAutoRepairAbilityStatusOrHealNearbyHoplites(faction, actor);
                                     ReduceCyclopsResistance(faction, actor);
                                 }
+
+                                // Failsafe Protocol is written as a consequence of the Cyclops dying,
+                                // so it has to be checked on the deaths that can make it true - the
+                                // Cyclops itself, and any hoplite death that brings the survivors down
+                                // to three. Checking only at the start of the Ancients' next turn meant
+                                // it read as simply not working: with the Cyclops down and a handful of
+                                // hoplites left the mission is usually over before that turn arrives.
+                                if (actor.HasGameTag(hopliteTag) || actor.HasGameTag(cyclopsTag))
+                                {
+                                    StuckHopliteVanillaFix.CheckHopliteKillList(faction);
+                                }
                             }
                         }
 
@@ -2092,10 +2103,20 @@ namespace TFTV
 
         internal class StuckHopliteVanillaFix
         {
+            /// <summary>
+            /// Guards against re-entry: this is now called from the ActorDied postfix, and the
+            /// hoplites it destroys each report their own death straight back into it.
+            /// </summary>
+            private static bool _resolvingFailsafe;
+
             public static void CheckHopliteKillList(TacticalFaction tacticalFaction)
             {
                 try
                 {
+                    if (_resolvingFailsafe || tacticalFaction == null)
+                    {
+                        return;
+                    }
 
                     if (!tacticalFaction.TacticalFactionDef.ShortNames.Contains("anc"))
                     {
@@ -2120,11 +2141,18 @@ namespace TFTV
 
                     TFTVLogger.Always($"Cyclops is dead and no more than 3 hoplites alive. Destroying them.");
 
-                    foreach (TacticalActor tacticalActor in aliveHoplites)
+                    _resolvingFailsafe = true;
+                    try
                     {
-                        tacticalActor.ApplyDamage(new DamageResult { HealthDamage = 500, Source = tacticalActor });
+                        foreach (TacticalActor tacticalActor in aliveHoplites)
+                        {
+                            tacticalActor.ApplyDamage(new DamageResult { HealthDamage = 500, Source = tacticalActor });
+                        }
                     }
-
+                    finally
+                    {
+                        _resolvingFailsafe = false;
+                    }
                 }
                 catch (Exception e)
                 {

--- a/TFTV/TFTVUI/Geoscape/TopInforBar.cs
+++ b/TFTV/TFTVUI/Geoscape/TopInforBar.cs
@@ -40,6 +40,61 @@ namespace TFTV.TFTVUI.Geoscape
         internal static Color syn = new Color(0.160784319f, 0.8862745f, 0.145098045f, 1.0f);
 
 
+        /// <summary>
+        /// Keeps the three exotic material counters on screen once Exotic Materials is researched,
+        /// even while the player holds none.
+        ///
+        /// Vanilla shows each of them only while the wallet holds some or something is producing it:
+        ///
+        ///   bool value2 = wallet[ResourceType.LivingCrystals].RoundedValue > 0 || totalOutput...Value > 0f;
+        ///   SetActive(LivingCrystalsController.transform.parent.gameObject, value2);
+        ///
+        /// so a counter that has been earned appears and disappears as the balance passes zero,
+        /// and a player who has just finished the research sees nothing at all. Once the research is
+        /// done these are permanent parts of the economy and should read zero rather than vanish.
+        ///
+        /// Goes through the module's own SetActive rather than setting the GameObject directly,
+        /// because that is what re-enables the layout group and lets the bar close the gap.
+        /// </summary>
+        [HarmonyPatch(typeof(UIModuleInfoBar), "UpdateResourceInfo")]
+        public static class UIModuleInfoBar_UpdateResourceInfo_ExoticMaterials_Patch
+        {
+            private const string ExoticMaterialsResearchId = "ExoticMaterialsResearch";
+
+            private static readonly System.Reflection.MethodInfo SetActiveMethod =
+                AccessTools.Method(typeof(UIModuleInfoBar), "SetActive", new Type[] { typeof(GameObject), typeof(bool) });
+
+            public static void Postfix(UIModuleInfoBar __instance, GeoFaction faction)
+            {
+                try
+                {
+                    if (__instance == null || SetActiveMethod == null) return;
+                    if (!(faction is GeoPhoenixFaction phoenix)) return;
+                    if (phoenix.Research == null || !phoenix.Research.HasCompleted(ExoticMaterialsResearchId)) return;
+
+                    Show(__instance, __instance.LivingCrystalsController);
+                    Show(__instance, __instance.OrichalcumController);
+                    Show(__instance, __instance.ProteanMutaneController);
+                }
+                catch (Exception e)
+                {
+                    TFTVLogger.Error(e);
+                }
+            }
+
+            private static void Show(UIModuleInfoBar infoBar, UIAnimatedResourceController controller)
+            {
+                GameObject row = controller != null && controller.transform.parent != null
+                    ? controller.transform.parent.gameObject
+                    : null;
+
+                if (row != null)
+                {
+                    SetActiveMethod.Invoke(infoBar, new object[] { row, true });
+                }
+            }
+        }
+
         [HarmonyPatch(typeof(UIAnimatedResourceController), "DisplayValue")] //VERIFIED
         public static class UIAnimatedResourceController_DisplayValue_patch
         {


### PR DESCRIPTION
Three unrelated fixes, batched at Voland's request.

## 1. Failsafe Protocol never fired (reported by geonik)

The ability reads *"If the Cyclops is destroyed and there are no more than 3 active hoplites remaining, they self-destruct"* — but `CheckHopliteKillList` only ran from `AncientsNewTurnCheck`, i.e. at the **start of the Ancients' next turn**. With the Cyclops down and two hoplites left, the mission is usually over before that turn ever arrives, so from the player's side it simply never triggered.

It's now also called from the `ActorDied` postfix, on the two deaths that can make the condition true:
- the Cyclops itself, and
- a hoplite death that brings the survivors down to three when the Cyclops is already dead.

The conditions inside `CheckHopliteKillList` are untouched — the rule is unchanged, only *when* it gets evaluated.

One hazard came with the move: the hoplites it destroys report their own deaths straight back into the same postfix, so the damage loop is now guarded against re-entry. `ActorDied` is a postfix, so the triggering death is fully processed before any of this runs.

## 2. Exotic material counters vanish at zero

Vanilla gates each row on the balance:

```csharp
bool value2 = wallet[ResourceType.LivingCrystals].RoundedValue > 0 || totalOutput...Value > 0f;
SetActive(LivingCrystalsController.transform.parent.gameObject, value2);
```

so Living Crystals, Orichalcum and Protean Mutane flicker in and out as balances cross zero, and a player who has just finished the research sees nothing at all. Once `ExoticMaterialsResearch` is complete these are permanent parts of the economy and should read zero rather than disappear.

A postfix on `UIModuleInfoBar.UpdateResourceInfo` forces all three visible in that case. It goes through the module's own private `SetActive` rather than setting the GameObject directly, because that is what re-enables the layout group and lets the bar close the gap.

## 3. A restored achievement could be complete and never published

Follow-up to #77, from review feedback. `PushCompletedAchievementsToPlatform` opens with:

```csharp
if (platformAchievements?.Achievements == null) return;
```

That list arrives asynchronously through Steam's `OnUserStatsReceived`, so on a slow reply it lands **after** `OnModEnabled` — the push finds null, returns, and nothing ever calls it again. The `LoadAchievemntsProgress` postfix is the only later callback.

It has a second, independent reason to run it: the shadow restore in that postfix can *itself* be what completes a checklist, and since the progress was read rather than earned, `_OldNormalizedProgress == NormalizedProgress` and the tracker's own publish never sees it. So even with the platform list present, a checklist completed by the restore would sit there unpublished.

Worth noting this only worked on the test machine because Steam happened to answer before mods loaded (47 achievements received by then) — a race we were winning, not a guarantee.

## Notes for review

- Failsafe and exotic counters are gameplay/UI and want in-game confirmation; the achievement change is a race fix and won't be visible unless Steam replies slowly.
- Builds clean; deployed to the dev mod folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
