### PR TITLE
Make the aircraft rework switch a hard off, and trim the incident tutorial

### DIFF
--- a/Dist/Assets/Localization/TFTV_AircraftRework_Localization.csv
+++ b/Dist/Assets/Localization/TFTV_AircraftRework_Localization.csv
@@ -392,15 +392,13 @@ TUTORIAL_INCIDENTS_TEXT0,Text,,"Incidents are Geoscape Events that take time to 
 Every 4-6 days, an Incident will occur at a previously visited haven, inviting you to resolve it within the next 5 days.
 
 To initiate the Incident, you must travel to the haven with an Aircraft with at least one Operative without the “Just a Grunt” perk.",,,,,,,,
-TUTORIAL_INCIDENTS_TEXT1,Text,,"Every Incident can be resolved in two different ways. One of the choices will correspond to one Approach, and the other choice will allow 2 different Approaches. You have to select one of them. 
+TUTORIAL_INCIDENTS_TEXT1,Text,,"Each Incident can be resolved two ways: one choice uses a single Approach, the other lets you pick between two.
 
-You must also choose the Operative to lead the team. Completing the Incident successfully will give the Leading Operative the Affinity corresponding to the Approach taken, or increase the Rank in that Affinity. 
+Choose an Operative to lead. On success they gain that Approach’s Affinity, or rise a Rank in it.
 
-Leading with an Operative who already has Rank 2 or Rank 3 in an Affinity also shapes the Personnel you gain: at Rank 2 one of them will have the leader’s Affinity at Rank 1, and at Rank 3 a second one will gain a different, randomly chosen Affinity at Rank 1. 
+A leader at Rank 2 passes their Affinity to one of the Personnel you gain; at Rank 3 a second gains a different one at random.
 
-You can also Cancel to return to the Incident later. 
-
-The time it will take to resolve an Incident depends on 1) Whether the Leading Operative has an Affinity corresponding to one of the chosen Approaches, and 2) how many Operatives there are in the Aircraft.",,,,,,,,
+Resolution time depends on whether the leader already has one of the chosen Approaches, and on how many Operatives are aboard. Cancel returns you to the Incident later.",,,,,,,,
 TUTORIAL_AFFINITIES_TITLE0,Text,,Affinities,,,,,,,,
 TUTORIAL_AFFINITIES_TEXT0,Text,,"- Affinities are gained and advanced in rank by resolving Incidents or inherited from a dead operative with an Affinity. 
 - There are three ranks.

--- a/TFTV/Assets/Localization/TFTV_AircraftRework_Localization.csv
+++ b/TFTV/Assets/Localization/TFTV_AircraftRework_Localization.csv
@@ -362,13 +362,13 @@ TUTORIAL_INCIDENTS_TEXT0,Text,,"Incidents are Geoscape Events that take time to 
 Every 4-6 days, an Incident will occur at a previously visited haven, inviting you to resolve it within the next 5 days.
 
 To initiate the Incident, you must travel to the haven with an Aircraft with at least one Operative without the “Just a Grunt” perk.",,,,,,,,
-TUTORIAL_INCIDENTS_TEXT1,Text,,"Every Incident can be resolved in two different ways. One of the choices will correspond to one Approach, and the other choice will allow 2 different Approaches. You have to select one of them. 
+TUTORIAL_INCIDENTS_TEXT1,Text,,"Each Incident can be resolved two ways: one choice uses a single Approach, the other lets you pick between two.
 
-You must also choose the Operative to lead the team. Completing the Incident successfully will give the Leading Operative the Affinity corresponding to the Approach taken, or increase the Rank in that Affinity. 
+Choose an Operative to lead. On success they gain that Approach’s Affinity, or rise a Rank in it.
 
-You can also Cancel to return to the Incident later. 
+A leader at Rank 2 passes their Affinity to one of the Personnel you gain; at Rank 3 a second gains a different one at random.
 
-The time it will take to resolve an Incident depends on 1) Whether the Leading Operative has an Affinity corresponding to one of the chosen Approaches, and 2) how many Operatives there are in the Aircraft.",,,,,,,,
+Resolution time depends on whether the leader already has one of the chosen Approaches, and on how many Operatives are aboard. Cancel returns you to the Incident later.",,,,,,,,
 TUTORIAL_AFFINITIES_TITLE0,Text,,Affinities,,,,,,,,
 TUTORIAL_AFFINITIES_TEXT0,Text,,"- Affinities are gained and advanced in rank by resolving Incidents or inherited from a dead operative with an Affinity. 
 - There are three ranks.

--- a/TFTV/TFTVAircraftRework/AircraftReworkDefs.cs
+++ b/TFTV/TFTVAircraftRework/AircraftReworkDefs.cs
@@ -1201,6 +1201,7 @@ namespace TFTV
         /* [HarmonyPatch(typeof(GeoRangeComponent), "OnActorInitialized")]
             public static class GeoRangeComponent_OnActorInitialized_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 static bool Prefix(GeoRangeComponent __instance, ActorComponent actor, ref Transform ____rangeIndicator, ref GameObject ____rangeEffect)
               {
                     try

--- a/TFTV/TFTVAircraftRework/AircraftReworkGeoscape.Scanning.cs
+++ b/TFTV/TFTVAircraftRework/AircraftReworkGeoscape.Scanning.cs
@@ -30,6 +30,7 @@ namespace TFTV
             [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0051")]
             public static class GeoPhoenixFaction_OnVehicleAdded_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 static void Postfix(GeoPhoenixFaction __instance, GeoVehicle vehicle)
                 {
                     try
@@ -54,6 +55,7 @@ namespace TFTV
             [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0051")]
             public static class GeoAbility_GetTargetDisabledState_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 static void Postfix(GeoAbility __instance, ref GeoFaction __result)
                 {
                     try
@@ -81,6 +83,7 @@ namespace TFTV
             [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0051")]
             public static class GeoAbilityView_CanActivate_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 static void Postfix(GeoAbilityView __instance, GeoAbilityTarget target, ref bool __result)
                 {
                     try
@@ -115,6 +118,7 @@ namespace TFTV
             [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0051")]
             public static class UIModuleActionsBar_UpdateAbilityInformation_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 static void Postfix(UIModuleActionsBar __instance, GeoAbility geoAbility, bool showAbilityState)
                 {
                     try
@@ -147,6 +151,7 @@ namespace TFTV
             [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0051")]
             public static class ScanAbility_GetCharges_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 static void Postfix(ScanAbility __instance, ref int __result)
                 {
                     try
@@ -172,6 +177,7 @@ namespace TFTV
             [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0051")]
             public static class ScanAbility_GetDisabledStateInternal_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 static void Postfix(ScanAbility __instance, ref GeoAbilityDisabledState __result)
                 {
                     try
@@ -212,6 +218,7 @@ namespace TFTV
              [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0051")]
              public static class ScanAbility_GetTargetDisabledStateInternal_Patch
              {
+                 static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                  static void Postfix(ScanAbility __instance, GeoAbilityTarget target, GeoAbilityTargetDisabledState __result)
                  {
                      try
@@ -238,6 +245,7 @@ namespace TFTV
               [HarmonyPatch("Init")]
               public static class GeoscapeRegionDrawer_Init_Patch
               {
+                  static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                   static void Postfix(PhoenixPoint.Geoscape.Levels.GeoscapeRegionDrawer __instance)
                   {
                       try
@@ -370,6 +378,7 @@ namespace TFTV
             [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0051")]
             public static class ScanAbility_ActivateInternal_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 static void Prefix(ScanAbility __instance)
                 {
                     try
@@ -440,6 +449,7 @@ namespace TFTV
             [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0051")]
             public static class GeoScanner_CompleteScan_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 static void Prefix(GeoScanner __instance)
                 {
                     try
@@ -487,6 +497,7 @@ namespace TFTV
             [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0051")]
             public static class GeoScanComponent_DetectSite_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
 
                 static bool Prefix(GeoScanComponent __instance, GeoSite site, GeoActor ____actor)
                 {
@@ -674,6 +685,7 @@ namespace TFTV
             [HarmonyPatch(typeof(PandoranBaseRevealDataBind), "ModalShowHandler", new[] { typeof(UIModal) })]
             public static class Patch_PandoranBaseRevealDataBind_ModalShowHandler
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 public static void Postfix(PandoranBaseRevealDataBind __instance, UIModal modal)
                 {
                     try
@@ -794,6 +806,7 @@ namespace TFTV
             [HarmonyPatch(typeof(GeoAlienFaction), "TryRevealAlienBase")]
             internal static class BC_GeoAlienFaction_TryRevealAlienBase_patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0051")]
                 private static bool Prefix(ref bool __result, GeoSite site, GeoFaction revealToFaction, GeoLevelController ____level)
                 {

--- a/TFTV/TFTVAircraftRework/AircraftReworkGeoscape.cs
+++ b/TFTV/TFTVAircraftRework/AircraftReworkGeoscape.cs
@@ -44,6 +44,7 @@ namespace TFTV
         [HarmonyPatch(typeof(GeoscapeView), "SetSelectedActor")]
         internal static class GeoscapeViewSelectionPatch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static readonly FieldInfo ContextField = AccessTools.Field(typeof(GeoscapeView), "_context");
 
             private static void Prefix(GeoscapeView __instance, ref GeoActor actor)

--- a/TFTV/TFTVAircraftRework/AircraftReworkHelpers.cs
+++ b/TFTV/TFTVAircraftRework/AircraftReworkHelpers.cs
@@ -288,6 +288,7 @@ namespace TFTV
         [HarmonyPatch(typeof(ItemDef), "GetDetailedImage")]
         public static class ItemDef_GetDetailedImage_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Postfix(ItemDef __instance, ref Sprite __result)
             {
                 try
@@ -314,6 +315,7 @@ namespace TFTV
         [HarmonyPatch(typeof(ItemDef), "GetSmallIcon")]
         public static class ItemDef_GetSmallIcon_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Postfix(ItemDef __instance, ref Sprite __result)
             {
                 try

--- a/TFTV/TFTVAircraftRework/AircraftReworkMaintenance.cs
+++ b/TFTV/TFTVAircraftRework/AircraftReworkMaintenance.cs
@@ -30,6 +30,7 @@ namespace TFTV
             [HarmonyPatch(typeof(GeoVehicle), "RepairAircraftHp")]
             public static class GeoVehicle_RepairAircraftHp_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 public static void Prefix(GeoVehicle __instance, ref int points)
                 {
                     try
@@ -204,6 +205,7 @@ namespace TFTV
         [HarmonyPatch(typeof(GeoVehicle), "SetHitpoints")]
         public static class GeoVehicle_SetHitpoints_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Postfix(GeoVehicle __instance)
             {
                 try
@@ -252,6 +254,7 @@ namespace TFTV
         [HarmonyPatch(typeof(GeoVehicle), "OnAircraftBreakingDown")]
         public static class GeoVehicle_OnAircraftBreakingDown_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static bool Prefix(GeoVehicle __instance)
             {
                 try
@@ -308,6 +311,7 @@ namespace TFTV
         [HarmonyPatch(typeof(GeoscapeLog), "OnFactionVehicleMaintenaceChanged")]
         public static class GeoscapeLog_OnFactionVehicleMaintenaceChanged
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static bool Prefix(GeoscapeLog __instance, GeoFaction faction, GeoVehicle vehicle, int oldValue, int newValue)
             {
                 try

--- a/TFTV/TFTVAircraftRework/AircraftReworkMissionDeployment.cs
+++ b/TFTV/TFTVAircraftRework/AircraftReworkMissionDeployment.cs
@@ -26,6 +26,7 @@ namespace TFTV
         [HarmonyPatch(typeof(UIStateRosterDeployment), "OnEnrollmentChanged")]
         public static class UIStateRosterDeployment_OnEnrollmentChanged_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
 
             private static void NoVehicleMutogWarning(UIStateRosterDeployment __instance, GeoRosterDeploymentItem item, MessageBox ____confirmationBox, List<GeoCharacter> ____selectedDeployment, List<GeoRosterDeploymentItem> ____deploymentItems)
             {
@@ -137,6 +138,7 @@ namespace TFTV
         [HarmonyPatch(typeof(UIStateRosterDeployment), "CheckForDeployment")]
         public static class UIStateRosterDeployment_CheckForDeployment_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static bool Prefix(UIStateRosterDeployment __instance, IEnumerable<GeoCharacter> squad, GeoMission ____mission)
             {
                 try
@@ -186,6 +188,7 @@ namespace TFTV
         [HarmonyPatch(typeof(GeoMission), "GetDeploymentSources")]
         public static class GeoMission_GetDeploymentSource_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Postfix(GeoMission __instance, GeoFaction faction, IGeoCharacterContainer priorityContainer, ref List<IGeoCharacterContainer> __result)
             {
                 try

--- a/TFTV/TFTVAircraftRework/AircraftReworkRemovingFS.cs
+++ b/TFTV/TFTVAircraftRework/AircraftReworkRemovingFS.cs
@@ -19,6 +19,7 @@ namespace TFTV.TFTVAircraftRework
         [HarmonyPatch(typeof(GeoLevelController), "get_HasFesteringSkies")]
         public static class GeoLevelController_get_HasFesteringSkies_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Postfix(GeoLevelController __instance, ref bool __result)
             {
                 try
@@ -44,6 +45,7 @@ namespace TFTV.TFTVAircraftRework
         [HarmonyPatch(typeof(GeoscapeTutorial), "UnlockUIForStep")]
         public static class GeoscapeTutorial_UnlockUIForStep_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Postfix(GeoscapeTutorial __instance, GeoscapeTutorialStepType step)
             {
                 try
@@ -78,6 +80,7 @@ namespace TFTV.TFTVAircraftRework
         [HarmonyPatch(typeof(UIModuleGeoSectionBar), "Show")]
         public static class UIModuleGeoSectionBar_Show_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static bool Prefix(UIModuleGeoSectionBar __instance, bool showSections)
             {
                 try
@@ -104,6 +107,7 @@ namespace TFTV.TFTVAircraftRework
         [HarmonyPatch(typeof(UIModuleGeoSectionBar), "ActivateVehicleRosterContent")]
         public static class UIModuleGeoSectionBar_ActivateVehicleRosterContent_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static bool Prefix(UIModuleGeoSectionBar __instance, GeoscapeViewContext ____context, UIGeoSection ____section)
             {
                 try
@@ -137,6 +141,7 @@ namespace TFTV.TFTVAircraftRework
         [HarmonyPatch(typeof(GeoscapeView), "InitView")]
         public static class GeoscapeView_InitView_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Postfix(GeoscapeView __instance)
             {
                 try

--- a/TFTV/TFTVAircraftRework/AircraftReworkSpeedAndRange.cs
+++ b/TFTV/TFTVAircraftRework/AircraftReworkSpeedAndRange.cs
@@ -114,6 +114,7 @@ namespace TFTV
             /* [HarmonyPatch(typeof(GeoVehicle), "UpdateVehicleBonusCache")]
              internal static class GeoVehicle_UpdateVehicleBonusCache_patch
              {
+                 static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                  private static void Prefix(GeoVehicle __instance)
                  {
                      try
@@ -146,6 +147,7 @@ namespace TFTV
         [HarmonyPatch(typeof(GeoVehicle), "UpdateVehicleStats")]
         public static class GeoVehicle_UpdateVehicleStats_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             static void Postfix(GeoVehicle __instance)
             {
 

--- a/TFTV/TFTVAircraftRework/AircraftReworkTacticalModules.cs
+++ b/TFTV/TFTVAircraftRework/AircraftReworkTacticalModules.cs
@@ -620,6 +620,7 @@ namespace TFTV
             /* [HarmonyPatch(typeof(DamageOverTimeStatus), "LowerDamageOverTimeLevelProportional")]
              public static class DamageOverTimeStatus_LowerDamageOverTimeLevelProportional_Patch
              {
+                 static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                  public static void Prefix(DamageOverTimeStatus __instance, ref float multiplier)
                  {
                      try
@@ -656,6 +657,7 @@ namespace TFTV
              [HarmonyPatch(typeof(DamageOverTimeStatus), "LowerDamageOverTimeLevel")]
              public static class DamageOverTimeStatus_LowerDamageOverTimeLevel_Patch
              {
+                 static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                  public static void Prefix(DamageOverTimeStatus __instance, ref float amount)
                  {
                      try
@@ -1046,6 +1048,7 @@ namespace TFTV
             [HarmonyPatch(typeof(TacticalPerceptionBase), "get_MistBlobPerceptionRangeCost")]
             public static class TacticalPerceptionBase_get_MistBlobPerceptionRangeCost_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 public static void Postfix(TacticalPerceptionBase __instance, ref float __result)
                 {
                     try
@@ -1114,6 +1117,7 @@ namespace TFTV
             [HarmonyPatch(typeof(TacticalActor), "ApplyMistEffects")]
             public static class TacticalActor_ApplyMistEffects_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 public static bool Prefix(TacticalActor __instance)
                 {
                     try
@@ -1159,6 +1163,7 @@ namespace TFTV
             [HarmonyPatch(typeof(TacticalFactionVision))]
             public static class TacticalFactionVision_PrefixPatch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 //────────────────────────────────────────────────────────────
                 // 1. Replacement for GatherKnowableActors
                 //────────────────────────────────────────────────────────────
@@ -1447,10 +1452,12 @@ namespace TFTV
         }
         internal class CaptureDrones
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
 
             [HarmonyPatch(typeof(UIStateRosterDeployment), "EnterState")]
             public static class UIStateRosterDeployment_EnterState_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 public static void Prefix(UIStateRosterDeployment __instance)
                 {
                     try
@@ -1508,6 +1515,7 @@ namespace TFTV
             /*  [HarmonyPatch(typeof(GeoMission), "GetItemsOnTheGround")]
               public static class GeoMission_GetItemsOnTheGround2_Patch
               {
+                  static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                   public static void Postfix(GeoMission __instance, TacMissionResult result, ref IEnumerable<GeoItem> __result)
                   {
                       try
@@ -1541,6 +1549,7 @@ namespace TFTV
             [HarmonyPatch(typeof(CrateComponent), "Open")]
             internal static class CrateComponent_Open_Postfix
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 // Postfix: after crate opens, reassign its faction if capture drones are present.
                 static void Postfix(CrateComponent __instance)
                 {
@@ -1580,6 +1589,7 @@ namespace TFTV
             [HarmonyPatch(typeof(GeoMission), "ManageGear")]
             public static class GeoMission_ManageGear_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 public static void Prefix(GeoMission __instance, TacMissionResult result, GeoSquad squad, out bool __state)
                 {
                     try
@@ -1641,6 +1651,7 @@ namespace TFTV
             [HarmonyPatch(typeof(TacticalLevelController), "GetMissionResult")]
             internal static class TacticalLevelController_GetMissionResult_Prefix
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 // Prefix fully replaces original; __result is set and we return false.
                 static void Prefix(TacticalLevelController __instance)
                 {
@@ -1695,6 +1706,7 @@ namespace TFTV
             /*      [HarmonyPatch(typeof(GeoMission), "GetItemsOnTheGround")]
               internal static class GeoMission_GetItemsOnTheGround_Prefix
               {
+                  static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                   // Prefix fully replaces original; __result is set and we return false.
                   static bool Prefix(GeoMission __instance, TacMissionResult result, ref IEnumerable<GeoItem> __result)
                   {
@@ -1975,6 +1987,7 @@ namespace TFTV
             [HarmonyPatch(typeof(DamageOverTimeStatus), "OnApply")]
             public static class DamageOverTimeStatus_OnApply_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 public static void Postfix(DamageOverTimeStatus __instance, StatusComponent statusComponent)
                 {
                     try
@@ -2011,6 +2024,7 @@ namespace TFTV
             [HarmonyPatch(typeof(FireStatus), "CalculateFireDamage")]
             public static class FireStatus_CalculateFireDamage_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 public static void Postfix(FireStatus __instance)
                 {
                     try
@@ -2045,6 +2059,7 @@ namespace TFTV
             /*  [HarmonyPatch(typeof(DamageOverTimeResistanceStatus), "ApplyResistance")]
               public static class DamageOverTimeResistanceStatus_ApplyResistance_Patch
               {
+                  static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                   static void Postfix(DamageOverTimeResistanceStatus __instance)
                   {
                       try
@@ -2080,6 +2095,7 @@ namespace TFTV
             [HarmonyPatch(typeof(TacticalLevelController), "OnLevelStart")]//OnLevelStateChanged")]
             public static class OnLevelStart_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 public static void Postfix(TacticalLevelController __instance) //Level.State prevState, Level.State state, )
                 {
                     try
@@ -2150,6 +2166,7 @@ namespace TFTV
         [HarmonyPatch(typeof(SurviveTurnsFactionObjectiveDef), "GenerateObjective")]
         public static class SurviveTurnsFactionObjectiveDef_GenerateObjective_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Prefix(SurviveTurnsFactionObjectiveDef __instance, TacticalLevelController level, TacticalFaction faction, out int? __state)//, int ____squadMaxDeployment)
             {
                 try

--- a/TFTV/TFTVAircraftRework/AircraftReworkUI.cs
+++ b/TFTV/TFTVAircraftRework/AircraftReworkUI.cs
@@ -37,6 +37,7 @@ namespace TFTV
         [HarmonyPatch(typeof(AircraftCrewController), nameof(AircraftCrewController.SetCrew))]
         internal static class AircraftCrewController_SetCrew_ZeroSpacePatch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static readonly FieldInfo CrewField = AccessTools.Field(typeof(AircraftCrewController), "_crew");
             private static readonly FieldInfo UnitsField = AccessTools.Field(typeof(AircraftCrewController), "_unitsOnBoardElements");
             private static readonly MethodInfo RefreshCrewBarsMethod = AccessTools.Method(typeof(AircraftCrewController), "RefreshCrewBars");
@@ -297,6 +298,7 @@ namespace TFTV
         [HarmonyPatch(typeof(GeoRosterContainterItem), nameof(GeoRosterContainterItem.Refresh))]
         internal static class GeoRosterContainterItem_Refresh_ZeroSpacePatch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             static void Postfix(GeoRosterContainterItem __instance)
             {
                 if (__instance == null)
@@ -330,6 +332,7 @@ namespace TFTV
         [HarmonyPatch(typeof(VehicleSelectionAircraftElementController), "SetItem")]
         public static class VehicleSelectionAircraftElementController_SetItem_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Postfix(VehicleSelectionAircraftElementController __instance, GeoVehicle vehicle)
             {
                 try
@@ -359,6 +362,7 @@ namespace TFTV
         [HarmonyPatch(typeof(ShortEquipmentInfoButton), "SetEquipment")]
         public static class ShortEquipmentInfoButton_SetEquipment_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Postfix(ShortEquipmentInfoButton __instance, GeoVehicleEquipment equipment)
             {
                 try
@@ -385,6 +389,7 @@ namespace TFTV
         [HarmonyPatch(typeof(AircraftEquipmentViewController), "SetEquipmentUIData")]
         public static class AircraftEquipmentViewController_SetEquipmentUIData_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Postfix(AircraftEquipmentViewController __instance, GeoVehicleEquipmentUIData data)
             {
 
@@ -432,6 +437,7 @@ namespace TFTV
         [HarmonyPatch(typeof(UIAircraftEquipmentTooltip), "DisplayAllStats")]
         public static class Patch_UIAircraftEquipmentTooltip_DisplayAllStats
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static bool Prefix(UIAircraftEquipmentTooltip __instance)
             {
                 try
@@ -544,6 +550,7 @@ namespace TFTV
         [HarmonyPatch(typeof(GeoVehicleRosterEquipmentSlot), "SetItem")]
         public static class GeoVehicleRosterEquipmentSlot_SetItem_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Postfix(GeoVehicleRosterEquipmentSlot __instance, GeoVehicleEquipmentUIData item)
             {
 
@@ -576,6 +583,7 @@ namespace TFTV
         [HarmonyPatch(typeof(UIModuleSoldierEquip), "DoFilter")]
         public static class UIModuleSoldierEquip_DoFilter_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Prefix(UIModuleSoldierEquip __instance)
             {
                 try
@@ -647,6 +655,7 @@ namespace TFTV
         [HarmonyPatch(typeof(UIModuleSelectionInfoBox), "SetActorInfo")]
         public static class UIModuleSelectionInfoBox_SetActorInfo_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static bool Prefix(UIModuleSelectionInfoBox __instance,
                 GeoscapeViewContext context, GeoActor actor, Vector3 tooltipPosition, float fov,
                 ref GeoscapeViewContext ____context, ref RectTransform ____moduleRect, ref RectTransform ____panelRect, ref bool ____showTooltip)
@@ -738,6 +747,7 @@ namespace TFTV
         [HarmonyPatch(typeof(UIModuleSelectionInfoBox), "SetExtendedGeoVehicleInfo")]
         public static class UIModuleSelectionInfoBox_SetExtendedGeoVehicleInfo_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static bool Prefix(UIModuleSelectionInfoBox __instance, GeoVehicle vehicle)
             {
                 try
@@ -854,6 +864,7 @@ namespace TFTV
         [HarmonyPatch(typeof(UIModuleVehicleSelection), "RefreshVehicleBars")]
         public static class UIModuleVehicleSelection_RefreshVehicleBars_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Postfix(UIModuleVehicleSelection __instance)
             {
                 try
@@ -894,6 +905,7 @@ namespace TFTV
         [HarmonyPatch(typeof(UIModuleActionsBar), "Awake")]
         public static class UIModuleActionsBar_Awake_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Postfix(UIModuleActionsBar __instance, ref List<ShortEquipmentInfoButton> ____shortEquipmentInfoButtons)
             {
                 try
@@ -920,6 +932,7 @@ namespace TFTV
         [HarmonyPatch(typeof(UIModuleActionsBar), "SetEquipment")]
         public static class UIModuleActionsBar_SetEquipment_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Prefix(ref List<GeoVehicleEquipment> equipments, ref List<ShortEquipmentInfoButton> ____shortEquipmentInfoButtons)
             {
                 try
@@ -959,6 +972,7 @@ namespace TFTV
         [HarmonyPatch(typeof(UIModuleVehicleSelection), "Init")]
         public static class UIModuleVehicleSelection_Init_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Prefix(UIModuleVehicleSelection __instance, GeoscapeViewContext context)
             {
                 try
@@ -982,6 +996,7 @@ namespace TFTV
         [HarmonyPatch(typeof(UIModuleVehicleSelection), "SetActiveAircraftListTab")]
         public static class UIModuleVehicleSelection_SetActiveAircraftListTab_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static bool Prefix(UIModuleVehicleSelection __instance)
             {
                 try
@@ -1012,6 +1027,7 @@ namespace TFTV
         [HarmonyPatch(typeof(AircraftInfoController), "SetInfo")]
         public static class AircraftInfoController_SetInfo_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Prefix(AircraftInfoController __instance, List<GeoVehicleEquipmentUIData> modules, AircraftInfoData aircraftInfoData)
             {
                 try
@@ -1094,6 +1110,7 @@ namespace TFTV
         [HarmonyPatch(typeof(AircraftStatsController), "SetInfo")]
         public static class AircraftStatsController_SetInfo_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Postfix(AircraftStatsController __instance, AircraftInfoData aircraftInfoData)
             {
                 try
@@ -1187,6 +1204,7 @@ namespace TFTV
         [HarmonyPatch(typeof(GeoVehicleRosterSlot), "UpdateVehicleEquipments")]
         public static class GeoVehicleRosterSlot_UpdateVehicleEquipments_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             static bool Prefix(GeoVehicleRosterSlot __instance)
             {
 
@@ -1294,6 +1312,7 @@ namespace TFTV
         [HarmonyPatch(typeof(UIVehicleEquipmentInventoryList), "Init")]
         public static class UIVehicleEquipmentInventoryList_Init_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             static void Prefix(UIVehicleEquipmentInventoryList __instance, ref IEnumerable<GeoVehicleEquipmentUIData> equipments)
             {
 
@@ -1339,6 +1358,7 @@ namespace TFTV
         [HarmonyPatch(typeof(UIModuleVehicleEquip), "UpdateData")]
         public static class UIModuleVehicleEquip_UpdateData_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
 
             static void Postfix(UIModuleVehicleEquip __instance, IEnumerable<GeoVehicleEquipmentUIData> modules, bool ____inPhoenixBase)
             {
@@ -1432,6 +1452,7 @@ namespace TFTV
         [HarmonyPatch(typeof(UIModuleVehicleEquip), "AttemptSlotSwap")]
         public static class PreventDuplicateModule_DragDrop_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
 
 
             static bool Prefix(UIModuleVehicleEquip __instance, UIVehicleEquipmentInventorySlot sourceSlot, UIVehicleEquipmentInventorySlot destinationSlot, ref bool __result)
@@ -1476,6 +1497,7 @@ namespace TFTV
         [HarmonyPatch(typeof(UIModuleVehicleEquip), "HandleDoubleclickOnSlot")]
         public static class ModuleDoubleClickRefinedPatch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             static bool Prefix(UIVehicleEquipmentInventorySlot clickedSlot, UIModuleVehicleEquip __instance, ref bool __result)
             {
                 try

--- a/TFTV/TFTVAircraftRework/Healing.cs
+++ b/TFTV/TFTVAircraftRework/Healing.cs
@@ -50,6 +50,7 @@ namespace TFTV
             [HarmonyPatch(typeof(GeoPhoenixFaction), "UpdateCharactersInVehicles")]
             public static class GeoPhoenixFaction_UpdateCharactersInVehicles_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 static void Postfix(GeoPhoenixFaction __instance)
                 {
                     try

--- a/TFTV/TFTVAircraftRework/TFTVAircraftReworkMain.cs
+++ b/TFTV/TFTVAircraftRework/TFTVAircraftReworkMain.cs
@@ -20,6 +20,22 @@ namespace TFTV
 {
     internal class TFTVAircraftReworkMain
     {
+        /// <summary>
+        /// The master switch for the aircraft rework, the base rework and incidents. False on the
+        /// main branch, true for the closed beta.
+        ///
+        /// Every Harmony patch class belonging to those systems carries
+        /// <c>static bool Prepare() =&gt; AircraftReworkOn;</c>. Harmony calls Prepare before it
+        /// patches and skips the class when it returns false, so with this off those patches are
+        /// never applied at all - not applied and then made to no-op, which is what a guard inside
+        /// each method would give, and which relies on every one of them remembering to check.
+        ///
+        /// BaseReworkCheck.BaseReworkEnabled also requires this flag, so a save made during the
+        /// beta cannot switch the base rework back on when loaded on a main-branch build.
+        ///
+        /// Ground vehicle rework (TFTVVehicleRework) is deliberately not gated: ReworkVehicles is
+        /// called unconditionally and ships on main. Only Vehicles/Ammo belongs to the beta.
+        /// </summary>
         public static bool AircraftReworkOn = true;
         internal static readonly float _mistSpeedMalus = 0.2f;
         //  internal static readonly float _mistSpeedBuff = 0.5f;

--- a/TFTV/TFTVAircraftRework/VehiclesAndMutogs.cs
+++ b/TFTV/TFTVAircraftRework/VehiclesAndMutogs.cs
@@ -151,6 +151,7 @@ namespace TFTV
             [HarmonyPatch("CurrentOccupiedSpace", MethodType.Getter)]
             public static class GeoVehicle_CurrentOccupiedSpace_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 public static void Postfix(GeoVehicle __instance, ref int __result)
                 {
                     try
@@ -169,6 +170,7 @@ namespace TFTV
             [HarmonyPatch(typeof(GeoVehicle), "get_UsedCharacterSpace")]
             public static class GeoVehicle_get_UsedCharacterSpace_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 public static void Postfix(GeoVehicle __instance, ref int __result)
                 {
                     try
@@ -186,6 +188,7 @@ namespace TFTV
             [HarmonyPatch(typeof(GeoVehicle), "get_FreeCharacterSpace")]
             public static class GeoVehicle_get_FreeCharacterSpace_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 public static void Postfix(GeoVehicle __instance, ref int __result)
                 {
                     try
@@ -203,6 +206,7 @@ namespace TFTV
             [HarmonyPatch(typeof(GeoCharacter), "get_OccupingSpace")]
             public static class GeoCharacter_get_OccupingSpace_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 public static void Postfix(GeoCharacter __instance, ref int __result)
                 {
                     try
@@ -256,6 +260,7 @@ namespace TFTV
             [HarmonyPatch(typeof(TransferActionMenuElement), "Init")]
             public static class TransferActionMenuElement_Init_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 public static bool Prefix(TransferActionMenuElement __instance, IGeoCharacterContainer targetContainer, GeoRosterItem targetItem)
                 {
                     try

--- a/TFTV/TFTVBaseRework/BaseActivation.cs
+++ b/TFTV/TFTVBaseRework/BaseActivation.cs
@@ -63,6 +63,7 @@ namespace TFTV.TFTVBaseRework
             [HarmonyPatch]
             public static class HideDestroyedPhoenixBaseTooltipPatch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 // Patch both states that can display the short Phoenix base tooltip.
                 static System.Collections.Generic.IEnumerable<System.Reflection.MethodBase> TargetMethods()
                 {
@@ -85,6 +86,7 @@ namespace TFTV.TFTVBaseRework
             [HarmonyPatch(typeof(ActivateBaseAbility), "GetDisabledStateInternal")]
             internal static class ActivateBaseAbility_GetDisabledStateInternal_patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 public static bool Prefix(ActivateBaseAbility __instance, ref GeoAbilityDisabledState __result)
                 {
                     try
@@ -139,6 +141,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(GeoVehicle), "OnArrivedAtDestination")]
         internal static class GeoVehicle_OnArrivedAtDestination_OpenActivationUI_patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
          
             public static void Postfix(GeoVehicle __instance, bool justPassing)
             {

--- a/TFTV/TFTVBaseRework/BaseActivationUI.cs
+++ b/TFTV/TFTVBaseRework/BaseActivationUI.cs
@@ -48,6 +48,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(GeoAbility), "GetTargetDisabledState")]
         internal static class GeoAbility_GetTargetDisabledState_ActivateBaseIgnoreResourceGate_patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Postfix(GeoAbility __instance, GeoAbilityTarget target, ref GeoAbilityTargetDisabledState __result)
             {
                 try
@@ -72,6 +73,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(ActivateBaseAbilityView), "PayResourcementCost")]
         internal static class ActivateBaseAbilityView_PayResourcementCost_patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static bool Prefix(ActivateBaseAbilityView __instance, ModalResult result)
             {
                 try
@@ -106,6 +108,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(PXBaseActivationDataBind), "ModalShowHandler", new Type[] { typeof(UIModal) })]
         internal static class PXBaseActivationDataBind_ModalShowHandler_CustomPanel_patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Postfix(PXBaseActivationDataBind __instance, UIModal modal, PhoenixBaseActivationData ____data)
             {
                 try

--- a/TFTV/TFTVBaseRework/BaseConstructionVisuals.cs
+++ b/TFTV/TFTVBaseRework/BaseConstructionVisuals.cs
@@ -229,6 +229,7 @@ namespace TFTV.TFTVBaseRework
         /* [HarmonyPatch(typeof(UIModuleSiteContextualMenu), "SetMenuItems")]
          internal static class UIModuleSiteContextualMenu_SetMenuItems_patch
          {
+             static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
              private static void Prefix(ref List<GeoAbility> rawAbilities)
              {
                  if (rawAbilities == null)
@@ -246,6 +247,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(GeoscapeEventSystem), "OnLevelStart")]
         internal static class GeoscapeEventSystem_OnLevelStart_patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Postfix(GeoscapeEventSystem __instance)
             {
                 try
@@ -264,6 +266,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(GeoscapeEventSystem), "Update")]
         internal static class GeoscapeEventSystem_Update_patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Postfix(GeoscapeEventSystem __instance)
             {
                 try

--- a/TFTV/TFTVBaseRework/BaseExploration.cs
+++ b/TFTV/TFTVBaseRework/BaseExploration.cs
@@ -71,6 +71,7 @@ namespace TFTV.TFTVBaseRework
     [HarmonyPatch(typeof(GeoFaction), "UpdateVehicleSite")]
     internal static class GeoFaction_UpdateVehicleSite_BlockAutoVisit_Patch
     {
+        static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
         private static bool Prefix(GeoFaction __instance, GeoVehicle vehicle, GeoSite site)
         {
             if (!BaseReworkCheck.BaseReworkEnabled)
@@ -104,6 +105,7 @@ namespace TFTV.TFTVBaseRework
     [HarmonyPatch(typeof(ExploreSiteAbility), "GetTargetDisabledStateInternal")]
     internal static class ExploreSiteAbility_GetTargetDisabledStateInternal_Patch
     {
+        static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
         private static bool Prefix(
             ExploreSiteAbility __instance,
             GeoAbilityTarget target,
@@ -158,6 +160,7 @@ namespace TFTV.TFTVBaseRework
     [HarmonyPatch(typeof(GeoFaction), "OnVehicleSiteExplored")]
     internal static class GeoFaction_OnVehicleSiteExplored_PhoenixBaseInfestation_Patch
     {
+        static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
         private static void Prefix(GeoFaction __instance, GeoVehicle vehicle)
         {
             if (!BaseReworkCheck.BaseReworkEnabled)
@@ -265,6 +268,7 @@ namespace TFTV.TFTVBaseRework
     [HarmonyPatch(typeof(GeoPhoenixBase), nameof(GeoPhoenixBase.BaseInfestationCheck))]
     internal static class GeoPhoenixBase_BaseInfestationCheck_DisableVanilla_Patch
     {
+        static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
         private static bool Prefix(GeoPhoenixBase __instance, ref bool __result)
         {
             if (!BaseReworkCheck.BaseReworkEnabled)
@@ -287,6 +291,7 @@ namespace TFTV.TFTVBaseRework
     [HarmonyPatch(typeof(MissionModalDataBind), nameof(MissionModalDataBind.ModalShowHandler))]
     internal static class MissionModalDataBind_ModalShowHandler_Patch
     {
+        static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
 
         private static readonly DefCache DefCache = TFTVMain.Main.DefCache;
         private static void Postfix(MissionModalDataBind __instance, UIModal modal)
@@ -367,6 +372,7 @@ namespace TFTV.TFTVBaseRework
     [HarmonyPatch(typeof(GeoscapeView), "GetMissionBriefModal")]
     internal static class GeoscapeView_BaseInfestationCheck_DisableVanilla_Patch
     {
+        static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
         private static void Postfix(GeoscapeView __instance, GeoMission mission, ref ModalType __result)
         {
             if (!BaseReworkCheck.BaseReworkEnabled)
@@ -392,6 +398,7 @@ namespace TFTV.TFTVBaseRework
     [HarmonyPatch(typeof(UIModuleShortPhoenixBaseTooltip), "SetTooltipData")]
     internal static class UIModuleShortPhoenixBaseTooltip_SetTooltipData_ExplorationChance_Patch
     {
+        static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
         private static void Postfix(UIModuleShortPhoenixBaseTooltip __instance, PhoenixBaseShortInfoData baseData)
         {
             try
@@ -467,6 +474,7 @@ namespace TFTV.TFTVBaseRework
     [HarmonyPatch(typeof(GeoPhoenixFaction), "ActivateBaseFromExploration")]
     public static class GeoPhoenixFaction_ActivateBaseFromExploration_Patch
     {
+        static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
 
         public static bool Prefix(GeoPhoenixFaction __instance, GeoSite site)
         {

--- a/TFTV/TFTVBaseRework/BaseInitialLoot.cs
+++ b/TFTV/TFTVBaseRework/BaseInitialLoot.cs
@@ -24,6 +24,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(GeoVehicle), "TeleportToSite")]
         internal static class GeoVehicle_TeleportToSite_OpenActivationUI_patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Prefix(GeoVehicle __instance, GeoSite site)
             {
                 try

--- a/TFTV/TFTVBaseRework/BaseOutpost.cs
+++ b/TFTV/TFTVBaseRework/BaseOutpost.cs
@@ -42,6 +42,7 @@ namespace TFTV.TFTVBaseRework
     [HarmonyPatch(typeof(UIModuleGeoAssetDeployment), "SetBaseButtonElement")]
     internal static class Patch_UIModuleGeoAssetDeployment_SetBaseButtonElement
     {
+        static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
 
         // private void SetBaseButtonElement(GeoDeployAssetBaseElementController element, GeoSite site, GeoDeployAssetFactionCharacterBind bind)
         private static void Postfix(
@@ -92,6 +93,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(GeoSiteVisualsController), "RefreshSiteVisuals")]
         private static class GeoSiteVisualsController_RefreshSiteVisuals_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static void Postfix(GeoSiteVisualsController __instance, GeoSite site)
             {
                 if (!BaseReworkCheck.BaseReworkEnabled) return;
@@ -151,6 +153,7 @@ namespace TFTV.TFTVBaseRework
     [HarmonyPatch(typeof(GeoscapeView), "PxFaction_OnBaseActivated")]
     public static class Patch_CaptureActivatedBase
     {
+        static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
         static void Postfix(GeoPhoenixBase @base, bool activatedFromExploration)
         {
             if (!BaseReworkCheck.BaseReworkEnabled) return;
@@ -170,6 +173,7 @@ namespace TFTV.TFTVBaseRework
     [HarmonyPatch(typeof(UIModuleModal), "Show")]
     public static class Patch_EditBaseOutcomeModalText
     {
+        static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
         static void Postfix(UIModuleModal __instance, ModalType modal)
         {
             if (!BaseReworkCheck.BaseReworkEnabled) return;
@@ -226,6 +230,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(GeoPhoenixFaction), "GetTotalAvailableStorage")]
         internal static class GeoPhoenixFaction_GetTotalAvailableStorage_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static void Postfix(GeoPhoenixFaction __instance, ref int __result)
             {
                 if (!BaseReworkCheck.BaseReworkEnabled) return;
@@ -244,6 +249,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(GeoPhoenixFaction), "UpdateStats")]
         internal static class GeoPhoenixFaction_UpdateStats_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static readonly AccessTools.FieldRef<GeoPhoenixFaction, int> SoldierCapacityField =
                 AccessTools.FieldRefAccess<GeoPhoenixFaction, int>("<SoldierCapacity>k__BackingField");
 
@@ -286,6 +292,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(GeoPhoenixBase), "UpdateStats")]
         internal static class GeoPhoenixBase_UpdateStats_patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static void Postfix(GeoPhoenixBase __instance)
             {
                 if (!BaseReworkCheck.BaseReworkEnabled) return;
@@ -300,6 +307,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(GeoPhoenixBase), "BaseHourlyUpdate")]
         internal static class GeoPhoenixBase_BaseHourlyUpdate_patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static bool Prefix(GeoPhoenixBase __instance)
             {
                 if (!BaseReworkCheck.BaseReworkEnabled) return true;
@@ -369,6 +377,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(UIModuleBaseLayout), "SetupChangeBaseButtons")]
         internal static class UIModuleBaseLayout_SetupChangeBaseButtons_patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static void Postfix(UIModuleBaseLayout __instance)
             {
                 try
@@ -406,6 +415,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(UIStatePhoenixBaseLayout), "EnterState")]
         internal static class UIStatePhoenixBaseLayout_EnterState_patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static void Postfix(UIStatePhoenixBaseLayout __instance)
             {
                 try

--- a/TFTV/TFTVBaseRework/BaseReworkActiveCheck.cs
+++ b/TFTV/TFTVBaseRework/BaseReworkActiveCheck.cs
@@ -4,7 +4,16 @@ namespace TFTV.TFTVBaseRework
 {
     internal static class BaseReworkCheck
     {
-        internal static bool BaseReworkEnabled => TFTVNewGameOptions.BaseRework;
-       
+        /// <summary>
+        /// The base rework only ever runs alongside the aircraft rework.
+        ///
+        /// Requiring both is what makes the aircraft rework switch a hard off for the main branch.
+        /// The per-game flag on its own is not enough: it is written into the save, so a save made
+        /// during the beta carries BaseRework = true and would switch the whole system back on when
+        /// loaded on a build where the aircraft rework is off - and the legacy-save fallback in
+        /// TFTVGeoscape sets it deliberately. Gating here means every check of this property is a
+        /// check of both, rather than relying on each of the eighty-odd call sites to remember.
+        /// </summary>
+        internal static bool BaseReworkEnabled => TFTVAircraftReworkMain.AircraftReworkOn && TFTVNewGameOptions.BaseRework;
     }
 }

--- a/TFTV/TFTVBaseRework/Data.cs
+++ b/TFTV/TFTVBaseRework/Data.cs
@@ -391,6 +391,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(UIModuleGeoRosterTabs), "CheckAvailableTabs")]
         public static class AlwaysUnlockRecruitTabPatch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static readonly AccessTools.FieldRef<UIModuleGeoRosterTabs, bool> RecruitsUnlockedRef =
                 AccessTools.FieldRefAccess<UIModuleGeoRosterTabs, bool>("_recruitsUnlocked");
 
@@ -414,6 +415,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(GeoPhoenixFaction), "GetNextRecruitRegeneration")]
         public static class SafeRecruitRegenerationTimePatch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static readonly AccessTools.FieldRef<GeoPhoenixFaction, TimeUnit> LastNakedRecruitRefreshRef =
                 AccessTools.FieldRefAccess<GeoPhoenixFaction, TimeUnit>("_lastNakedRecruitRefresh");
 
@@ -1246,6 +1248,7 @@ namespace TFTV.TFTVBaseRework
 
         internal static class Patch_GeoscapeLog_PhoenixFaction_OnRecruitsRegenerated
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             static bool Prefix(IEnumerable<GeoUnitDescriptor> nakedRecruits, GeoLevelController ____level)
             {
                 if (!BaseReworkCheck.BaseReworkEnabled)
@@ -1282,6 +1285,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(GeoPhoenixFaction), nameof(GeoPhoenixFaction.RegenerateNakedRecruits))]
         internal static class GeoPhoenixFaction_RegenerateNakedRecruits_PersonnelSync
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
 
             private static void Postfix(GeoPhoenixFaction __instance, ref TimeUnit ____lastNakedRecruitRefresh, ref Dictionary<GeoUnitDescriptor, ResourcePack> ____nakedRecruits)
             {

--- a/TFTV/TFTVBaseRework/Fallen.cs
+++ b/TFTV/TFTVBaseRework/Fallen.cs
@@ -383,48 +383,56 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(AlienBaseOutcomeDataBind), "ModalShowHandler")]
         private static class AlienBaseOutcomeDataBindPatch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static void Postfix(UIModal modal) => ShowForModal(modal);
         }
 
         [HarmonyPatch(typeof(AmbushOutcomeDataBind), "ModalShowHandler")]
         private static class AmbushOutcomeDataBindPatch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static void Postfix(UIModal modal) => ShowForModal(modal);
         }
 
         [HarmonyPatch(typeof(AncientSiteOutcomeDataBind), "ModalShowHandler")]
         private static class AncientSiteOutcomeDataBindPatch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static void Postfix(UIModal modal) => ShowForModal(modal);
         }
 
         [HarmonyPatch(typeof(HavenDefenceOutcomeDataBind), "ModalShowHandler")]
         private static class HavenDefenceOutcomeDataBindPatch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static void Postfix(UIModal modal) => ShowForModal(modal);
         }
 
         [HarmonyPatch(typeof(HavenInfiltrateMissionOutcomeDataBind), "ModalShowHandler")]
         private static class HavenInfiltrateMissionOutcomeDataBindPatch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static void Postfix(UIModal modal) => ShowForModal(modal);
         }
 
         [HarmonyPatch(typeof(InfestedHavenOutcomeDataBind), "ModalShowHandler")]
         private static class InfestedHavenOutcomeDataBindPatch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static void Postfix(UIModal modal) => ShowForModal(modal);
         }
 
         [HarmonyPatch(typeof(PhoenixBaseDefenseOutcomeDataBind), "ModalShowHandler")]
         private static class PhoenixBaseDefenseOutcomeDataBindPatch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static void Postfix(UIModal modal) => ShowForModal(modal);
         }
 
         [HarmonyPatch(typeof(ScavengeOutcomeDataBind), "ModalShowHandler")]
         private static class ScavengeOutcomeDataBindPatch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static void Postfix(UIModal modal) => ShowForModal(modal);
         }
 

--- a/TFTV/TFTVBaseRework/FoodAndLivingSpacePolicy.cs
+++ b/TFTV/TFTVBaseRework/FoodAndLivingSpacePolicy.cs
@@ -1,4 +1,4 @@
-using Base.Core;
+﻿using Base.Core;
 using HarmonyLib;
 using PhoenixPoint.Common.Core;
 using PhoenixPoint.Common.Entities;
@@ -163,6 +163,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(GeoPhoenixFaction), "UpdateFeeding")]
         internal static class GeoPhoenixFaction_UpdateFeeding_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static readonly MethodInfo EvaluateSoldiersStateMethod =
                 AccessTools.Method(typeof(GeoPhoenixFaction), "EvaluateSoldiersState");
 
@@ -201,6 +202,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(GeoPhoenixFaction), "FeedSoldiers")]
         internal static class GeoPhoenixFaction_FeedSoldiers_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static bool Prefix(GeoPhoenixFaction __instance, int totalFood)
             {
                 if (!BaseReworkCheck.BaseReworkEnabled)
@@ -248,6 +250,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(GeoPhoenixFaction), "EvaluateSoldiersState")]
         internal static class GeoPhoenixFaction_EvaluateSoldiersState_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static readonly AccessTools.FieldRef<GeoPhoenixFaction, bool> LowOnFoodField =
                 AccessTools.FieldRefAccess<GeoPhoenixFaction, bool>("<LowOnFood>k__BackingField");
 
@@ -299,6 +302,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(GeoPhoenixFaction), "get_LivingQuarterFreeSpace")]
         internal static class GeoPhoenixFaction_LivingQuarterFreeSpace_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static bool Prefix(GeoPhoenixFaction __instance, ref int __result)
             {
                 if (!BaseReworkCheck.BaseReworkEnabled)
@@ -314,6 +318,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(GeoPhoenixFaction), nameof(GeoPhoenixFaction.CanRecruitCharacter))]
         internal static class GeoPhoenixFaction_CanRecruitCharacter_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static bool Prefix(GeoPhoenixFaction __instance, GeoUnitDescriptor character, ResourcePack cost, ref bool __result)
             {
                 if (!BaseReworkCheck.BaseReworkEnabled)

--- a/TFTV/TFTVBaseRework/GeoCharacterFilter.cs
+++ b/TFTV/TFTVBaseRework/GeoCharacterFilter.cs
@@ -74,6 +74,7 @@ namespace TFTV.TFTVBaseRework
             [HarmonyPatch(typeof(UIModuleGeneralPersonelRoster), "InitRosterSlots")]
             internal static class Patch_UIModuleGeneralPersonelRoster_InitRosterSlots_HideRows
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 static void Postfix(UIModuleGeneralPersonelRoster __instance)
                 {
                     if (__instance?.Slots == null) return;
@@ -96,6 +97,7 @@ namespace TFTV.TFTVBaseRework
             [HarmonyPatch(new Type[] { typeof(GeoCharacter), typeof(IEnumerable<GeoCharacter>), typeof(StateStackAction) })]
             internal static class Patch_GeoscapeView_ToEditUnitState_FilterCharacters
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 static void Prefix(
                     GeoscapeView __instance,
                     ref GeoCharacter initCharacter,
@@ -124,6 +126,7 @@ namespace TFTV.TFTVBaseRework
     new Type[] { typeof(IEnumerable<GeoCharacter>), typeof(GeoCharacter), typeof(GeoscapeViewContext) })]
             internal static class Patch_UIModuleActorCycle_Init_FilterCharacters
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 static void Prefix(
                     ref IEnumerable<GeoCharacter> characters,
                     ref GeoCharacter initialCharacter)
@@ -148,6 +151,7 @@ namespace TFTV.TFTVBaseRework
             [HarmonyPatch(typeof(GeoSiteVisualsController), "RefreshSiteVisuals")]
             public static class GeoSiteVisualsController_BaseIconAbilityFilterPatch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
 
                 private static readonly MethodInfo RefreshAvailableSoldiersCountMethod = AccessTools.Method(typeof(GeoSiteVisualsController), "RefreshAvailableSoldiersCount");
 
@@ -183,6 +187,7 @@ namespace TFTV.TFTVBaseRework
             [HarmonyPatch(typeof(GeoPhoenixFaction), "get_Soldiers")]
             private static class GeoPhoenixFaction_GetSoldiers_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 private static void Postfix(GeoPhoenixFaction __instance, ref IEnumerable<GeoCharacter> __result)
                 {
                     if (!Enabled || __result == null)
@@ -254,6 +259,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(UIStateEditSoldier), "OnDismissSoldierDialogCallback")]
         internal static class UIStateEditSoldier_OnDismissSoldierDialogCallback_HiddenOperativeCleanup_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static void Postfix(UIStateEditSoldier __instance, MessageBoxCallbackResult msgResult, ref List<GeoCharacter> ____characters)
             {
                 if (msgResult.DialogResult != MessageBoxResult.Yes)
@@ -273,6 +279,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(GeoMission), nameof(GeoMission.GetDefaultDeploymentSetup), new Type[] { typeof(IEnumerable<GeoCharacter>) })]
         internal static class GeoMission_GetDefaultDeploymentSetup_FromEnumerable_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static void Postfix(ref IEnumerable<GeoCharacter> __result)
             {
                 if (!Enabled)
@@ -287,6 +294,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(GeoMission), nameof(GeoMission.GetDefaultDeploymentSetup), new Type[] { typeof(GeoFaction), typeof(IGeoCharacterContainer) })]
         internal static class GeoMission_GetDefaultDeploymentSetup_FromFaction_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static void Postfix(ref IEnumerable<GeoCharacter> __result)
             {
                 if (!Enabled)
@@ -308,6 +316,7 @@ namespace TFTV.TFTVBaseRework
         })]
         internal static class UIStateRosterDeployment_Ctor_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static readonly AccessTools.FieldRef<UIStateRosterDeployment, List<GeoCharacter>> SelectedDeploymentField = AccessTools.FieldRefAccess<UIStateRosterDeployment, List<GeoCharacter>>("_selectedDeployment");
             private static readonly AccessTools.FieldRef<UIStateRosterDeployment, GeoCharacter> InitialCharacterField = AccessTools.FieldRefAccess<UIStateRosterDeployment, GeoCharacter>("_initialCharacter");
 
@@ -332,6 +341,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(SiteManagementRow), "ShowSiteStats")]
         internal static class Patch_SiteManagementRow_ShowSiteStats
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static void Postfix(SiteManagementRow __instance)
             {
 
@@ -357,6 +367,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(UIModuleBaseLayout), "SetLeftSideInfo")]
         internal static class Patch_UIModuleBaseLayout_SetLeftSideInfo
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static void Postfix(UIModuleBaseLayout __instance)
             {
                 if (!Enabled)

--- a/TFTV/TFTVBaseRework/LivingQuarters.cs
+++ b/TFTV/TFTVBaseRework/LivingQuarters.cs
@@ -16,6 +16,7 @@ internal class LivingQuarters
     [HarmonyPatch]
     internal static class LivingQuartersReworkPatches
     {
+        static bool Prepare() => TFTV.TFTVAircraftReworkMain.AircraftReworkOn;
         private static readonly AccessTools.FieldRef<PhoenixBaseStats, GeoPhoenixBaseLayout> LayoutField =
             AccessTools.FieldRefAccess<PhoenixBaseStats, GeoPhoenixBaseLayout>("_layout");
 

--- a/TFTV/TFTVBaseRework/PersonnelDismissal.cs
+++ b/TFTV/TFTVBaseRework/PersonnelDismissal.cs
@@ -228,6 +228,7 @@ namespace TFTV.TFTVBaseRework
         })]
         internal static class GeoPhoenixFaction_KillCharacter_DismissedOperativeToCivilian_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static bool Prefix(GeoPhoenixFaction __instance, GeoCharacter unit, CharacterDeathReason reason)
             {
                 try

--- a/TFTV/TFTVBaseRework/TrainingFacilityRework.cs
+++ b/TFTV/TFTVBaseRework/TrainingFacilityRework.cs
@@ -975,6 +975,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(GeoPhoenixFaction), "AddRecruit")]
         internal static class GeoPhoenixFaction_AddRecruit_TrainingStats_Postfix
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static void Postfix(GeoPhoenixFaction __instance, GeoCharacter recruit, IGeoCharacterContainer toContainer)
             {
                 if (!BaseReworkCheck.BaseReworkEnabled)
@@ -1037,6 +1038,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(PostmissionReplenishManager), "AddPreferredLoadout")]
         internal static class TFTV_PostmissionReplenishManager_AddPreferredLoadout_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static readonly FieldInfo PreferredLoadoutsField = AccessTools.Field(typeof(PostmissionReplenishManager), "_preferredLoadouts");
             private static readonly MethodInfo UpdatePreferredLoadoutMethod = AccessTools.Method(typeof(PostmissionReplenishManager), "UpdatePreferredLoadout");
 

--- a/TFTV/TFTVBaseRework/UI/Harmony.cs
+++ b/TFTV/TFTVBaseRework/UI/Harmony.cs
@@ -26,6 +26,7 @@ namespace TFTV.TFTVBaseRework
     [HarmonyPatch(typeof(UIModuleGeoRosterTabs), nameof(UIModuleGeoRosterTabs.CheckAvailableTabs))]
     public static class UIModuleGeoRosterTabs_CheckAvailableTabs_Patch
     {
+        static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
         private static void Postfix(UIModuleGeoRosterTabs __instance)
         {
 
@@ -284,6 +285,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(UIStateAssetDeployment), "EnterState")]
         internal static class UIStateAssetDeployment_EnterState_PersonnelManagement
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static void Postfix()
             {
                 if (!BaseReworkEnabled)
@@ -362,6 +364,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(UIStateRosterRecruits), "EnterState")]
         internal static class UIStateRosterRecruits_EnterState_PersonnelManagement
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static void Postfix(UIStateRosterRecruits __instance)
             {
                 if (!BaseReworkEnabled)
@@ -382,6 +385,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(UIStateRosterRecruits), "ExitState")]
         internal static class UIStateRosterRecruits_ExitState_PersonnelManagement
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static void Postfix()
             {
                 if (!BaseReworkEnabled)
@@ -410,6 +414,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(UIStateAssetDeployment), "ExitState")]
         internal static class UIStateAssetDeployment_ExitState_PersonnelManagement
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static void Postfix()
             {
                 if (!BaseReworkEnabled)
@@ -435,6 +440,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(UIModuleRecruitsList), nameof(UIModuleRecruitsList.SetRecruitsList))]
         public static class PersonnelManagementPatch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Postfix(UIModuleRecruitsList __instance)
             {
                 if (!BaseReworkEnabled)

--- a/TFTV/TFTVBaseRework/UI/VanillaTooltips.cs
+++ b/TFTV/TFTVBaseRework/UI/VanillaTooltips.cs
@@ -1,4 +1,4 @@
-using Base.Entities.Abilities;
+﻿using Base.Entities.Abilities;
 using PhoenixPoint.Common.Entities.Addons;
 using PhoenixPoint.Common.Entities.Items;
 using PhoenixPoint.Geoscape.Entities;
@@ -267,6 +267,7 @@ namespace TFTV.TFTVBaseRework
     [HarmonyPatch(typeof(UIInventoryTooltipItemPanel), nameof(UIInventoryTooltipItemPanel.SetAbilities))]
     internal static class UIInventoryTooltipItemPanel_SetAbilities_Capacity
     {
+        static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
         private static bool IsPersonnelTooltip(UIInventoryTooltipItemPanel panel)
         {
             return panel.GetComponentInParent<UIGeoItemTooltip>()?.gameObject.name == "TFTV_PersonnelItemTooltip";

--- a/TFTV/TFTVBaseRework/Workers.cs
+++ b/TFTV/TFTVBaseRework/Workers.cs
@@ -25,6 +25,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(GeoPhoenixFaction), nameof(GeoPhoenixFaction.UpdateBasesHourly))]
         internal static class GeoPhoenixFaction_UpdateBasesHourly_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static void Postfix(GeoPhoenixFaction __instance)
             {
                 if (!BaseReworkCheck.BaseReworkEnabled)
@@ -41,6 +42,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(GeoFactionFacilityBuffCollection), nameof(GeoFactionFacilityBuffCollection.GetValue))]
         internal static class GeoFactionFacilityBuffCollection_GetValue_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static bool Prefix(PhoenixFacilityDef facility, GeoFacilityComponentDef component, float baseValue, float addedValue, float multiplier, ref float __result)
             {
                 if (!BaseReworkCheck.BaseReworkEnabled || component == null)
@@ -60,6 +62,7 @@ namespace TFTV.TFTVBaseRework
         [HarmonyPatch(typeof(UIModuleInfoBar), "UpdateResourceInfo")]
         internal static class UIModuleInfoBar_UpdateResourceInfo_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Postfix(UIModuleInfoBar __instance, GeoFaction faction)
             {
                 try

--- a/TFTV/TFTVIncidents/AdvanceWarningHavenAttack.cs
+++ b/TFTV/TFTVIncidents/AdvanceWarningHavenAttack.cs
@@ -417,6 +417,7 @@ namespace TFTV.TFTVIncidents
         [HarmonyPatch(typeof(GeoSiteVisualsController), "Update")]
         internal static class GeoSiteVisualsController_Update_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Postfix(GeoSiteVisualsController __instance)
             {
                 GeoSite site = __instance.Site;

--- a/TFTV/TFTVIncidents/Affinities.cs
+++ b/TFTV/TFTVIncidents/Affinities.cs
@@ -901,6 +901,7 @@ int option)
             })]
             public static class DynamicAbilityDescriptionPatch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 /// <summary>
                 /// Assign this from your mod entry to supply dynamic descriptions.
                 /// Return null or empty to keep vanilla text.

--- a/TFTV/TFTVIncidents/AffinityBenefitChoiceUI.cs
+++ b/TFTV/TFTVIncidents/AffinityBenefitChoiceUI.cs
@@ -1,4 +1,4 @@
-using Base.UI;
+﻿using Base.UI;
 using HarmonyLib;
 using PhoenixPoint.Geoscape.Events;
 using PhoenixPoint.Geoscape.Levels;
@@ -129,6 +129,7 @@ namespace TFTV.TFTVIncidents
         [HarmonyPatch(typeof(UIModuleSiteEncounters), "SetEncounter")]
         private static class UIModuleSiteEncounters_SetEncounter_AffinityChoice_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static void Postfix(UIModuleSiteEncounters __instance, GeoscapeEvent geoEvent, bool pagingEvent)
             {
                 try
@@ -145,6 +146,7 @@ namespace TFTV.TFTVIncidents
         [HarmonyPatch(typeof(UIModuleSiteEncounters), "SetClosingEncounter")]
         private static class UIModuleSiteEncounters_SetClosingEncounter_AffinityChoice_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static void Postfix(UIModuleSiteEncounters __instance, GeoscapeEvent geoEvent, GeoEventChoice closingChoice, bool useEventTexts)
             {
                 try

--- a/TFTV/TFTVIncidents/AffinityGeoscapeEffects.cs
+++ b/TFTV/TFTVIncidents/AffinityGeoscapeEffects.cs
@@ -40,6 +40,7 @@ namespace TFTV.TFTVIncidents
             [HarmonyPatch(typeof(ResourceMissionOutcomeDef), nameof(ResourceMissionOutcomeDef.ApplyOutcome))]
             private static class ResourceMissionOutcomeDef_ApplyOutcome_AffinityHavenDefenseReward_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 private static void Postfix(GeoMission mission, ref MissionRewardDescription rewardDescription)
                 {
                     try
@@ -98,6 +99,7 @@ namespace TFTV.TFTVIncidents
             [HarmonyPatch(typeof(UIModuleSiteContextualMenu))]
             internal static class UIModuleSiteContextualMenu_ExploreSiteTimePatch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 private const string TimeSeparator = " ~ ";
                 private const string TimeFormat = "{0}H";
                 private const string ExplorationTimeKey = "KEY_TFTV_INCIDENT_EXPLORATION_TIME";
@@ -227,6 +229,7 @@ namespace TFTV.TFTVIncidents
             [HarmonyPatch(typeof(GeoVehicle), "StartExploringCurrentSite")]
             private static class GeoVehicle_StartExploringCurrentSite_AffinityExplorationBonus_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 private static void Prefix(GeoVehicle __instance)
                 {
                     try
@@ -257,6 +260,7 @@ namespace TFTV.TFTVIncidents
             [HarmonyPatch(typeof(GeoSite), "get_ExplorationTime")]
             private static class GeoSite_get_ExplorationTime_AffinityExplorationBonus_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 public static void Postfix(GeoSite __instance, ref TimeUnit __result)
                 {
                     try

--- a/TFTV/TFTVIncidents/AffinityTacticalEffects.cs
+++ b/TFTV/TFTVIncidents/AffinityTacticalEffects.cs
@@ -206,6 +206,7 @@ namespace TFTV.TFTVIncidents
             [HarmonyPatch(typeof(DeploymentRuleData), "CalculateDeployment")]
             public static class DeploymentRuleData_CalculateDeployment_PsychoSociologyBonus_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
 
                 private static int GetAffinityRankForApproach(GeoCharacter character, LeaderSelection.AffinityApproach approach)
                 {

--- a/TFTV/TFTVIncidents/BiotechMedkit.cs
+++ b/TFTV/TFTVIncidents/BiotechMedkit.cs
@@ -103,6 +103,7 @@ namespace TFTV.TFTVIncidents
         [HarmonyPatch(typeof(HealAbility))]
         internal static class HealAbility_BiotechMedkitPatch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private const string DiagTag = "[Incidents][BiotechMedkit]";
             private const float BaseDeliriumWillRestoreAmount = 3f;
             private const string DeliriumRestoreSourceName = "BiotechMedkit_DeliriumRestore";
@@ -115,6 +116,7 @@ namespace TFTV.TFTVIncidents
             [HarmonyPatch(typeof(TacticalLevelController), "OnLevelStart")]
             private static class TacticalLevelController_OnLevelStart_ClearBiotechRestore_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 private static void Postfix()
                 {
                     Option2RestoreAppliedByActorId.Clear();
@@ -127,6 +129,7 @@ namespace TFTV.TFTVIncidents
             [HarmonyPatch(typeof(TacStatus), "OnUnapply")]
             private static class TacStatus_OnUnapply_BiotechIgnorePain_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 private static void Postfix(TacStatus __instance)
                 {
                     try

--- a/TFTV/TFTVIncidents/GeoUIAdjustments.cs
+++ b/TFTV/TFTVIncidents/GeoUIAdjustments.cs
@@ -25,6 +25,7 @@ namespace TFTV.TFTVIncidents
             [HarmonyPatch(typeof(UIModuleSiteContextualMenu), nameof(UIModuleSiteContextualMenu.SetMenuItems))]
             private static class UIModuleSiteContextualMenu_SetMenuItems_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 private static void Prefix(List<GeoAbility> rawAbilities)
                 {
 
@@ -78,6 +79,7 @@ namespace TFTV.TFTVIncidents
             [HarmonyPatch(typeof(UIModuleSiteContextualMenu), "OnAbilityHover")]
             private static class UIModuleSiteContextualMenu_OnAbilityHover_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 public static void Postfix(UIModuleSiteContextualMenu __instance, bool isHovered, SiteContextualMenuItem menuItem)
                 {
                     GeoSite site = __instance?.SelectedSite;

--- a/TFTV/TFTVIncidents/IncidentOutcomeSummaryUI.cs
+++ b/TFTV/TFTVIncidents/IncidentOutcomeSummaryUI.cs
@@ -230,6 +230,7 @@ namespace TFTV.TFTVIncidents
         [HarmonyPatch(typeof(UIModuleSiteEncounters), "SetEncounter")]
         private static class UIModuleSiteEncounters_SetEncounter_OutcomeSummary_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static void Postfix(UIModuleSiteEncounters __instance, GeoscapeEvent geoEvent, bool pagingEvent)
             {
                 try
@@ -267,6 +268,7 @@ namespace TFTV.TFTVIncidents
         [HarmonyPatch(typeof(UIModuleSiteEncounters), "SetClosingEncounter")]
         private static class UIModuleSiteEncounters_SetClosingEncounter_OutcomeSummary_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static void Postfix(UIModuleSiteEncounters __instance, GeoscapeEvent geoEvent, GeoEventChoice closingChoice, bool useEventTexts)
             {
                 try

--- a/TFTV/TFTVIncidents/IncidentResolutionUI.cs
+++ b/TFTV/TFTVIncidents/IncidentResolutionUI.cs
@@ -29,6 +29,7 @@ namespace TFTV.TFTVIncidents
         [HarmonyPatch(typeof(UIModuleSiteEncounters), "SetEncounter")]
         internal static class GeoscapeEventCrewListPatch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private const string CrewRootName = "[Mod]EventCrewListRoot";
             private const string HeaderName = "[Mod]EventCrewListHeader";
             private const string CrewGridName = "[Mod]EventCrewListGrid";

--- a/TFTV/TFTVIncidents/PortraitGenerator.cs
+++ b/TFTV/TFTVIncidents/PortraitGenerator.cs
@@ -1549,6 +1549,7 @@ namespace TFTV.TFTVIncidents
         [HarmonyPatch(typeof(UIModuleSiteEncounters), "ShowEncounter")]
         internal static class UIModuleSiteEncounters_ShowEncounter_ResetLeaderSlot_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Prefix(UIModuleSiteEncounters __instance)
             {
                 ResetLeaderSlot(__instance);

--- a/TFTV/TFTVIncidents/Resolution.cs
+++ b/TFTV/TFTVIncidents/Resolution.cs
@@ -1144,6 +1144,7 @@ namespace TFTV.TFTVIncidents
             [HarmonyPatch(typeof(GeoscapeEventSystem), "OnLevelStart")]
             internal static class GeoscapeEventSystem_OnLevelStart_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 private static void Postfix(GeoscapeEventSystem __instance)
                 {
                     IncidentController.OnGeoscapeLevelStart(__instance);
@@ -1153,6 +1154,7 @@ namespace TFTV.TFTVIncidents
             [HarmonyPatch(typeof(UIModuleSiteEncounters), "SelectChoice")]
             internal static class UIModuleSiteEncounters_SelectChoice_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 private static void Postfix(UIModuleSiteEncounters __instance, GeoEventChoice choice)
                 {
                     IncidentController.OnChoiceResolved(__instance, choice);
@@ -1162,6 +1164,7 @@ namespace TFTV.TFTVIncidents
             [HarmonyPatch(typeof(GeoscapeEventSystem), "Update")]
             internal static class GeoscapeEventSystem_Update_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 private static void Postfix(GeoscapeEventSystem __instance)
                 {
                     IncidentController.Tick(__instance);
@@ -1171,6 +1174,7 @@ namespace TFTV.TFTVIncidents
             [HarmonyPatch(typeof(MoveVehicleAbility), "GetDisabledStateInternal")]
             internal static class MoveVehicleAbility_GetDisabledStateInternal_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 private static void Postfix(MoveVehicleAbility __instance, ref GeoAbilityDisabledState __result)
                 {
                     if (!BaseReworkCheck.BaseReworkEnabled) return;
@@ -1192,6 +1196,7 @@ namespace TFTV.TFTVIncidents
             [HarmonyPatch(typeof(MoveVehicleAbility), "ActivateInternal")]
             internal static class MoveVehicleAbility_ActivateInternal_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 private static void Prefix(MoveVehicleAbility __instance)
                 {
                     if (!BaseReworkCheck.BaseReworkEnabled) return;
@@ -1210,6 +1215,7 @@ namespace TFTV.TFTVIncidents
             [HarmonyPatch(typeof(GeoVehicle), nameof(GeoVehicle.CanTransferBetweenContainer))]
             internal static class GeoVehicle_CanTransferBetweenContainer_BlockIncidentTransfer_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 private static void Postfix(GeoVehicle __instance, IGeoCharacterContainer container, ref bool __result)
                 {
                     if (!__result) return;
@@ -1235,6 +1241,7 @@ namespace TFTV.TFTVIncidents
             [HarmonyPatch(typeof(GeoscapeEventSystem), nameof(GeoscapeEventSystem.TriggerGeoscapeEvent))]
             internal static class GeoscapeEventSystem_TriggerGeoscapeEvent_IncidentPersonnelReward_Patch
             {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
                 private sealed class SameHavenTagInfo
                 {
                     public int IncidentId;

--- a/TFTV/TFTVIncidents/TextAdjustment.cs
+++ b/TFTV/TFTVIncidents/TextAdjustment.cs
@@ -23,6 +23,7 @@ namespace TFTV.TFTVIncidents
         [HarmonyPatch(typeof(GeoscapeEventContext), nameof(GeoscapeEventContext.ReplaceEventTokens))]
         public static class GeoscapeEventTokenPostfixPatch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             // Register any custom tokens you want to support.
             private static readonly Regex IncidentIdRegex = new Regex(@"TFTV_INCIDENT_(\d+)_", RegexOptions.IgnoreCase);
 

--- a/TFTV/Vehicles/Ammo/MissionEndReplenish.cs
+++ b/TFTV/Vehicles/Ammo/MissionEndReplenish.cs
@@ -43,6 +43,7 @@ namespace TFTV.Vehicles.Ammo
         [HarmonyPatch]
         public static class PostmissionReplenishManager_GetMissingItems_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             static MethodBase TargetMethod()
             {
                 return typeof(PostmissionReplenishManager).GetMethod(
@@ -124,6 +125,7 @@ namespace TFTV.Vehicles.Ammo
         [HarmonyPatch]
         public static class UIModuleReplenish_AddMissingItem_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static readonly AccessTools.FieldRef<UIModuleReplenish, GeoPhoenixFaction> FactionRef =
                 AccessTools.FieldRefAccess<UIModuleReplenish, GeoPhoenixFaction>("_faction");
 
@@ -165,6 +167,7 @@ namespace TFTV.Vehicles.Ammo
         [HarmonyPatch(typeof(GeoMission), "TryReloadItem")]
         public static class GeoMission_TryReloadItem_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static bool Prefix(GeoItem item, ItemStorage storage, string storageName, ref bool __result)
             {
                 if (!TFTVAircraftReworkMain.AircraftReworkOn)
@@ -242,6 +245,7 @@ namespace TFTV.Vehicles.Ammo
         [HarmonyPatch(typeof(UIModuleReplenish), "AddMissingAmmo")]
         public static class UIModuleReplenish_AddMissingAmmo_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static readonly AccessTools.FieldRef<UIModuleReplenish, GeoscapeViewContext> ReplenishContext =
                 AccessTools.FieldRefAccess<UIModuleReplenish, GeoscapeViewContext>("_context");
             private static readonly AccessTools.FieldRef<UIModuleReplenish, GeoPhoenixFaction> ReplenishFaction =
@@ -542,6 +546,7 @@ namespace TFTV.Vehicles.Ammo
         [HarmonyPatch(typeof(UIModuleReplenish), "SingleItemReloadAndRefresh")]
         public static class UIModuleReplenish_SingleItemReloadAndRefresh_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static bool Prefix(UIModuleReplenish __instance, GeoManufactureItem item)
             {
                 try
@@ -581,6 +586,7 @@ namespace TFTV.Vehicles.Ammo
         [HarmonyPatch(typeof(UIModuleReplenish), "SingleItemReload")]
         public static class UIModuleReplenish_SingleItemReload_ModuleAmmo_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static bool Prefix(GeoItem geoItem, ref bool __result)
             {
                 try

--- a/TFTV/Vehicles/Ammo/SubaddonWeapons.cs
+++ b/TFTV/Vehicles/Ammo/SubaddonWeapons.cs
@@ -30,6 +30,7 @@ namespace TFTV.Vehicles.Ammo
     [HarmonyPatch(typeof(UIStateEditVehicle), "SoldierSlotItemChangedHandler")]
     public static class UIStateEditVehicle_SoldierSlotItemChangedHandler_patch
     {
+        static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
         public static bool Prefix(UIStateEditVehicle __instance, UIInventorySlot slot)
         {
             try
@@ -53,6 +54,7 @@ namespace TFTV.Vehicles.Ammo
     [HarmonyPatch]
     public static class VehicleModuleAmmoHarmonyPatches
     {
+        static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
        
 
         private sealed class TooltipOverrideHolder
@@ -593,6 +595,7 @@ namespace TFTV.Vehicles.Ammo
         [HarmonyPatch(typeof(UIInventorySlotSideButton), "GetState")]
         public static class UIInventorySlotSideButton_GetState_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static readonly AccessTools.FieldRef<UIInventorySlotSideButton, bool> ButtonPossible =
                 AccessTools.FieldRefAccess<UIInventorySlotSideButton, bool>("_buttonPossible");
             private static readonly AccessTools.FieldRef<UIInventorySlotSideButton, UIInventorySlot> OwningSlot =
@@ -877,6 +880,7 @@ namespace TFTV.Vehicles.Ammo
         [HarmonyPatch(typeof(UIInventorySlotSideButton), "RefreshState")]
         public static class UIInventorySlotSideButton_RefreshState_MarketplaceTooltipOverride_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static readonly AccessTools.FieldRef<UIInventorySlotSideButton, UIInventorySlotSideButton.GeneralState> CurrentState =
                 AccessTools.FieldRefAccess<UIInventorySlotSideButton, UIInventorySlotSideButton.GeneralState>("_currentState");
 
@@ -1195,6 +1199,7 @@ namespace TFTV.Vehicles.Ammo
         [HarmonyPatch(typeof(UIInventorySlotSideButton), "OnSideButtonPressed")]
         public static class UIInventorySlotSideButton_OnSideButtonPressed_MarketplaceAmmoFallback_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             private static readonly AccessTools.FieldRef<UIInventorySlotSideButton, UIInventorySlotSideButton.GeneralState> CurrentState =
                 AccessTools.FieldRefAccess<UIInventorySlotSideButton, UIInventorySlotSideButton.GeneralState>("_currentState");
             private static readonly AccessTools.FieldRef<UIInventorySlotSideButton, UIModuleSoldierEquip> ParentModule =
@@ -1677,6 +1682,7 @@ namespace TFTV.Vehicles.Ammo
         [HarmonyPatch(typeof(CommonItemData), "SetOwnerItem")]
         public static class CommonItemData_SetOwnerItem_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Postfix(CommonItemData __instance)
             {
                 if (!TFTVAircraftReworkMain.AircraftReworkOn)
@@ -1700,6 +1706,7 @@ namespace TFTV.Vehicles.Ammo
         [HarmonyPatch(typeof(UIInventorySlot), "UpdateItem")]
         public static class UIInventorySlot_UpdateItem_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Postfix(UIInventorySlot __instance)
             {
                 if (!TFTVAircraftReworkMain.AircraftReworkOn)
@@ -1770,6 +1777,7 @@ namespace TFTV.Vehicles.Ammo
         [HarmonyPatch(typeof(UIInventoryList), "TryLoadItemWithItem")]
         public static class UIInventoryList_TryLoadItemWithItem_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static bool Prefix(UIInventoryList __instance, ICommonItem item, ICommonItem ammoItem, UIInventorySlot ammoSlot, ref bool __result)
             {
                 if (!TFTVAircraftReworkMain.AircraftReworkOn)
@@ -1832,6 +1840,7 @@ namespace TFTV.Vehicles.Ammo
         [HarmonyPatch(typeof(UIInventoryList), "TryStripAmmo")]
         public static class UIInventoryList_TryStripAmmo_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static bool Prefix(UIInventoryList __instance, ICommonItem item, UIInventorySlot itemSlot)
             {
                 if (!TFTVAircraftReworkMain.AircraftReworkOn)
@@ -1888,6 +1897,7 @@ namespace TFTV.Vehicles.Ammo
         [HarmonyPatch(typeof(TacticalItem), "ToItemData")]
         public static class TacticalItem_ToItemData_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Prefix(TacticalItem __instance)
             {
                 if (!TFTVAircraftReworkMain.AircraftReworkOn)
@@ -1932,6 +1942,7 @@ namespace TFTV.Vehicles.Ammo
         [HarmonyPatch(typeof(TacticalActor), "ProcessInstanceData")]
         public static class TacticalActor_ProcessInstanceData_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Postfix(TacticalActor __instance)
             {
                 if (!TFTVAircraftReworkMain.AircraftReworkOn)

--- a/TFTV/Vehicles/Ammo/SubaddonWeaponsLoadAmmoPatch.cs
+++ b/TFTV/Vehicles/Ammo/SubaddonWeaponsLoadAmmoPatch.cs
@@ -15,6 +15,7 @@ namespace TFTV.Vehicles.Ammo
         [HarmonyPatch(typeof(UIInventoryList), "TryLoadAmmo")]
         public static class UIInventoryListTryLoadAmmoLoggingPatch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static bool Prefix(UIInventoryList __instance, ICommonItem item, UIInventorySlot itemSlot, UIInventoryList sourceList)
             {
                 try

--- a/TFTV/Vehicles/Ammo/VehicleAmmoReloadingFixes.cs
+++ b/TFTV/Vehicles/Ammo/VehicleAmmoReloadingFixes.cs
@@ -10,6 +10,7 @@ namespace TFTV.Vehicles.Ammo
         [HarmonyPatch(typeof(UIInventoryList), "IsVehicleEquipment")]
         public static class UIInventoryList_IsVehicleEquipment_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Postfix(UIInventoryList __instance, ref bool __result)
             {
                 if (TFTVAircraftReworkMain.AircraftReworkOn)
@@ -22,6 +23,7 @@ namespace TFTV.Vehicles.Ammo
         [HarmonyPatch(typeof(UIInventorySlot), "IsVehicleEquipment")]
         public static class UIInventorySlot_IsVehicleEquipment_Patch
         {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
             public static void Postfix(UIInventorySlot __instance, ref bool __result)
             {
                 if (TFTVAircraftReworkMain.AircraftReworkOn)


### PR DESCRIPTION
Two unrelated changes, both requested for the Patch 26 release prep.

## 1. `AircraftReworkOn = false` now actually turns everything off

The switch is false on the main branch, but it was only ever enforced by each patch remembering to check it. Auditing the 199 Harmony patch classes across `TFTVAircraftRework/`, `TFTVBaseRework/`, `TFTVIncidents/` and `Vehicles/Ammo/`:

- **67 never tested a flag at all.**
- Some were false alarms — they delegate to a helper that does the checking, like `GetAdjustedOccupiedSpace`.
- **33 genuinely weren't covered**, including `GeoCharacterFilter`'s roster filters, the eight mission-outcome modal patches in `Fallen.cs`, and `TextAdjustment`'s geoscape event token rewriter.

Rather than write 33 more guards and depend on the next patch remembering, every patch class in those folders now carries:

```csharp
static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
```

Harmony calls `Prepare()` before patching and **skips the class entirely** when it returns false. With the switch off those 192 patches are never applied — not applied and then made to no-op, which is what a guard inside each method gives you. It also skips their `TargetMethod()` reflection.

### `BaseReworkEnabled` now requires the aircraft flag too

This mattered more than it looks. The per-game flag alone could not hold the line:

```csharp
internal static bool BaseReworkEnabled => TFTVAircraftReworkMain.AircraftReworkOn && TFTVNewGameOptions.BaseRework;
```

`BaseRework` is written into the save, so a save made during the beta carries `BaseRework = true` and would have switched the whole system back on when loaded on a main-branch build — and the legacy-save fallback in `TFTVGeoscape` sets it deliberately. Gating at the property turns all ~80 existing call sites into checks of both flags at once.

### Scope

**Ground vehicle rework is deliberately not gated.** `ReworkVehicles()` is called unconditionally from `OnModEnabled`, so `TFTVVehicleRework` (Armadillo, Aspida, Scarab, Mutog, Kaos buggy) ships on main. Only `Vehicles/Ammo` belongs to the beta.

The explanation lives once, on the flag itself, rather than 192 times.

## 2. Incident tutorial panel didn't fit on screen

Reported with a screenshot at 3840×2160 — the top of the panel was cut off. The panel is anchored bottom-left with pivot (0,0) and a `ContentSizeFitter`, so it grows *upward*, and five paragraphs ran off the top.

`TUTORIAL_INCIDENTS_TEXT1` cut from **981 to 555 characters**, keeping every rule it taught: the two-Approach choice, the leader gaining or ranking up an Affinity, the Rank 2 and Rank 3 personnel inheritance, and what drives resolution time. The standalone "you can Cancel" paragraph is folded into the last line.

## Testing and known limits

- Compiles cleanly with `AircraftReworkOn` flipped to `false`, and restored to `true`.
- **Not verified: that nothing on main depended on one of the gated patches.** Two worth a look — `TFTVBaseRework/Fallen.cs` adds a fallen-operatives panel to every mission outcome modal and works fine without the rework, so it may be intended to ship; `TFTVIncidents/AdvanceWarningHavenAttack.cs` likewise reads like a general feature sitting in an incidents folder. If either should be on for everyone they need moving out or exempting.
- The tutorial panel's upward-growing pivot is untouched, so a longer translation could overflow again. Fixing that properly means re-anchoring the panel; say the word if it's wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
