### PR TITLE
Return a dismissed operative's gear to storage, and survive an empty roster

### DIFF
--- a/TFTV/TFTVBaseRework/GeoCharacterFilter.cs
+++ b/TFTV/TFTVBaseRework/GeoCharacterFilter.cs
@@ -147,6 +147,40 @@ namespace TFTV.TFTVBaseRework
                 }
             }
 
+            /// <summary>
+            /// The roster screen keeps its own character list and only the actor cycle module was
+            /// being filtered, so the two disagreed once operatives had been dismissed into
+            /// personnel: _characters still held them, the module was initialised with none, and
+            /// EnterState then handed OnActorCycled a non-null _initialCharacter while the module's
+            /// CurrentCharacter was null. Vanilla dereferences that in RefreshUnitStatsModule, and
+            /// the mod's own DisplaySoldier patch went down with it.
+            ///
+            /// Filtering the list at its source keeps the empty-roster path vanilla already has -
+            /// null initial character, OnActorCycled returning early - reachable once every
+            /// operative has been dismissed.
+            /// </summary>
+            [HarmonyPatch(typeof(UIStateGeoRoster), "RefreshCharacters")]
+            internal static class Patch_UIStateGeoRoster_RefreshCharacters_FilterCharacters
+            {
+                static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
+                static void Postfix(List<GeoCharacter> ____characters)
+                {
+                    try
+                    {
+                        if (!Enabled || ____characters == null)
+                        {
+                            return;
+                        }
+
+                        ____characters.RemoveAll(c => RosterFilterPolicy.ShouldHide(c));
+                    }
+                    catch (Exception e)
+                    {
+                        TFTVLogger.Error(e);
+                    }
+                }
+            }
+
 
             [HarmonyPatch(typeof(GeoSiteVisualsController), "RefreshSiteVisuals")]
             public static class GeoSiteVisualsController_BaseIconAbilityFilterPatch

--- a/TFTV/TFTVBaseRework/PersonnelDismissal.cs
+++ b/TFTV/TFTVBaseRework/PersonnelDismissal.cs
@@ -1,11 +1,14 @@
-﻿using HarmonyLib;
+﻿using Base.UI.MessageBox;
+using HarmonyLib;
 using PhoenixPoint.Common.View.ViewModules;
 using PhoenixPoint.Geoscape.Entities;
 using PhoenixPoint.Geoscape.Levels;
 using PhoenixPoint.Geoscape.Levels.Factions;
+using PhoenixPoint.Geoscape.View.ViewStates;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace TFTV.TFTVBaseRework
 {
@@ -220,6 +223,59 @@ namespace TFTV.TFTVBaseRework
         }
 
 
+
+        /// <summary>
+        /// The soldier equip screen commits its own inventory lists back over the data model when it
+        /// closes: ExitState calls UpdateStorage(), which trims faction storage down to whatever its
+        /// storage list holds, and UpdateSoldierEquipment(), which re-equips the character from its
+        /// armour, ready and inventory lists.
+        ///
+        /// Vanilla gets away with that because a dismissed soldier is dropped from LivingSoldiers by
+        /// the CharacterDied event, and ExitState skips both calls for a character that is no longer
+        /// living. Our conversion never lets the character be killed, so the soldier stays in
+        /// LivingSoldiers, both calls run, and between them they put the loadout back on the dismissed
+        /// operative and prune the copies the conversion had just added to storage - the gear vanished
+        /// from storage even though the conversion reported it returned.
+        ///
+        /// Running vanilla's own UnloadLoadout before the dismissal moves the gear across the screen's
+        /// lists first, so the lists already agree with what the conversion is about to do to the data
+        /// model and the commit on exit is a no-op.
+        /// </summary>
+        [HarmonyPatch(typeof(UIStateEditSoldier), "OnDismissSoldierDialogCallback")]
+        internal static class UIStateEditSoldier_OnDismissSoldierDialogCallback_UnloadLoadoutFirst_Patch
+        {
+            static bool Prepare() => TFTVAircraftReworkMain.AircraftReworkOn;
+
+            private static readonly MethodInfo _unloadLoadout = AccessTools.Method(
+                typeof(UIStateEditSoldier),
+                "UnloadLoadout",
+                new Type[] { typeof(GeoCharacter) });
+
+            private static void Prefix(UIStateEditSoldier __instance, MessageBoxCallbackResult msgResult, GeoCharacter ____currentCharacter)
+            {
+                try
+                {
+                    if (msgResult.DialogResult != MessageBoxResult.Yes || _unloadLoadout == null)
+                    {
+                        return;
+                    }
+
+                    GeoPhoenixFaction faction = ____currentCharacter?.Faction as GeoPhoenixFaction;
+
+                    if (!ShouldConvertDismissedOperativeToCivilian(faction, ____currentCharacter, CharacterDeathReason.Dismissed))
+                    {
+                        return;
+                    }
+
+                    _unloadLoadout.Invoke(__instance, new object[] { ____currentCharacter });
+                    TFTVLogger.Always($"{LogPrefix} Emptied the equip screen's loadout lists for {____currentCharacter.DisplayName} before dismissing them.");
+                }
+                catch (Exception e)
+                {
+                    TFTVLogger.Error(e);
+                }
+            }
+        }
 
         [HarmonyPatch(typeof(GeoPhoenixFaction), "KillCharacter", new Type[]
         {

--- a/TFTV/TFTVUI/Personnel/ShowWithoutHelmet.cs
+++ b/TFTV/TFTVUI/Personnel/ShowWithoutHelmet.cs
@@ -330,6 +330,14 @@ namespace TFTV.TFTVUI.Personnel
             {
                 try
                 {
+                    // Vanilla DisplaySoldier tolerates a null character - it just logs that the
+                    // character is not in the module and returns - and the roster hands it one when
+                    // there is nobody left to show, which the base rework makes easy to reach by
+                    // dismissing every operative.
+                    if (character == null)
+                    {
+                        return true;
+                    }
 
                     if (character.CharacterStats.Corruption > 0f && character.Fatigue == null)
                     {
@@ -342,7 +350,7 @@ namespace TFTV.TFTVUI.Personnel
                         return true;
                     }
 
-                    if (character != null && character.TemplateDef.IsHuman && !character.IsMutoid && !character.TemplateDef.IsMutog && !character.TemplateDef.IsVehicle)
+                    if (character.TemplateDef.IsHuman && !character.IsMutoid && !character.TemplateDef.IsMutog && !character.TemplateDef.IsVehicle)
                     {
                         bool hasAugmentedHead = HasAugmentedHead(character, bionicalTag, mutationTag, headSlot);
 


### PR DESCRIPTION
## What changed

Two bugs found while testing operative dismissal under the base rework.

### 1. A dismissed operative's equipment never reached faction storage

Dismissing from the vanilla soldier equip screen left the loadout nowhere. `TFTV.log` reported success —

```
[PesonnelDismissal] Returned 7 items from Sophia Brown to storage.
```

— but storage was empty and the gear was still on the dismissed operative.

`UIStateEditSoldier` treats its own inventory lists as the source of truth and commits them on close. In `ExitState`:

```csharp
if (GameUtl.GameComponent<PhoenixStatisticsManager>().CurrentGameStats.LivingSoldiers.ContainsKey(_currentCharacter.Id))
{
    UpdateStorage();                           // trims faction storage down to the screen's storage list
    UpdateSoldierEquipment(_currentCharacter); // re-equips the character from the screen's lists
}
```

Vanilla is safe here only because a dismissal fires `CharacterDied` → `ActorKilledInGeoscape` → `LivingSoldiers.Remove(...)`, so the guard fails and neither call runs. The base rework's `KillCharacter` prefix returns `false` to keep the operative alive as personnel, so `CharacterDied` never fires, the soldier stays in `LivingSoldiers`, and both calls run: `UpdateSoldierEquipment` puts the loadout back on from the stale UI lists, and `UpdateStorage`'s `Except`/`RemoveItems` pass deletes exactly the items the conversion had added.

**Fix:** a prefix on `UIStateEditSoldier.OnDismissSoldierDialogCallback` that runs vanilla's own `UnloadLoadout(character)` first, but only for dismissals we are going to convert. That moves the gear across the *screen's* lists, so by the time `ExitState` reconciles, the lists already agree with what the conversion did to the data model and both commits become no-ops.

### 2. Dismissing every operative broke the roster screen

```
[PesonnelDismissal] Converted dismissed operative Victoria Rodriguez to civilian personnel.
EXCEPTION: Object reference not set to an instance of an object
  at TFTV.TFTVUI.Personnel.ShowWithoutHelmet+BG_UIModuleActorCycle_DisplaySoldier_patch.Prefix
```

`Player.log` has the fuller story — vanilla NREs too, one line further on:

```
[ERROR] Character  is not in ActorCycleModule (UnityEngine.GameObject)
NullReferenceException at UIStateGeoRoster.RefreshUnitStatsModule ()
  at UIStateGeoRoster.OnActorCycled (...)
  at UIStateGeoRoster.EnterState_Patch1 (...)
```

`UIStateGeoRoster` keeps its own `_characters` list, and only the actor cycle module was being filtered. Once every operative had been dismissed into personnel the two disagreed: `_characters` still held them, so `_initialCharacter` was non-null, but the module was initialised with an empty list so `CurrentCharacter` returned null. `EnterState` calls `OnActorCycled(null, _initialCharacter, true)` directly — the non-null `newCharacter` sails past vanilla's empty-roster guard, and `DisplaySoldier(CurrentCharacter /* null */)` follows.

**Fix:** filter the roster's own list at its source (postfix on `UIStateGeoRoster.RefreshCharacters`, same `RosterFilterPolicy.ShouldHide` predicate the actor-cycle filter already uses), so vanilla's existing empty-roster path — null initial character, `OnActorCycled` returning early to `ShowNone()`/`HideSoldier()` — stays reachable. Also added the missing `character == null` guard at the top of the `DisplaySoldier` prefix; vanilla `DisplaySoldier` tolerates a null character by logging and returning, so the prefix should too. That method already had a `character != null` check further down — the first dereference just happened above it, which is now redundant and removed.

## Why it matters

The first bug silently destroyed a full loadout per dismissal. The second made the Roster screen unusable after dismissing the last operative, and took vanilla down with it.

## Notes for reviewers

- All patches are behind the existing `Prepare() => TFTVAircraftReworkMain.AircraftReworkOn` gate and the `BaseReworkEnabled` check.
- The base rework's own personnel panel dismissal path never had bug 1 — no equip screen is open there — and is unchanged.
- One caveat left as-is: `UpdateSoldierEquipment` also calls `UpdatePreferredLoadout`, so a dismissed operative's saved loadout is cleared. Cosmetic, and it matches what vanilla's unequip-all button already does.
- Both fixes were built and tested in-game against the deployed dev mod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
