### PR TITLE
Fix Acheron Goo Spray target status

### DIFF
--- a/TFTV/TFTVDefsInjectedOnlyOnce.cs
+++ b/TFTV/TFTVDefsInjectedOnlyOnce.cs
@@ -6773,7 +6773,7 @@ namespace TFTV
                 //Adjusting GooSpray
                 AINonHealthDamageAttackPositionConsiderationDef gooSprayConsideration = DefCache.GetDef<AINonHealthDamageAttackPositionConsiderationDef>("Acheron_GooSprayAttackPosition_AIConsiderationDef");
                 gooSprayConsideration.EnemyMask = PhoenixPoint.Tactical.AI.ActorType.Combatant;
-                gooSprayConsideration.DamageTypeStatusDef = acidStatus;
+                gooSprayConsideration.DamageTypeStatusDef = DefCache.GetDef<GooedStatusDef>("Gooed_StatusDef");
 
 
 


### PR DESCRIPTION
## Summary
- configure Acheron Goo Spray's non-health-damage consideration to evaluate Gooed_StatusDef rather than Acid_StatusDef

## Validation
- dotnet build TFTV.sln --configuration Debug --no-restore (0 errors; 7 pre-existing CS0649 warnings)