### PR TITLE
Double acid decay on the actor-wide multiplier, not the slot one

### DIFF
--- a/TFTV/TFTVAcid.cs
+++ b/TFTV/TFTVAcid.cs
@@ -164,7 +164,7 @@ namespace TFTV
                         // scaled by the effect's per-point damage, which is what a tick spends.
                         AcidTick tick = AcidTick.Resolve(status.Value * status.DamagePerTurn, armour, resistance);
 
-                        float decay = GetAcidDecayForSlot(status, slot, actor, resistance);
+                        float decay = GetAcidDecayForSlot(status, slot, actor);
 
                         limbs.Add(new LimbAcid
                         {
@@ -197,15 +197,25 @@ namespace TFTV
         /// LowerDamageOverTimeLevel a second time for bionic limbs and vehicles, which doubles it
         /// again for those slots only.
         /// </summary>
-        internal static float GetAcidDecayForSlot(AcidStatus status, ItemSlot slot, TacticalActor actor, float resistance)
+        internal static float GetAcidDecayForSlot(AcidStatus status, ItemSlot slot, TacticalActor actor)
         {
             float perTurn = status.DamageOverTimeStatusDef.LowerLevelPerTurn;
 
-            if (resistance < 1f)
+            // Deliberately actor-wide, and deliberately not the slot figure used for the damage.
+            // LowerDamageOverTimeLevel doubles the step on GetDamageMultiplier(), which reads
+            // TacticalActorBase.GetDamageMultiplierFor - the overload that drops slot-targeted
+            // statuses. A resistance scoped to one limb therefore reduces that limb's damage
+            // without speeding up its burn-off, and reusing the slot figure here would predict a
+            // drop of 20 where the status really drops by 10. Read from the status def rather than
+            // the cached type so it matches whatever GetDamageMultiplier itself looks up.
+            DamageTypeBaseEffectDef damageType = status.DamageOverTimeStatusDef.DamageTypeDef;
+
+            if (damageType != null && actor != null && actor.GetDamageMultiplierFor(damageType) < 1f)
             {
                 perTurn *= 2f;
             }
 
+            // Only the workshop bonus is slot-specific: it is applied per body part.
             if (AircraftReworkTacticalModules.WorkshopModule.LowersAcidOnSlot(actor, slot))
             {
                 perTurn *= 2f;


### PR DESCRIPTION
Follow-up to #84, addressing a review comment on it. The comment is correct and the bug was introduced by that PR.

## What went wrong

#84 made acid resistance slot-scoped for the *damage*, which was right — `ApplyAddedDamage_Default` takes its multiplier from `ItemSlot.GetDamageMultiplierFor`, which keeps a slot-targeted `TacStatus` for the slot it targets. It then fed that same figure into the decay doubling, which is a different check:

```csharp
public virtual void LowerDamageOverTimeLevel(float amount = 1f)
{
    if (Utl.LesserThan(GetDamageMultiplier(), 1f)) { amount *= 2f; }
    ...
}

protected float GetDamageMultiplier()
{
    ...
    return base.TacticalActorBase.GetDamageMultiplierFor(DamageOverTimeStatusDef.DamageTypeDef);
}
```

That is the **actor-wide** overload, the one that drops slot-targeted statuses entirely.

So for exactly the case #84 added support for — a resistance scoped to a single limb — that limb's damage is halved but its burn-off is *not* accelerated. The tooltip would have predicted `acid 20→0` where the status really goes `20→10`: wrong in precisely the scenario the change existed to handle.

## The fix

The doubling reads `actor.GetDamageMultiplierFor` again. Only the workshop bonus stays slot-specific, which is correct — that one really is applied per body part.

Two details beyond the literal fix:

- The damage type now comes from `status.DamageOverTimeStatusDef.DamageTypeDef` rather than the cached `AcidDamageTypeDef`, so it matches whatever `GetDamageMultiplier` itself looks up instead of assuming the two defs agree.
- The `resistance` parameter is removed from `GetAcidDecayForSlot` rather than left unused. Passing a multiplier into a function that must not use it for this purpose is how the bug happened.

The generic `DecayPerTurn` in `StatusForecast.cs` was already actor-wide and is untouched.

One file, thirteen lines. Built clean and deployed to the dev mod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
