### PR TITLE
Let Junker ammunition be reloaded, bought and restocked

### DIFF
--- a/TFTV/TFTV.csproj
+++ b/TFTV/TFTV.csproj
@@ -412,6 +412,7 @@
     <Compile Include="Vehicles\Abilities\HealPassengersStatusDef.cs" />
     <Compile Include="Vehicles\Abilities\InvertedDamageMultiplierStatus.cs" />
     <Compile Include="Vehicles\Abilities\InvertedDamageMultiplierStatusDef.cs" />
+    <Compile Include="Vehicles\Ammo\AmmoDiagnostics.cs" />
     <Compile Include="Vehicles\Ammo\MissionEndReplenish.cs" />
     <Compile Include="Vehicles\Ammo\SubaddonWeapons.cs" />
     <Compile Include="Vehicles\Ammo\SubaddonWeaponsLoadAmmoPatch.cs" />

--- a/TFTV/TFTVMarketplace/TFTVKaosGuns.cs
+++ b/TFTV/TFTVMarketplace/TFTVKaosGuns.cs
@@ -165,7 +165,10 @@ namespace TFTV
                     newAmmo.Tags.Remove(phoenixFactionTag);
                     newAmmo.Tags.Add(neutralFactionTag);
                     newAmmo.Tags.Remove(DefCache.GetDef<ClassTagDef>("Assault_ClassTagDef"));
-                    newAmmo.Tags.Add(classTagDef);
+                    if (classTagDef != null)
+                    {
+                        newAmmo.Tags.Add(classTagDef);
+                    }
                     //  newAmmo.CombineWhenStacking = false;
                     newAmmo.ManufactureTech = 0;
                     newAmmo.ManufactureMaterials = minPrice;
@@ -207,7 +210,17 @@ namespace TFTV
                     AmmoWeaponDatabase.AmmoToWeaponDictionary.Add(newAmmo, new List<TacticalItemDef>() { weaponDef });
                     GeoMarketplaceItemOptionDef weaponMarketPlaceOption = (GeoMarketplaceItemOptionDef)geoMarketplaceItemOptionDefs.Find(o => o is GeoMarketplaceItemOptionDef marketOption && marketOption.ItemDef == weaponDef);
 
-                    _kGWeaponsAndAmmo.Add(weaponMarketPlaceOption, newMarketplaceItem);
+                    // Find returns null when no marketplace option exists for this weapon, and a null
+                    // key throws on Add - so the pairing is only recorded when there is something to
+                    // pair. Offer generation copes with the weapon being absent from the map.
+                    if (weaponMarketPlaceOption != null)
+                    {
+                        _kGWeaponsAndAmmo[weaponMarketPlaceOption] = newMarketplaceItem;
+                    }
+                    else
+                    {
+                        TFTVLogger.Always($"[KaosGuns] No marketplace option found for {weaponDef.name}; its ammunition will not be bundled with it.");
+                    }
 
                     GeoFactionDef neutralFaction = DefCache.GetDef<GeoFactionDef>("Neutral_GeoFactionDef");
 

--- a/TFTV/TFTVMarketplace/TFTVMarketPlaceGenerateOffers.cs
+++ b/TFTV/TFTVMarketplace/TFTVMarketPlaceGenerateOffers.cs
@@ -407,6 +407,11 @@ namespace TFTV
                     GenerateMercenaryChoices(currentlyPossibleOptions, Math.Min(numberOfOffers / 4, 6), geoMarketPlace, voPriceMultiplier);
                     GenerateResearchChoices(currentlyPossibleOptions, Math.Min(numberOfOffers / 4, 8), geoMarketPlace, voPriceMultiplier);
 
+                    if (TFTVAircraftReworkMain.AircraftReworkOn)
+                    {
+                        StockAmmoForSeenWeaponModules(controller, geoMarketPlace, voPriceMultiplier);
+                    }
+
                     if (TFTVAircraftReworkMain.AircraftReworkOn) //&& controller.EventSystem.GetVariable(_marketPlaceStockRotated) > 3)
                     {
                         TFTVAircraftReworkMain.MarketPlace.GenerateMarketPlaceModules(geoMarketPlace, voPriceMultiplier);
@@ -484,19 +489,24 @@ namespace TFTV
                         int price = (int)(UnityEngine.Random.Range(weaponOffer.MinPrice, weaponOffer.MaxPrice) * priceModifier);
 
                         GeoEventChoice item = GenerateItemChoice(weaponOffer.ItemDef, price);
-                        GeoMarketplaceItemOptionDef ammoOffer = TFTVKaosGuns._kGWeaponsAndAmmo[weaponOffer];
+                        geoMarketplace.MarketplaceChoices.Add(item);
+
+                        // TryGetValue, not the indexer: a Kaos weapon whose marketplace option went
+                        // missing would otherwise throw KeyNotFoundException out of here and take the
+                        // entire restock with it, leaving the player an empty marketplace.
+                        GeoMarketplaceItemOptionDef ammoOffer;
+                        if (!TFTVKaosGuns._kGWeaponsAndAmmo.TryGetValue(weaponOffer, out ammoOffer) || ammoOffer?.ItemDef == null)
+                        {
+                            TFTVLogger.Always($"[Marketplace] {weaponOffer.name} has no ammunition option; offering the weapon alone.");
+                            continue;
+                        }
 
                         int ammoPrice = (int)(UnityEngine.Random.Range(ammoOffer.MinPrice, ammoOffer.MaxPrice) * priceModifier);
 
-                        List<GeoEventChoice> ammo = new List<GeoEventChoice>()
-                    {
-                        GenerateItemChoice(ammoOffer.ItemDef, ammoPrice),
-                        GenerateItemChoice(ammoOffer.ItemDef, ammoPrice),
-                        GenerateItemChoice(ammoOffer.ItemDef, ammoPrice),
-                    };
-
-                        geoMarketplace.MarketplaceChoices.Add(item);
-                        geoMarketplace.MarketplaceChoices.AddRange(ammo);
+                        for (int ammoCount = 0; ammoCount < 3; ammoCount++)
+                        {
+                            geoMarketplace.MarketplaceChoices.Add(GenerateItemChoice(ammoOffer.ItemDef, ammoPrice));
+                        }
                         //  TFTVLogger.Always($"should have added {weaponOffer.name} and 3 ammo for it");
                     }
 
@@ -553,6 +563,8 @@ namespace TFTV
 
                         if (TFTVAircraftReworkMain.AircraftReworkOn)
                         {
+                            RememberWeaponModuleOffered(vehicleItemToOffer);
+
                             List<GeoMarketplaceItemOptionDef> ammoOffers = GetMarketplaceAmmoOffersForVehicleItem(vehicleItemToOffer);
 
                             foreach (GeoMarketplaceItemOptionDef ammoOffer in ammoOffers)
@@ -569,6 +581,92 @@ namespace TFTV
                 {
                     TFTVLogger.Error(e);
                     throw;
+                }
+            }
+
+            /// <summary>
+            /// The Junker's weapon modules, each of which carries two ammunition types.
+            /// </summary>
+            private static readonly string[] JunkerWeaponModuleDefNames =
+            {
+                "KS_Buggy_The_Vishnu_Gun_GroundVehicleModuleDef",
+                "KS_Buggy_Fullstop_GroundVehicleModuleDef",
+                "KS_Buggy_The_Screamer_GroundVehicleModuleDef",
+            };
+
+            private static string SeenVariableFor(string moduleDefName)
+            {
+                return "TFTV_MarketOffered_" + moduleDefName;
+            }
+
+            /// <summary>
+            /// Notes that a weapon module has been put on sale, so its ammunition can be stocked from
+            /// now on.
+            ///
+            /// The Junker itself is always offer zero and bundles minigun and Vishnu ammunition with
+            /// it, but the Fullstop and Screamer modules are drawn at random from a pool of some
+            /// fifteen vehicle options - roughly a one-in-three chance each restock. Their ammunition
+            /// rode along with that draw, so a player running either of those had a far worse resupply
+            /// cadence than one running the Vishnu, for no reason they could see.
+            /// </summary>
+            private static void RememberWeaponModuleOffered(GeoMarketplaceItemOptionDef offer)
+            {
+                try
+                {
+                    GroundVehicleModuleDef moduleDef = offer?.ItemDef as GroundVehicleModuleDef;
+                    if (moduleDef == null || !JunkerWeaponModuleDefNames.Contains(moduleDef.name)) return;
+
+                    GeoLevelController controller = GameUtl.CurrentLevel()?.GetComponent<GeoLevelController>();
+                    if (controller?.EventSystem == null) return;
+
+                    string variable = SeenVariableFor(moduleDef.name);
+                    if (controller.EventSystem.GetVariable(variable) > 0) return;
+
+                    controller.EventSystem.SetVariable(variable, 1);
+                    TFTVLogger.Always($"[Marketplace] {moduleDef.name} offered for the first time; its ammunition will be stocked from now on.");
+                }
+                catch (Exception e)
+                {
+                    TFTVLogger.Error(e);
+                }
+            }
+
+            /// <summary>
+            /// Stocks ammunition for every Junker weapon module the marketplace has offered at least
+            /// once, whether or not that module is on sale this time round.
+            ///
+            /// Gated on having been offered rather than being unconditional, so ammunition never
+            /// appears for a weapon the player has had no chance to see. AddMarketplaceAmmoChoices caps
+            /// the count per ammunition type, so this tops up rather than piling on.
+            /// </summary>
+            private static void StockAmmoForSeenWeaponModules(GeoLevelController controller, GeoMarketplace geoMarketplace, float priceModifier)
+            {
+                try
+                {
+                    if (controller?.EventSystem == null || geoMarketplace == null) return;
+
+                    foreach (string moduleDefName in JunkerWeaponModuleDefNames)
+                    {
+                        if (controller.EventSystem.GetVariable(SeenVariableFor(moduleDefName)) <= 0) continue;
+
+                        GroundVehicleModuleDef moduleDef = DefCache.GetDef<GroundVehicleModuleDef>(moduleDefName);
+                        if (moduleDef == null) continue;
+
+                        foreach (TacticalItemDef ammoDef in VehicleModuleAmmoHarmonyPatches.GetModuleAmmoDefs(moduleDef))
+                        {
+                            GeoMarketplaceItemOptionDef ammoOffer;
+                            if (VehiclesAmmoMain.MarketplaceAmmoDefsAndOptions.TryGetValue(ammoDef, out ammoOffer) && ammoOffer != null)
+                            {
+                                AddMarketplaceAmmoChoices(geoMarketplace, ammoOffer, priceModifier);
+                                AmmoDiagnostics.Trace("Restock",
+                                    $"Stocked {ammoDef.name} for {moduleDefName}, which has been offered before.");
+                            }
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    TFTVLogger.Error(e);
                 }
             }
 

--- a/TFTV/Vehicles/Ammo/AmmoDiagnostics.cs
+++ b/TFTV/Vehicles/Ammo/AmmoDiagnostics.cs
@@ -1,0 +1,258 @@
+﻿using Base.Core;
+using Base.Defs;
+using Base.Utils.GameConsole;
+using PhoenixPoint.Common.Core;
+using PhoenixPoint.Common.Entities;
+using PhoenixPoint.Common.Entities.Equipments;
+using PhoenixPoint.Common.Entities.Items;
+using PhoenixPoint.Tactical.Entities.Equipments;
+using PhoenixPoint.Tactical.Entities.Weapons;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TFTV.Vehicles.Ammo
+{
+    /// <summary>
+    /// Reports how ground vehicle weapon modules are actually wired to ammunition.
+    ///
+    /// The question this exists to answer: the game ships both KS_Buggy_Fullstop_WeaponDef and
+    /// KS_Buggy_Fullstop_GroundVehicleWeaponDef (and the same pair for the Screamer, but not for the
+    /// Vishnu), and this mod only gives ammo to the plain WeaponDef of each pair. GetSubWeapons()
+    /// returns anything deriving from WeaponDef, so if the modules reference the GroundVehicleWeaponDef
+    /// variants instead, that ammo is inert - which looks identical to a replenishment bug but is not
+    /// one. Def contents cannot be read outside the game, so this asks the loaded defs directly.
+    /// </summary>
+    internal static class AmmoDiagnostics
+    {
+        private const string LogPrefix = "[TFTV][VehicleAmmo] ";
+        private const string TracePrefix = "[TFTV][AmmoTrace] ";
+
+        /// <summary>
+        /// Off by default, and deliberately so.
+        ///
+        /// Every ammunition interaction worth following sits inside something that runs on a UI
+        /// refresh or a per-frame update, so tracing them unconditionally buries the log - which is
+        /// exactly what this file's predecessor did. Turn it on for the run where the question
+        /// matters, read the answer, turn it off.
+        /// </summary>
+        internal static bool TraceEnabled { get; private set; }
+
+        [ConsoleCommand(
+            Command = "tftv_ammo_trace",
+            Description = "Follows every ammunition interaction in the log. Usage: tftv_ammo_trace on|off")]
+        public static void SetAmmoTrace(IConsole console, string state)
+        {
+            bool on = string.Equals(state, "on", StringComparison.OrdinalIgnoreCase)
+                   || string.Equals(state, "true", StringComparison.OrdinalIgnoreCase)
+                   || state == "1";
+
+            bool off = string.Equals(state, "off", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(state, "false", StringComparison.OrdinalIgnoreCase)
+                    || state == "0";
+
+            if (!on && !off)
+            {
+                console.WriteLine("Usage: tftv_ammo_trace on|off");
+                return;
+            }
+
+            TraceEnabled = on;
+            string message = on
+                ? "Ammunition tracing on - every load, reload, replenish and purchase goes to TFTV.log."
+                : "Ammunition tracing off.";
+
+            console.WriteLine(message);
+            TFTVLogger.Always(TracePrefix + message);
+        }
+
+        /// <summary>
+        /// One line of the ammunition trace. <paramref name="stage"/> names where in the chain this
+        /// happened - post-mission, replenish screen, equip screen - so a log can be read as a
+        /// sequence rather than a pile.
+        /// </summary>
+        internal static void Trace(string stage, string message)
+        {
+            if (!TraceEnabled) return;
+
+            try
+            {
+                TFTVLogger.Always($"{TracePrefix}[{stage}] {message}");
+            }
+            catch
+            {
+                // Tracing must never be the thing that breaks a reload.
+            }
+        }
+
+        /// <summary>
+        /// A module or weapon's ammunition state, for one trace line rather than several.
+        /// </summary>
+        internal static string DescribeAmmo(ICommonItem item)
+        {
+            try
+            {
+                if (item?.ItemDef == null) return "<no item>";
+
+                GroundVehicleModuleDef moduleDef = item.ItemDef as GroundVehicleModuleDef;
+                if (moduleDef == null)
+                {
+                    int charges = item.CommonItemData?.CurrentCharges ?? -1;
+                    return $"{item.ItemDef.name} {charges}/{item.ItemDef.ChargesMax}";
+                }
+
+                List<string> parts = new List<string>();
+                foreach (TacticalItemDef ammoDef in VehicleModuleAmmoHarmonyPatches.GetModuleAmmoDefs(moduleDef))
+                {
+                    int have = VehicleModuleAmmoHarmonyPatches.GetAmmoChargesForDef(item.CommonItemData, ammoDef);
+                    int max = VehicleModuleAmmoHarmonyPatches.GetAmmoCapacityForDef(moduleDef, ammoDef);
+                    parts.Add($"{ammoDef.name} {have}/{max}");
+                }
+
+                return parts.Count > 0
+                    ? $"{moduleDef.name} [{string.Join(", ", parts)}]"
+                    : $"{moduleDef.name} [no ammo types]";
+            }
+            catch
+            {
+                return "<unreadable>";
+            }
+        }
+
+        [ConsoleCommand(
+            Command = "tftv_vehicle_ammo_report",
+            Description = "Lists every ground vehicle weapon module, its sub-weapons and the ammo each is wired to.")]
+        public static void ReportVehicleAmmoWiring(IConsole console)
+        {
+            try
+            {
+                DefRepository repo = GameUtl.GameComponent<DefRepository>();
+                if (repo == null)
+                {
+                    console.WriteLine("No DefRepository available.");
+                    return;
+                }
+
+                List<GroundVehicleModuleDef> modules = repo.GetAllDefs<GroundVehicleModuleDef>()
+                    .Where(m => m != null)
+                    .OrderBy(m => m.name, StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+
+                Report(console, $"=== {modules.Count} GroundVehicleModuleDef(s) ===");
+
+                int withWeapons = 0;
+                List<string> unarmedSubWeapons = new List<string>();
+
+                foreach (GroundVehicleModuleDef module in modules)
+                {
+                    List<WeaponDef> subWeapons = SafeSubWeapons(module);
+                    if (subWeapons.Count == 0)
+                    {
+                        // Engines, hulls and plating - no ammo to report.
+                        continue;
+                    }
+
+                    withWeapons++;
+                    Report(console, $"{module.name}");
+
+                    foreach (WeaponDef weapon in subWeapons)
+                    {
+                        // The concrete type is the whole point: WeaponDef vs GroundVehicleWeaponDef
+                        // distinguishes the def this mod patched from the twin it did not.
+                        string weaponType = weapon.GetType().Name;
+
+                        List<TacticalItemDef> ammo = weapon.CompatibleAmmunition != null
+                            ? weapon.CompatibleAmmunition.Where(a => a != null).ToList()
+                            : new List<TacticalItemDef>();
+
+                        string ammoText = ammo.Count > 0
+                            ? string.Join(", ", ammo.Select(a => $"{a.name} (clip {a.ChargesMax})"))
+                            : "<<< NO AMMO WIRED >>>";
+
+                        Report(console, $"    {weapon.name} [{weaponType}] mag {weapon.ChargesMax}" +
+                            $", freeReloadOnMissionEnd {weapon.FreeReloadOnMissionEnd} -> {ammoText}");
+
+                        if (ammo.Count == 0)
+                        {
+                            unarmedSubWeapons.Add($"{module.name} / {weapon.name} [{weaponType}]");
+                        }
+                    }
+                }
+
+                Report(console, $"=== {withWeapons} module(s) carry sub-weapons ===");
+
+                // The headline answer. Anything listed here is a sub-weapon a player can fire but
+                // never reload, because nothing gave it a magazine.
+                if (unarmedSubWeapons.Count == 0)
+                {
+                    Report(console, "Every sub-weapon has ammunition wired. The duplicate-weapon-def theory is dead.");
+                }
+                else
+                {
+                    Report(console, $"SUB-WEAPONS WITH NO AMMUNITION ({unarmedSubWeapons.Count}):");
+                    foreach (string entry in unarmedSubWeapons)
+                    {
+                        Report(console, "    " + entry);
+                    }
+                }
+
+                ReportDuplicateWeaponDefs(console, repo);
+            }
+            catch (Exception e)
+            {
+                TFTVLogger.Error(e);
+                console.WriteLine("Failed - see TFTV.log.");
+            }
+        }
+
+        /// <summary>
+        /// Names that exist as both a WeaponDef and a GroundVehicleWeaponDef, with which of the pair
+        /// carries ammunition. If a module above referenced the unarmed twin, this is where it shows.
+        /// </summary>
+        private static void ReportDuplicateWeaponDefs(IConsole console, DefRepository repo)
+        {
+            try
+            {
+                Report(console, "=== Kaos buggy weapon defs, armed or not ===");
+
+                List<WeaponDef> buggyWeapons = repo.GetAllDefs<WeaponDef>()
+                    .Where(w => w != null && w.name.StartsWith("KS_Buggy", StringComparison.OrdinalIgnoreCase))
+                    .OrderBy(w => w.name, StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+
+                foreach (WeaponDef weapon in buggyWeapons)
+                {
+                    int ammoCount = weapon.CompatibleAmmunition != null ? weapon.CompatibleAmmunition.Length : 0;
+                    string ammoNames = ammoCount > 0
+                        ? string.Join(", ", weapon.CompatibleAmmunition.Where(a => a != null).Select(a => a.name))
+                        : "none";
+
+                    Report(console, $"    {weapon.name} [{weapon.GetType().Name}] -> {ammoNames}");
+                }
+            }
+            catch (Exception e)
+            {
+                TFTVLogger.Error(e);
+            }
+        }
+
+        private static List<WeaponDef> SafeSubWeapons(GroundVehicleModuleDef module)
+        {
+            try
+            {
+                return module.GetSubWeapons() ?? new List<WeaponDef>();
+            }
+            catch (Exception e)
+            {
+                TFTVLogger.Error(e);
+                return new List<WeaponDef>();
+            }
+        }
+
+        private static void Report(IConsole console, string line)
+        {
+            console.WriteLine(line);
+            TFTVLogger.Always(LogPrefix + line);
+        }
+    }
+}

--- a/TFTV/Vehicles/Ammo/MissionEndReplenish.cs
+++ b/TFTV/Vehicles/Ammo/MissionEndReplenish.cs
@@ -1,4 +1,5 @@
-﻿using Base.Core;
+﻿using Assets.Code.PhoenixPoint.Geoscape.Entities.Sites.TheMarketplace;
+using Base.Core;
 using HarmonyLib;
 using PhoenixPoint.Common.Core;
 using PhoenixPoint.Common.Entities.Equipments;
@@ -6,6 +7,7 @@ using PhoenixPoint.Common.Entities.GameTags;
 using PhoenixPoint.Common.Entities.Items;
 using PhoenixPoint.Common.View.ViewControllers;
 using PhoenixPoint.Geoscape.Entities;
+using PhoenixPoint.Geoscape.Events;
 using PhoenixPoint.Geoscape.Levels;
 using PhoenixPoint.Geoscape.Levels.Factions;
 using PhoenixPoint.Geoscape.View;
@@ -58,8 +60,6 @@ namespace TFTV.Vehicles.Ammo
                     if (!TFTVAircraftReworkMain.AircraftReworkOn)
                         return;
 
-                    TFTVLogger.Always($"[ReplenishFix] GetMissingItems Postfix running; entry count={__result?.Count ?? -1}");
-
                     if (__result == null)
                         return;
 
@@ -69,22 +69,16 @@ namespace TFTV.Vehicles.Ammo
                     if (phoenixFaction == null)
                         TFTVLogger.Always($"[ReplenishFix] PhoenixFaction unavailable; falling back to GroundVehicleModuleDef-only filter.");
 
+                    // Runs on every refresh of the replenish screen, so it reports what it changed and
+                    // nothing else - a per-character, per-item trace here buried the log.
+                    int strippedTotal = 0;
+                    int emptiedEntries = 0;
+
                     for (int i = __result.Count - 1; i >= 0; i--)
                     {
                         PostmissionReplenishManager.ReplenishableItems replenishable = __result[i];
                         if (replenishable == null)
                             continue;
-
-                        string charName = replenishable.Character?.DisplayName ?? "null";
-                        TFTVLogger.Always($"[ReplenishFix] Character '{charName}': " +
-                            $"MissingEquip={replenishable.MissingEquipmentItems?.Count ?? 0} " +
-                            $"MissingInv={replenishable.MissingInventoryItems?.Count ?? 0} " +
-                            $"MissingArmour={replenishable.MissingArmourItems?.Count ?? 0} " +
-                            $"Reloadable={replenishable.ReloadableItems?.Count ?? 0}");
-
-                        if (replenishable.MissingEquipmentItems != null)
-                            foreach (ItemDef def in replenishable.MissingEquipmentItems)
-                                TFTVLogger.Always($"[ReplenishFix]   MissingEquip: {def?.name} ({def?.GetType()?.Name})");
 
                         int removed;
                         if (phoenixFaction != null)
@@ -101,16 +95,21 @@ namespace TFTV.Vehicles.Ammo
                             removed += replenishable.MissingArmourItems?.RemoveAll(def => def is GroundVehicleModuleDef) ?? 0;
                         }
 
-                        if (removed > 0)
-                            TFTVLogger.Always($"[ReplenishFix] Stripped {removed} non-manufacturable item(s) for '{charName}'.");
+                        strippedTotal += removed;
 
                         // If nothing remains for this character, remove the entry entirely so no
                         // ghost soldier header appears in the replenish UI.
                         if (replenishable.IsEmpty())
                         {
-                            TFTVLogger.Always($"[ReplenishFix] Entry for '{charName}' is empty after filtering; removing.");
+                            emptiedEntries++;
                             __result.RemoveAt(i);
                         }
+                    }
+
+                    if (strippedTotal > 0 || emptiedEntries > 0)
+                    {
+                        TFTVLogger.Always($"[ReplenishFix] Stripped {strippedTotal} non-manufacturable item(s); " +
+                            $"removed {emptiedEntries} now-empty entr(y/ies).");
                     }
                 }
                 catch (Exception e)
@@ -141,8 +140,10 @@ namespace TFTV.Vehicles.Ammo
                     GeoPhoenixFaction faction = FactionRef(__instance);
                     if (faction != null && faction.Manufacture.GetManufacturableItemByDef(def) == null)
                     {
-                        TFTVLogger.Always($"[ReplenishFix] AddMissingItem safety-net: blocking '{def?.name}' ({def?.GetType()?.Name})" +
-                            $" for '{character?.DisplayName}' — not in faction.Manufacture.");
+                        // A genuine safety net: reaching here means the postfix filter above missed
+                        // something, which is worth knowing about, and it should be rare.
+                        TFTVLogger.Always($"[ReplenishFix] AddMissingItem safety-net blocked '{def?.name}' ({def?.GetType()?.Name})" +
+                            $" for '{character?.DisplayName}' - not in faction.Manufacture.");
                         __result = false;
                         return false;
                     }
@@ -179,6 +180,8 @@ namespace TFTV.Vehicles.Ammo
                     return false;
                 }
 
+                AmmoDiagnostics.Trace("PostMission", $"Reloading from {storageName}: {AmmoDiagnostics.DescribeAmmo(item)}");
+
                 bool allFull = true;
                 foreach (TacticalItemDef ammoDef in GetModuleAmmoDefs(moduleDef))
                 {
@@ -192,6 +195,8 @@ namespace TFTV.Vehicles.Ammo
 
                     if (!storage.Items.ContainsKey(ammoDef))
                     {
+                        AmmoDiagnostics.Trace("PostMission",
+                            $"{ammoDef.name} short at {currentCharges}/{maxCharges} but none in {storageName}; left as is.");
                         Debug.Log($"POSTMISSION RELOAD: Trying to reload {item} ({ammoDef.name}) but there is no ammo available in {storageName}!");
                         allFull = false;
                         continue;
@@ -216,6 +221,7 @@ namespace TFTV.Vehicles.Ammo
                     }
 
                     int finalCharges = GetAmmoChargesForDef(item.CommonItemData, ammoDef);
+                    AmmoDiagnostics.Trace("PostMission", $"{ammoDef.name} now {finalCharges}/{maxCharges} from {storageName}.");
                     Debug.Log($"POSTMISSION RELOAD: Reloaded {item} ({ammoDef.name}) now at {finalCharges}/{maxCharges} from {storageName}!");
 
                     if (storageAmmo.CommonItemData.IsEmpty())
@@ -268,15 +274,11 @@ namespace TFTV.Vehicles.Ammo
                     return true;
                 }
 
-                TFTVLogger.Always($"UIModuleReplenish_AddMissingAmmo_Patch Prefix called for item {item.ItemDef.name}");
-
                 var moduleDef = (item != null) ? (item.ItemDef as GroundVehicleModuleDef) : null;
                 if (moduleDef == null)
                 {
                     return true;
                 }
-
-                TFTVLogger.Always($"UIModuleReplenish_AddMissingAmmo_Patch got past here for {item.ItemDef.name}");
 
                 if (!EnsureModuleAmmo(item.CommonItemData, moduleDef))
                 {
@@ -293,15 +295,23 @@ namespace TFTV.Vehicles.Ammo
                     }
                     int currentCharges = GetAmmoChargesForDef(item.CommonItemData, tacticalItemDef);
 
-                    TFTVLogger.Always($"UIModuleReplenish_AddMissingAmmo_Patch current charges for {tacticalItemDef.name} {currentCharges}, max charges {maxCharges}");
-
                     if (currentCharges >= maxCharges)
                     {
                         continue;
                     }
                     float num = (float)currentCharges / (float)maxCharges;
 
-                    ResourcePack repairCost = GeoCharacter.GetRepairCost(tacticalItemDef, num);
+                    // Buy-only ammunition is priced at a whole magazine from the marketplace; anything
+                    // the player can manufacture keeps vanilla's proportional repair cost.
+                    bool marketplaceOnly = IsMarketplaceOnlyAmmo(tacticalItemDef);
+                    ResourcePack marketplaceCost = null;
+                    bool magazineOnSale = marketplaceOnly &&
+                        CanBuyMagazine(ReplenishFaction(__instance), tacticalItemDef, out marketplaceCost);
+
+                    ResourcePack repairCost = marketplaceOnly
+                        ? (marketplaceCost ?? MarketplacePrice(0))
+                        : GeoCharacter.GetRepairCost(tacticalItemDef, num);
+
                     GeoManufactureItem geoManufactureItem = UnityEngine.Object.Instantiate<GeoManufactureItem>(__instance.ItemListPrefab, __instance.ItemListContainer);
                     GeoManufactureItem geoManufactureItem2 = geoManufactureItem;
                     InteractHandler interactHandler = GetInteractHandler(__instance, "OnEnterSlot");
@@ -333,7 +343,21 @@ namespace TFTV.Vehicles.Ammo
                     __instance.Items.Add(geoManufactureItem);
                     GameTagDef manufacturableTag = GameUtl.GameComponent<SharedData>().SharedGameTags.ManufacturableTag;
                     GeoPhoenixFaction geoPhoenixFaction = ReplenishFaction(__instance);
-                    bool flag2 = geoPhoenixFaction.Wallet.HasResources(repairCost) && tacticalItemDef.Tags.Contains(manufacturableTag) && geoPhoenixFaction.Manufacture.Contains(tacticalItemDef);
+
+                    // Buy-only ammunition is never in the faction's manufacture list, so asking whether
+                    // it can be built would disable every one of these rows. What gates it instead is
+                    // whether a magazine is actually on sale and affordable.
+                    bool flag2 = marketplaceOnly
+                        ? magazineOnSale
+                        : geoPhoenixFaction.Wallet.HasResources(repairCost)
+                            && tacticalItemDef.Tags.Contains(manufacturableTag)
+                            && geoPhoenixFaction.Manufacture.Contains(tacticalItemDef);
+
+                    AmmoDiagnostics.Trace("ReplenishScreen",
+                        $"Row for {tacticalItemDef.name} on {moduleDef.name} ({currentCharges}/{maxCharges}), " +
+                        $"{(marketplaceOnly ? "marketplace" : "manufacture")} priced " +
+                        $"{repairCost.ByResourceType(ResourceType.Materials).RoundedValue} materials, " +
+                        $"{(flag2 ? "buyable" : "not buyable")}.");
                     PhoenixGeneralButton component = geoManufactureItem.AddToQueueButton.GetComponent<PhoenixGeneralButton>();
                     if (component != null)
                     {
@@ -352,33 +376,247 @@ namespace TFTV.Vehicles.Ammo
             }
         }
 
-        /*     [HarmonyPatch(typeof(UIModuleReplenish), "SingleItemReloadAndRefresh")]
-             public static class UIModuleReplenish_SingleItemReloadAndRefresh_Patch
-             {
-                 public static bool Prefix(UIModuleReplenish __instance, GeoManufactureItem item)
-                 {
-                     if (!TFTVAircraftReworkMain.AircraftReworkOn)
-                     {
-                         return true;
-                     }
+        #region Buying module ammunition from the marketplace
 
-                     if (item == null)
-                     {
-                         return true;
-                     }
-                     AmmoDefHolder ammoDefHolder;
-                     if (!ReplenishAmmoDefs.TryGetValue(item, out ammoDefHolder))
-                     {
-                         return true;
-                     }
-                     GeoItem item2 = item.GetComponent<ReplenishmentElementController>().Item;
-                     if (ReloadModuleAmmo(item2, ammoDefHolder.AmmoDef))
-                     {
-                         AccessTools.Method(typeof(UIModuleReplenish), "RemoveFromList")?.Invoke(__instance, new object[] { item, true });
-                         AccessTools.Method(typeof(UIModuleReplenish), "RefreshItemList")?.Invoke(__instance, null);
-                     }
-                     return false;
-                 }
-             }*/
+        // Ground vehicle module ammunition is Kaos kit: it is never manufacturable, so the replenish
+        // screen's usual "pay the repair cost, conjure the clip" route does not apply to it. A module
+        // magazine is bought from the marketplace at the going rate for a whole magazine, and whatever
+        // the weapon cannot hold goes into faction storage rather than being thrown away.
+
+        /// <summary>
+        /// The cheapest magazine of this ammunition currently on sale, or null when the marketplace is
+        /// not offering any. Deliberately has no fallback price: ammunition that is not on sale cannot
+        /// be bought, and the replenish row stays disabled until the next restock.
+        /// </summary>
+        private static GeoEventChoice FindCheapestListing(GeoMarketplace marketplace, TacticalItemDef ammoDef, out int price)
+        {
+            price = 0;
+            if (marketplace?.MarketplaceChoices == null || ammoDef == null)
+            {
+                return null;
+            }
+
+            GeoEventChoice cheapest = null;
+            int cheapestPrice = int.MaxValue;
+
+            foreach (GeoEventChoice choice in marketplace.MarketplaceChoices)
+            {
+                if (choice?.Outcome?.Items == null || choice.Outcome.Items.Count == 0) continue;
+                if (choice.Outcome.Items[0].ItemDef != ammoDef) continue;
+                if (choice.Requirments?.Resources == null) continue;
+
+                int choicePrice = choice.Requirments.Resources.ByResourceType(ResourceType.Materials).RoundedValue;
+                if (choicePrice < cheapestPrice)
+                {
+                    cheapestPrice = choicePrice;
+                    cheapest = choice;
+                }
+            }
+
+            if (cheapest == null)
+            {
+                return null;
+            }
+
+            price = cheapestPrice;
+            return cheapest;
+        }
+
+        /// <summary>
+        /// Ammunition that can only ever be bought, never built - the Junker's magazines and the
+        /// Purgatory's. Everything else a vehicle fires is Phoenix, New Jericho or Synedrion kit that
+        /// the manufacture-cost route already prices correctly, and is left alone.
+        /// </summary>
+        internal static bool IsMarketplaceOnlyAmmo(TacticalItemDef ammoDef)
+        {
+            return ammoDef != null && VehiclesAmmoMain.MarketplaceAmmoDefsAndOptions.ContainsKey(ammoDef);
+        }
+
+        internal static ResourcePack MarketplacePrice(int price)
+        {
+            return new ResourcePack(new ResourceUnit(ResourceType.Materials, price));
+        }
+
+        /// <summary>
+        /// Whether a magazine of this ammunition could be bought right now: one is on sale and the
+        /// faction can afford the cheapest.
+        /// </summary>
+        internal static bool CanBuyMagazine(GeoPhoenixFaction faction, TacticalItemDef ammoDef, out ResourcePack cost)
+        {
+            cost = null;
+
+            GeoLevelController controller = GameUtl.CurrentLevel()?.GetComponent<GeoLevelController>();
+            if (controller == null || faction == null) return false;
+
+            int price;
+            if (FindCheapestListing(controller.Marketplace, ammoDef, out price) == null) return false;
+
+            cost = MarketplacePrice(price);
+            return faction.Wallet.HasResources(cost);
+        }
+
+        /// <summary>
+        /// Buys one whole magazine of this ammunition at the cheapest price on sale, loads the module
+        /// with as much of it as the weapon can hold, and banks the rest in faction storage.
+        ///
+        /// The listing is consumed, so a single cheap magazine cannot be used to refill a whole fleet -
+        /// buying it here is the same transaction as buying it at the marketplace, and removes it from
+        /// the offers for the same reason.
+        /// </summary>
+        private static bool TryBuyMagazineAndLoad(GeoItem moduleItem, TacticalItemDef ammoDef)
+        {
+            try
+            {
+                GroundVehicleModuleDef moduleDef = moduleItem?.ItemDef as GroundVehicleModuleDef;
+                if (moduleDef == null || ammoDef == null || ammoDef.ChargesMax <= 0) return false;
+                if (!EnsureModuleAmmo(moduleItem.CommonItemData, moduleDef)) return false;
+
+                GeoLevelController controller = GameUtl.CurrentLevel()?.GetComponent<GeoLevelController>();
+                GeoPhoenixFaction faction = controller?.PhoenixFaction;
+                if (faction == null) return false;
+
+                int needed = GetAmmoCapacityForDef(moduleDef, ammoDef) - GetAmmoChargesForDef(moduleItem.CommonItemData, ammoDef);
+                if (needed <= 0)
+                {
+                    AmmoDiagnostics.Trace("Purchase", $"{ammoDef.name} already full on {moduleDef.name}; nothing bought.");
+                    return true;
+                }
+
+                int price;
+                GeoEventChoice listing = FindCheapestListing(controller.Marketplace, ammoDef, out price);
+                if (listing == null)
+                {
+                    TFTVLogger.Always($"[ModuleAmmo] No {ammoDef.name} on sale; cannot replenish {moduleDef.name}.");
+                    return false;
+                }
+
+                ResourcePack cost = MarketplacePrice(price);
+                if (!faction.Wallet.HasResources(cost))
+                {
+                    AmmoDiagnostics.Trace("Purchase",
+                        $"Cheapest {ammoDef.name} is {price} materials; faction cannot afford it.");
+                    return false;
+                }
+
+                faction.Wallet.Take(cost, OperationReason.Purchase);
+                controller.Marketplace.MarketplaceChoices.Remove(listing);
+
+                // The magazine is bought whole: the weapon takes what it has room for and the balance
+                // is banked, so nothing the player paid for is lost.
+                int loaded = Math.Min(needed, ammoDef.ChargesMax);
+                int leftover = ammoDef.ChargesMax - loaded;
+
+                GeoItem magazine = new GeoItem(ammoDef, 1, -1, null, -100);
+                magazine.CommonItemData.ModifyCharges(-magazine.CommonItemData.CurrentCharges, false);
+                magazine.CommonItemData.ModifyCharges(loaded, false);
+                moduleItem.CommonItemData.Ammo.LoadMagazine(magazine);
+
+                if (leftover > 0)
+                {
+                    GeoItem remainder = new GeoItem(ammoDef, 1, -1, null, -100);
+                    remainder.CommonItemData.ModifyCharges(-remainder.CommonItemData.CurrentCharges, false);
+                    remainder.CommonItemData.ModifyCharges(leftover, false);
+                    faction.ItemStorage.AddItem(remainder);
+                }
+
+                TFTVLogger.Always($"[ModuleAmmo] Bought a {ammoDef.name} magazine for {price} materials; " +
+                    $"{loaded} into {moduleDef.name}, {leftover} to storage.");
+
+                AmmoDiagnostics.Trace("Purchase",
+                    $"Listing consumed; marketplace now holds " +
+                    $"{controller.Marketplace.MarketplaceChoices.Count} choice(s). Module: {AmmoDiagnostics.DescribeAmmo(moduleItem)}");
+
+                return true;
+            }
+            catch (Exception e)
+            {
+                TFTVLogger.Error(e);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// The row-level buy button. Each row stands for one of the module's ammunition types, and
+        /// only that type is bought.
+        /// </summary>
+        [HarmonyPatch(typeof(UIModuleReplenish), "SingleItemReloadAndRefresh")]
+        public static class UIModuleReplenish_SingleItemReloadAndRefresh_Patch
+        {
+            public static bool Prefix(UIModuleReplenish __instance, GeoManufactureItem item)
+            {
+                try
+                {
+                    if (!TFTVAircraftReworkMain.AircraftReworkOn || item == null) return true;
+
+                    AmmoDefHolder holder;
+                    if (!ReplenishAmmoDefs.TryGetValue(item, out holder)) return true;
+
+                    GeoItem moduleItem = item.GetComponent<ReplenishmentElementController>()?.Item;
+                    if (moduleItem == null) return true;
+
+                    AmmoDiagnostics.Trace("ReplenishScreen",
+                        $"Row clicked for {holder.AmmoDef?.name}: {AmmoDiagnostics.DescribeAmmo(moduleItem)}");
+
+                    if (TryBuyMagazineAndLoad(moduleItem, holder.AmmoDef))
+                    {
+                        AccessTools.Method(typeof(UIModuleReplenish), "RemoveFromList")?.Invoke(__instance, new object[] { item, true });
+                        AccessTools.Method(typeof(UIModuleReplenish), "RefreshItemList")?.Invoke(__instance, null);
+                    }
+
+                    return false;
+                }
+                catch (Exception e)
+                {
+                    TFTVLogger.Error(e);
+                    return true;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Replenish All routes every reloadable item through SingleItemReload, which cannot read a
+        /// module - vanilla resolves CompatibleAmmunition on the module def, finds none, and gives up.
+        /// A module is reloaded here instead, buying a magazine for each of its ammunition types.
+        /// </summary>
+        [HarmonyPatch(typeof(UIModuleReplenish), "SingleItemReload")]
+        public static class UIModuleReplenish_SingleItemReload_ModuleAmmo_Patch
+        {
+            public static bool Prefix(GeoItem geoItem, ref bool __result)
+            {
+                try
+                {
+                    if (!TFTVAircraftReworkMain.AircraftReworkOn) return true;
+
+                    GroundVehicleModuleDef moduleDef = geoItem?.ItemDef as GroundVehicleModuleDef;
+                    if (moduleDef == null) return true;
+
+                    AmmoDiagnostics.Trace("ReplenishAll", $"Reloading {AmmoDiagnostics.DescribeAmmo(geoItem)}");
+
+                    bool allFull = true;
+                    foreach (TacticalItemDef ammoDef in GetModuleAmmoDefs(moduleDef))
+                    {
+                        int missing = GetAmmoCapacityForDef(moduleDef, ammoDef) - GetAmmoChargesForDef(geoItem.CommonItemData, ammoDef);
+                        if (missing <= 0) continue;
+
+                        if (!TryBuyMagazineAndLoad(geoItem, ammoDef))
+                        {
+                            allFull = false;
+                        }
+                    }
+
+                    // Only reports success when the module is genuinely full, so a row for ammunition
+                    // that could not be bought stays on the list instead of quietly disappearing.
+                    __result = allFull;
+                    return false;
+                }
+                catch (Exception e)
+                {
+                    TFTVLogger.Error(e);
+                    return true;
+                }
+            }
+        }
+
+        #endregion
     }
 }

--- a/TFTV/Vehicles/Ammo/SubaddonWeapons.cs
+++ b/TFTV/Vehicles/Ammo/SubaddonWeapons.cs
@@ -1224,6 +1224,10 @@ namespace TFTV.Vehicles.Ammo
                     UIInventorySlot owningSlot = OwningSlot(__instance);
                     ICommonItem owningItem = owningSlot?.Item;
 
+                    AmmoDiagnostics.Trace("EquipScreen",
+                        $"Side button {state.Action} pressed on {AmmoDiagnostics.DescribeAmmo(owningItem)}" +
+                        $", itemToProduce {ItemToProduce(__instance)?.name ?? "<none>"}");
+
                     WeaponDef weaponDef;
                     TacticalItemDef weaponAmmoDef;
                     if (owningItem != null && IsKaosGunWeapon(owningItem.ItemDef, out weaponDef, out weaponAmmoDef))
@@ -1643,6 +1647,9 @@ namespace TFTV.Vehicles.Ammo
             {
                 return false;
             }
+
+            AmmoDiagnostics.Trace("FreeReload",
+                $"Filling {ammoDef.name} on {AmmoDiagnostics.DescribeAmmo(item)} without cost");
             var moduleDef = item.ItemDef as GroundVehicleModuleDef;
             if (moduleDef == null || !EnsureModuleAmmo(item.CommonItemData, moduleDef))
             {

--- a/TFTV/Vehicles/Ammo/SubaddonWeaponsLoadAmmoPatch.cs
+++ b/TFTV/Vehicles/Ammo/SubaddonWeaponsLoadAmmoPatch.cs
@@ -6,6 +6,7 @@ using PhoenixPoint.Tactical.Entities.Equipments;
 using PhoenixPoint.Tactical.Entities.Weapons;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace TFTV.Vehicles.Ammo
 {
@@ -76,7 +77,9 @@ namespace TFTV.Vehicles.Ammo
                     return false;
                 }
 
-                HashSet<TacticalItemDef> ammoDefs = new HashSet<TacticalItemDef>();
+                // A list in sub-weapon order, not a HashSet: which of a two-ammo module's types went
+                // in first was otherwise unspecified, so the same press behaved differently run to run.
+                List<TacticalItemDef> ammoDefs = new List<TacticalItemDef>();
                 foreach (WeaponDef weaponDef in subWeapons)
                 {
                     if (weaponDef == null || weaponDef.CompatibleAmmunition == null)
@@ -86,7 +89,7 @@ namespace TFTV.Vehicles.Ammo
 
                     foreach (TacticalItemDef ammoDef in weaponDef.CompatibleAmmunition)
                     {
-                        if (ammoDef != null)
+                        if (ammoDef != null && !ammoDefs.Contains(ammoDef))
                         {
                             ammoDefs.Add(ammoDef);
                         }
@@ -98,8 +101,18 @@ namespace TFTV.Vehicles.Ammo
                     return false;
                 }
 
+                AmmoDiagnostics.Trace("EquipScreen",
+                    $"Loading module ammo: {AmmoDiagnostics.DescribeAmmo(item)}, " +
+                    $"types [{string.Join(", ", ammoDefs.Select(a => a.name))}]");
+
+                // Every ammunition type the module takes, in one press. Returning after the first
+                // success meant a Junker module needed two clicks to fill both its weapons.
+                bool loadedAny = false;
+
                 foreach (TacticalItemDef ammoDef in ammoDefs)
                 {
+                    bool loadedThisType = false;
+
                     foreach (UIInventorySlot slot in sourceList.Slots)
                     {
                         if (slot.Empty || slot.Item == null || slot.Item.ItemDef != ammoDef)
@@ -109,37 +122,46 @@ namespace TFTV.Vehicles.Ammo
 
                         if (list.TryLoadItemWithItem(item, slot.Item, slot))
                         {
-                            if (itemSlot != null)
-                            {
-                                itemSlot.UpdateItem();
-                            }
-                            return false;
+                            loadedThisType = true;
+                            break;
                         }
                     }
 
-                    for (int i = 0; i < sourceList.UnfilteredItems.Count; i++)
+                    if (!loadedThisType)
                     {
-                        ICommonItem commonItem = sourceList.UnfilteredItems[i];
-                        if (commonItem == null || commonItem.ItemDef != ammoDef)
+                        for (int i = 0; i < sourceList.UnfilteredItems.Count; i++)
                         {
-                            continue;
-                        }
-
-                        if (list.TryLoadItemWithItem(item, commonItem, null))
-                        {
-                            if (itemSlot != null)
+                            ICommonItem commonItem = sourceList.UnfilteredItems[i];
+                            if (commonItem == null || commonItem.ItemDef != ammoDef)
                             {
-                                itemSlot.UpdateItem();
+                                continue;
                             }
 
-                            if (commonItem.CommonItemData.IsEmpty())
+                            if (list.TryLoadItemWithItem(item, commonItem, null))
                             {
-                                sourceList.UnfilteredItems.RemoveAt(i);
+                                loadedThisType = true;
+
+                                if (commonItem.CommonItemData.IsEmpty())
+                                {
+                                    sourceList.UnfilteredItems.RemoveAt(i);
+                                }
+                                break;
                             }
-                            return false;
                         }
                     }
+
+                    loadedAny |= loadedThisType;
                 }
+
+                if (loadedAny && itemSlot != null)
+                {
+                    itemSlot.UpdateItem();
+                }
+
+                AmmoDiagnostics.Trace("EquipScreen",
+                    loadedAny
+                        ? $"Loaded: {AmmoDiagnostics.DescribeAmmo(item)}"
+                        : $"Nothing loaded - no matching ammo in the list for {AmmoDiagnostics.DescribeAmmo(item)}");
 
                 return false;
             }

--- a/TFTV/Vehicles/Ammo/VehiclesAmmoMain.cs
+++ b/TFTV/Vehicles/Ammo/VehiclesAmmoMain.cs
@@ -332,7 +332,10 @@ namespace TFTV.Vehicles.Ammo
                     newAmmo.CrateSpawnWeight = 1000;
                     newAmmo.Tags.Remove(DefCache.GetDef<FactionTagDef>("NewJerico_FactionTagDef"));
                     newAmmo.Tags.Remove(DefCache.GetDef<ClassTagDef>("Heavy_ClassTagDef"));
-                    newAmmo.Tags.Add(classTagDef);
+                    if (classTagDef != null)
+                    {
+                        newAmmo.Tags.Add(classTagDef);
+                    }
                     newAmmo.Tags.Add(vehicleTag);
 
                     newAmmo.ManufactureTech = techPrice;
@@ -422,16 +425,22 @@ namespace TFTV.Vehicles.Ammo
                         );
                     // "vehicles_ammo_purgatory.png"
 
+                    // These two share the Vishnu minigun's magazine rather than getting one of their
+                    // own, so they are wired up by hand instead of through CreateAmmoForJunkerWeapon -
+                    // which means they also have to be given the reload ability by hand. Without it the
+                    // weapon can be fired dry in tactical with no way to reload it.
                     WeaponDef junkerMinigunFullstop = DefCache.GetDef<WeaponDef>("KS_Buggy_Minigun_Fullstop_WeaponDef");
                     junkerMinigunFullstop.CompatibleAmmunition = new TacticalItemDef[] { junkerMinigun.CompatibleAmmunition[0] };
                     junkerMinigunFullstop.FreeReloadOnMissionEnd = false;
                     junkerMinigunFullstop.ViewElementDef.SmallIcon = junkerMinigunFullstop.ViewElementDef.InventoryIcon;
+                    AddReloadAbilityIfMissing(junkerMinigunFullstop);
                     AmmoWeaponDatabase.AmmoToWeaponDictionary[junkerMinigun.CompatibleAmmunition[0]].Add(junkerMinigunFullstop);
 
                     WeaponDef junkerMinigunScreamer = DefCache.GetDef<WeaponDef>("KS_Buggy_Minigun_Screamer_WeaponDef");
                     junkerMinigunScreamer.CompatibleAmmunition = new TacticalItemDef[] { junkerMinigun.CompatibleAmmunition[0] };
                     junkerMinigunScreamer.FreeReloadOnMissionEnd = false;
                     junkerMinigunScreamer.ViewElementDef.SmallIcon = junkerMinigunScreamer.ViewElementDef.InventoryIcon;
+                    AddReloadAbilityIfMissing(junkerMinigunScreamer);
                     AmmoWeaponDatabase.AmmoToWeaponDictionary[junkerMinigun.CompatibleAmmunition[0]].Add(junkerMinigunScreamer);
 
                 }


### PR DESCRIPTION
An audit of ground vehicle ammunition handling — def creation, sub-addon module ammo, Kaos gun ammo, laser battery packs, marketplace offers and post-mission replenishment — and the fixes it turned up.

Everything here is the Junker. It's the only vehicle whose weapons are `GroundVehicleModuleDef`s with sub-weapons (3 of the game's 23 modules, all Kaos buggy), and every path that assumes a weapon is an item with its own `CompatibleAmmunition` fails there. Scarab, Armadillo and Aspida turrets are ordinary items and work through vanilla untouched.

## The Screamer and Fullstop miniguns had no reload

Fire them dry in tactical and there was no way to reload. They share the Vishnu minigun's magazine rather than getting one of their own, so they're wired up by hand instead of through `CreateAmmoForJunkerWeapon` — and that hand-written block sets `CompatibleAmmunition`, `FreeReloadOnMissionEnd` and the icon, but never calls `AddReloadAbilityIfMissing`. The Vishnu minigun goes through the shared path and was always fine, which is why it looked weapon-specific rather than structural.

## Module ammunition showed replenish rows that nothing could buy

```csharp
// vanilla UIModuleReplenish.SingleItemReload
ItemDef itemDef = geoItem.ItemDef;                          // stays the module def
if (!itemDef.CompatibleAmmunition.IsEmpty()) …              // empty on a module, no redirect
if (… || !_faction.Manufacture.Contains(itemDef)) return false;   // module isn't manufacturable
```

So neither the row's own button nor **Replenish All** — which loops through the same method — did anything, and the rows never cleared. The mod built the rows but its half of the transaction was commented out, and would have handed out **free** ammunition had it been enabled, since it never took the cost.

Both paths now buy from the marketplace, which is where Kaos ammunition comes from:

| | |
|---|---|
| **Price** | the cheapest magazine actually on sale; no listing means no purchase, and the row stays disabled until a restock rather than falling back to an invented price |
| **The listing** | consumed, as though bought at the marketplace |
| **The magazine** | bought whole — the weapon takes what it can hold, the rest is banked in faction storage |
| **Currency** | Materials, matching marketplace purchases |

The rows themselves were priced with `GetRepairCost` and gated on `Manufacture.Contains`, which is false for every Junker magazine and disabled all of them. Buy-only ammunition now shows the marketplace price and is enabled when a magazine is on sale and affordable. Manufacturable vehicle ammunition keeps vanilla's proportional repair cost.

The banked remainder isn't stranded: the post-mission storage pass runs *before* the replenish rows are built, so it's consumed automatically next mission and no purchase row appears. Verified in the trace.

## Fullstop and Screamer ammunition restocked far more rarely than the Vishnu's

The Junker is always vehicle offer zero and a special case bundles minigun and Vishnu ammunition with it, so those appear every restock. The other two modules are drawn at random from a pool of ~15 vehicle options (`min(numberOfOffers/4, 10)` draws), so their ammunition showed up roughly a third of the time — a materially worse resupply cadence for no reason the player could see.

The marketplace now remembers the first time it offers each weapon module and stocks that module's ammunition on every restock afterwards. Gated on having been offered, so ammunition never appears for a weapon the player has had no chance to see.

## Three smaller findings

- `_kGWeaponsAndAmmo[weaponOffer]` used the dictionary indexer, so a Kaos weapon whose marketplace option went missing threw `KeyNotFoundException` out of offer generation and took the entire restock with it, leaving an empty marketplace. A null key could get in too, from a `Find` that returned null.
- Two ammunition creation paths added a possibly-null class tag that their New Jericho and Aspida siblings guard against.
- `TryLoadModuleAmmo` returned after the first ammunition type it loaded and iterated a `HashSet`, so a two-ammunition module needed two presses in an unspecified order.

## Diagnostics

Both console commands, both silent otherwise.

- **`tftv_vehicle_ammo_report`** — every module, its sub-weapons and what each is wired to. This is what established that all three Junker modules use the plain `WeaponDef`s this mod patches, rather than the `KS_Buggy_Fullstop_GroundVehicleWeaponDef` / `..._Screamer_...` twins the game also ships, which had been a live theory for the missing ammo.
- **`tftv_ammo_trace on|off`** — follows every ammunition interaction, tagged by stage (`PostMission`, `ReplenishScreen`, `ReplenishAll`, `Purchase`, `EquipScreen`, `FreeReload`, `Restock`). **Off by default**: these all sit inside UI refreshes and per-frame updates, so tracing unconditionally buries the log.

Per-refresh logging in `GetMissingItems` is reduced from per-character, per-item to a single line reporting what it actually stripped.

## Testing

Exercised in game across two runs with tracing on, no exceptions:

- **Replenish All** with both weapons short — both magazines bought in one press, both listings consumed, correct split into weapon and storage (`50 into module, 30 to storage`; `2 into module, 6 to storage`).
- **Post-mission auto reload** from mission items then faction storage, including the case where nothing is available.
- **Equip screen +** button, which fills one ammunition type per press with `itemToProduce` naming which.
- Tactical reload on the Screamer minigun.

## Notes for review

- The + button goes through `OnSideButtonPressed`'s own handling and never reaches `UIInventoryList.TryLoadAmmo`, so the `TryLoadModuleAmmo` change above is on a path nothing has exercised yet — presumably drag-and-drop. Harmless and probably correct there, but not verified.
- `[Restock]` and `[FreeReload]` are likewise untested — one needs a marketplace restock, the other needs buying a Junker at the marketplace.
- Buying a whole magazine means 81 materials to top up 2 Screamer rounds. That's the agreed design and the 6 spare are banked, not wasted, but it's the one number that looks alarming in isolation.
- Deliberately not changed: the Junker being hard-coded as vehicle offer zero (confirmed intended), and the dead `PossibleOptions` registration in `TFTVKaosGuns` (harmless — ammunition reaches the marketplace by bundling instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
