### PR TITLE
Add rendered portraits to the haven recruit details panel

### DIFF
--- a/TFTV/TFTV.csproj
+++ b/TFTV/TFTV.csproj
@@ -250,6 +250,7 @@
     <Compile Include="TFTVUI\Geoscape\SiteManagementNav.cs" />
     <Compile Include="TFTVUI\Home\NewGameOptionsNav.cs" />
     <Compile Include="TFTVUI\Geoscape\TFTVHavenRecruitsUI\HavenRecruitAbilityIconView.cs" />
+    <Compile Include="TFTVUI\Geoscape\TFTVHavenRecruitsUI\HavenRecruitPortrait.cs" />
     <Compile Include="TFTVUI\Geoscape\TFTVHavenRecruitsUI\HavenRecruitAbilityTooltipTrigger.cs" />
     <Compile Include="TFTVUI\Geoscape\TFTVHavenRecruitsUI\HavenRecruitResourceChipView.cs" />
     <Compile Include="TFTVUI\Geoscape\TFTVHavenRecruitsUI\HavenRecruitsButton.cs" />

--- a/TFTV/TFTVIncidents/PortraitGenerator.cs
+++ b/TFTV/TFTVIncidents/PortraitGenerator.cs
@@ -128,10 +128,76 @@ namespace TFTV.TFTVIncidents
         internal static float LookAtVerticalOffset = 0.04f;
 
         /// <summary>
+        /// Where the camera stands for one portrait.
+        ///
+        /// The incident leader picture and the recruit panel take different crops out of the same
+        /// subject: the incident slot is large and wants a bust, with the armour and shoulders under
+        /// the head reading as part of the picture, while the recruit slot is small enough that a
+        /// bust reduces the face to a smudge - there it is the face that carries the portrait.
+        /// </summary>
+        internal struct PortraitFraming
+        {
+            internal float NoseDistance;
+            internal float HeadDistance;
+            internal float FieldOfView;
+            internal float YawDegrees;
+            internal float Height;
+            internal float LookAtVerticalOffset;
+        }
+
+        /// <summary>
+        /// The incident leader picture's framing - the live portrait_* tunables above, read fresh so
+        /// a console change still takes effect on the next render.
+        /// </summary>
+        private static PortraitFraming IncidentFraming => new PortraitFraming
+        {
+            NoseDistance = NoseDistance,
+            HeadDistance = HeadDistance,
+            FieldOfView = CameraFoV,
+            YawDegrees = CameraYawDegrees,
+            Height = CameraHeight,
+            LookAtVerticalOffset = LookAtVerticalOffset,
+        };
+
+        /// <summary>
+        /// The recruit panel's framing: the same shot pulled in until the face fills the frame.
+        ///
+        /// At the incident distance of 1.00m a 25 degree lens covers 0.44m at the subject, which is a
+        /// head and most of a chest - in a slot this small the head lands in the top third and the
+        /// armour takes the rest. 0.60m covers 0.27m, and the 20 degree lens brings that to 0.21m:
+        /// a head, a jaw and a collar.
+        ///
+        /// The crop is tightened by narrowing the lens rather than walking the camera in. Both fill
+        /// the frame equally, but a camera closer to a face exaggerates whatever is nearest it - the
+        /// nose and the brow - while a longer lens at the same distance flattens the face the way a
+        /// portrait lens is meant to.
+        /// </summary>
+        internal static PortraitFraming RecruitFraming = new PortraitFraming
+        {
+            NoseDistance = 0.60f,
+            HeadDistance = 0.68f,
+            FieldOfView = 20f,
+            YawDegrees = -20f,
+
+            // Level with the point being looked at, so the lens is not tilted down into the top of
+            // the skull - a tilt foreshortens the crown, which is the part with least room to spare.
+            Height = 0.05f,
+
+            // Aims above the nose, which drops the subject in the frame. The half-frame at this lens
+            // and distance reaches 0.106m, so 0.045 puts the top of the frame about 0.15m above the
+            // nose - clear of the crown - while the bottom still falls below the chin.
+            LookAtVerticalOffset = 0.045f,
+        };
+
+        /// <summary>
         /// Writes every render to persistentDataPath as a PNG named after the settings that produced
         /// it, which is how framing and quality changes get compared side by side.
+        ///
+        /// A tuning aid, not something to ship on: encoding and writing a PNG happens inline with the
+        /// render, so leaving it on costs every portrait a synchronous disk write and litters the
+        /// player's data folder. Turn it on for a tuning session with portrait_dump on.
         /// </summary>
-        internal static bool DumpRenderToDisk = true;
+        internal static bool DumpRenderToDisk = false;
 
         // ---------------------------------------------------------------------------------------
         // Lighting. One directional light per role, angled relative to the subject (the rig is
@@ -509,70 +575,242 @@ namespace TFTV.TFTVIncidents
         /// </summary>
         private static Vector2Int ResolvePortraitResolution(UIModuleSiteEncounters module)
         {
-            try
+            Vector2Int measured = ResolveSlotResolution(module?.EncounterLeaderImage?.rectTransform, DisplayScale, MaxPortraitResolution);
+            if (measured.x > 0 && measured.y > 0)
             {
-                RectTransform rect = module?.EncounterLeaderImage?.rectTransform;
-                if (rect != null)
-                {
-                    Vector3[] corners = new Vector3[4];
-                    rect.GetWorldCorners(corners);
-
-                    float width;
-                    float height;
-
-                    Canvas canvas = module.EncounterLeaderImage.canvas;
-                    if (canvas != null && canvas.renderMode != RenderMode.ScreenSpaceOverlay && canvas.worldCamera != null)
-                    {
-                        Vector2 min = RectTransformUtility.WorldToScreenPoint(canvas.worldCamera, corners[0]);
-                        Vector2 max = RectTransformUtility.WorldToScreenPoint(canvas.worldCamera, corners[2]);
-                        width = Mathf.Abs(max.x - min.x);
-                        height = Mathf.Abs(max.y - min.y);
-                    }
-                    else
-                    {
-                        // Screen-space overlay: world corners are already screen pixels.
-                        width = Mathf.Abs(corners[2].x - corners[0].x);
-                        height = Mathf.Abs(corners[2].y - corners[0].y);
-                    }
-
-                    if (width > 1f && height > 1f)
-                    {
-                        // The slot is drawn at DisplayScale, so that is the size the portrait is
-                        // actually seen at - measure against that, not the unscaled rect.
-                        width *= DisplayScale;
-                        height *= DisplayScale;
-
-                        // Scale both axes by the same factor. Clamping them independently, as this
-                        // used to, changes the render's aspect ratio away from the slot's, and the
-                        // Image then letterboxes the result and throws the difference away.
-                        float fit = Mathf.Min(1f, MaxPortraitResolution / Mathf.Max(width, height));
-                        Vector2Int resolution = new Vector2Int(
-                            Mathf.Max(MinPortraitResolution, Mathf.RoundToInt(width * fit)),
-                            Mathf.Max(MinPortraitResolution, Mathf.RoundToInt(height * fit)));
-
-                        TFTVLogger.Always($"{LogPrefix} Leader slot measures {width:F0}x{height:F0} on screen -> portrait {resolution.x}x{resolution.y}.");
-                        return resolution;
-                    }
-                }
-            }
-            catch (Exception e)
-            {
-                TFTVLogger.Error(e);
+                TFTVLogger.Always($"{LogPrefix} Leader slot -> portrait {measured.x}x{measured.y}.");
+                return measured;
             }
 
             return new Vector2Int(FallbackPortraitResolution, FallbackPortraitResolution);
         }
 
+        /// <summary>
+        /// Portrait resolution for a UI slot: the slot's own on-screen pixel size, scaled down to fit
+        /// <paramref name="maxResolution"/> without changing its aspect ratio. Rendering to anything
+        /// else means the Image either throws rendered pixels away or magnifies them.
+        ///
+        /// Returns zero when the slot cannot be measured - a rect with no layout pass behind it yet -
+        /// so the caller can decide between a fallback and waiting a frame.
+        /// </summary>
+        internal static Vector2Int ResolveSlotResolution(RectTransform rect, float displayScale, int maxResolution)
+        {
+            try
+            {
+                if (rect == null)
+                {
+                    return Vector2Int.zero;
+                }
+
+                Vector3[] corners = new Vector3[4];
+                rect.GetWorldCorners(corners);
+
+                float width;
+                float height;
+
+                Canvas canvas = rect.GetComponentInParent<Canvas>();
+                if (canvas != null && canvas.renderMode != RenderMode.ScreenSpaceOverlay && canvas.worldCamera != null)
+                {
+                    Vector2 min = RectTransformUtility.WorldToScreenPoint(canvas.worldCamera, corners[0]);
+                    Vector2 max = RectTransformUtility.WorldToScreenPoint(canvas.worldCamera, corners[2]);
+                    width = Mathf.Abs(max.x - min.x);
+                    height = Mathf.Abs(max.y - min.y);
+                }
+                else
+                {
+                    // Screen-space overlay: world corners are already screen pixels.
+                    width = Mathf.Abs(corners[2].x - corners[0].x);
+                    height = Mathf.Abs(corners[2].y - corners[0].y);
+                }
+
+                if (width <= 1f || height <= 1f)
+                {
+                    return Vector2Int.zero;
+                }
+
+                // The slot may be drawn at a scale, and that is the size the portrait is actually
+                // seen at - measure against that, not the unscaled rect.
+                width *= displayScale;
+                height *= displayScale;
+
+                // Scale both axes by the same factor. Clamping them independently changes the
+                // render's aspect ratio away from the slot's, and the Image then letterboxes the
+                // result and throws the difference away.
+                float fit = Mathf.Min(1f, maxResolution / Mathf.Max(width, height));
+                return new Vector2Int(
+                    Mathf.Max(MinPortraitResolution, Mathf.RoundToInt(width * fit)),
+                    Mathf.Max(MinPortraitResolution, Mathf.RoundToInt(height * fit)));
+            }
+            catch (Exception e)
+            {
+                TFTVLogger.Error(e);
+                return Vector2Int.zero;
+            }
+        }
+
         private static IEnumerator RenderPortrait(GeoCharacter character, Vector2Int resolution, Action<Sprite> onDone)
         {
-            GeoLevelController level = GameUtl.CurrentLevel()?.GetComponent<GeoLevelController>();
-            if (level == null)
+            yield return RenderPortrait(
+                new UnitDisplayData(character, GameUtl.GameComponent<SharedData>()),
+                character,
+                resolution,
+                IncidentFraming,
+                requireFaceBone: false,
+                dumpToDisk: DumpRenderToDisk,
+                onDone: onDone);
+        }
+
+        /// <summary>
+        /// Renders a portrait of a recruit - a unit the player does not own yet, and which therefore
+        /// exists only as a GeoUnitDescriptor rather than a GeoCharacter.
+        ///
+        /// The descriptor overload of UnitDisplayData is the one vanilla's own recruit screen builds
+        /// its 3D model from (UIModuleActorCycle.Init), so the same appearance tags reach the builder
+        /// here. Two things differ from the GeoCharacter path: there is no character to refresh tags
+        /// on - the descriptor's identity carries them directly - and no Delirium, since a recruit has
+        /// no corruption until they are hired.
+        ///
+        /// A descriptor with no face bone (a Scarab, an Aspida) renders nothing rather than a
+        /// close-up of a hull: the framing below is a face framing and nothing else.
+        ///
+        /// The face, hair and eyes are the recruit's own; the armour is painted in the one fixed
+        /// pair of colours every portrait uses. See <see cref="ApplyPortraitArmourColours"/> for why
+        /// the recruit's own armour colours are not what a portrait wants.
+        /// </summary>
+        internal static IEnumerator RenderPortrait(GeoUnitDescriptor recruit, Vector2Int resolution, Action<Sprite> onDone)
+        {
+            if (recruit == null)
             {
                 onDone?.Invoke(null);
                 yield break;
             }
 
-            UnitDisplayData displayData = new UnitDisplayData(character, GameUtl.GameComponent<SharedData>());
+            UnitDisplayData displayData = new UnitDisplayData(recruit, GameUtl.GameComponent<SharedData>());
+            displayData.GameTags = ApplyPortraitArmourColours(displayData.GameTags);
+            LogRecruitCustomization(recruit);
+
+            yield return RenderPortrait(
+                displayData,
+                null,
+                resolution,
+                RecruitFraming,
+                requireFaceBone: true,
+                dumpToDisk: false,
+                onDone: onDone);
+        }
+
+
+        /// <summary>
+        /// The armour colours every recruit portrait is painted in.
+        ///
+        /// A recruit's own colours are randomised per recruit when their identity is first asked for
+        /// (GeoUnitDescriptor.GenerateIdentity, under the randomized-initial-customization campaign
+        /// option), so a haven's offers came out in a scatter of unrelated colours. One fixed pair
+        /// makes the panel read as a set of portraits rather than a paint chart.
+        ///
+        /// Palette entries, by def name. Armour palette entry N supplies both a
+        /// CustomizationColorTagDef_N for the primary channel and a
+        /// CustomizationSecondaryColorTagDef_N for the secondary one, so these two names are entry 1
+        /// for the primary and entry 2 for the secondary.
+        /// </summary>
+        private const string PortraitPrimaryColorDefName = "CustomizationColorTagDef_1";
+        private const string PortraitSecondaryColorDefName = "CustomizationSecondaryColorTagDef_2";
+
+        /// <summary>
+        /// Swaps the armour colours in a recruit's tag list for the two fixed portrait colours.
+        ///
+        /// Only the armour channels: hair and eye colour are CustomizationColorTagDefs as well, but
+        /// they are their own subtypes, so selecting on the primary and secondary subtypes leaves a
+        /// recruit's own head colouring alone. The pattern is left alone too.
+        ///
+        /// Only the tags handed to the builder are changed - the recruit's identity is untouched, so
+        /// hiring them still produces the operative the rest of the game agreed on.
+        /// </summary>
+        private static IEnumerable<GameTagDef> ApplyPortraitArmourColours(IEnumerable<GameTagDef> tags)
+        {
+            try
+            {
+                if (tags == null)
+                {
+                    return tags;
+                }
+
+                DefCache defCache = TFTVMain.Main.DefCache;
+                CustomizationPrimaryColorTagDef primary = defCache.GetDef<CustomizationPrimaryColorTagDef>(PortraitPrimaryColorDefName);
+                CustomizationSecondaryColorTagDef secondary = defCache.GetDef<CustomizationSecondaryColorTagDef>(PortraitSecondaryColorDefName);
+
+                if (primary == null && secondary == null)
+                {
+                    TFTVLogger.Always($"{LogPrefix} Neither {PortraitPrimaryColorDefName} nor {PortraitSecondaryColorDefName} exists - " +
+                        "portraits keep the recruit's own colours.");
+                    return tags;
+                }
+
+                // Each channel is only dropped when there is something to put back in its place.
+                List<GameTagDef> result = tags
+                    .Where(tag => !(primary != null && tag is CustomizationPrimaryColorTagDef)
+                        && !(secondary != null && tag is CustomizationSecondaryColorTagDef))
+                    .ToList();
+
+                if (primary != null)
+                {
+                    result.Add(primary);
+                }
+
+                if (secondary != null)
+                {
+                    result.Add(secondary);
+                }
+
+                return result;
+            }
+            catch (Exception e)
+            {
+                TFTVLogger.Error(e);
+                return tags;
+            }
+        }
+
+        /// <summary>
+        /// The colours a recruit's portrait is about to be built with. Worth a line each: a portrait
+        /// whose armour looks wrong is otherwise indistinguishable from one that rendered wrongly.
+        /// </summary>
+        private static void LogRecruitCustomization(GeoUnitDescriptor recruit)
+        {
+            try
+            {
+                CharacterIdentity identity = recruit.GetIdentity();
+                TFTVLogger.Always($"{LogPrefix} {recruit.GetName()} customization: " +
+                    $"armour {PortraitPrimaryColorDefName}/{PortraitSecondaryColorDefName} (fixed) | " +
+                    $"pattern {identity?.PatternTag?.name ?? "-"} | conditional {identity?.ConditionalCustiomizationTag?.name ?? "-"} | " +
+                    $"own armour was {identity?.PrimaryColorTag?.name ?? "-"}/{identity?.SecondaryColorTag?.name ?? "-"}");
+            }
+            catch (Exception e)
+            {
+                TFTVLogger.Error(e);
+            }
+        }
+
+        /// <summary>
+        /// Builds the subject, renders it and hands back the sprite. The one place a portrait is
+        /// actually made; every caller above is a way of describing the subject to it.
+        /// </summary>
+        private static IEnumerator RenderPortrait(
+            UnitDisplayData displayData,
+            GeoCharacter character,
+            Vector2Int resolution,
+            PortraitFraming framing,
+            bool requireFaceBone,
+            bool dumpToDisk,
+            Action<Sprite> onDone)
+        {
+            GeoLevelController level = GameUtl.CurrentLevel()?.GetComponent<GeoLevelController>();
+            if (level == null || displayData == null)
+            {
+                onDone?.Invoke(null);
+                yield break;
+            }
+
             AddonsCharacterBuilder builder = CreateSubjectBuilder();
             try
             {
@@ -584,7 +822,7 @@ namespace TFTV.TFTVIncidents
                     yield break;
                 }
 
-                Texture2D rendered = RenderSubject(builder, displayData, resolution);
+                Texture2D rendered = RenderSubject(builder, displayData, resolution, framing, requireFaceBone);
                 if (rendered == null)
                 {
                     onDone?.Invoke(null);
@@ -596,7 +834,10 @@ namespace TFTV.TFTVIncidents
                 rendered.filterMode = FilterMode.Trilinear;
                 rendered.anisoLevel = 4;
 
-                DumpRender(character, rendered);
+                if (dumpToDisk)
+                {
+                    DumpRender(displayData.Name, rendered);
+                }
 
                 onDone?.Invoke(Sprite.Create(
                     rendered,
@@ -614,16 +855,11 @@ namespace TFTV.TFTVIncidents
         /// Writes the render to persistentDataPath under a name carrying the settings that produced
         /// it, so a run of portrait_* variations leaves a directory that can be compared file by file.
         /// </summary>
-        private static void DumpRender(GeoCharacter character, Texture2D rendered)
+        private static void DumpRender(string subjectName, Texture2D rendered)
         {
-            if (!DumpRenderToDisk)
-            {
-                return;
-            }
-
             try
             {
-                string name = $"TFTV_Portrait_{character.Id}_{SettingsSlug()}.png";
+                string name = $"TFTV_Portrait_{SanitizeFileName(subjectName)}_{SettingsSlug()}.png";
                 System.IO.File.WriteAllBytes(System.IO.Path.Combine(Application.persistentDataPath, name), rendered.EncodeToPNG());
                 TFTVLogger.Always($"{LogPrefix} Wrote {name} ({rendered.width}x{rendered.height}).");
             }
@@ -631,6 +867,24 @@ namespace TFTV.TFTVIncidents
             {
                 TFTVLogger.Error(dumpError);
             }
+        }
+
+        /// <summary>
+        /// Operative names reach the dump file name, and they can carry anything the player typed.
+        /// </summary>
+        private static string SanitizeFileName(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return "unnamed";
+            }
+
+            foreach (char invalid in System.IO.Path.GetInvalidFileNameChars())
+            {
+                value = value.Replace(invalid, '_');
+            }
+
+            return value;
         }
 
         private static string SettingsSlug()
@@ -732,6 +986,10 @@ namespace TFTV.TFTVIncidents
         /// its OnCharacterRebuilded step: tags first with autorefresh off, rebuild, then autorefresh
         /// back on - which is what applies the customization (armour colours and patterns, skin, hair,
         /// eyes) to the addons that were just built.
+        ///
+        /// <paramref name="character"/> is null when the subject is a recruit: a GeoUnitDescriptor's
+        /// display data already reads its appearance tags straight off the identity, so there is
+        /// nothing to refresh and no corruption to apply.
         /// </summary>
         private static IEnumerator BuildSubject(AddonsCharacterBuilder builder, GeoCharacter character, UnitDisplayData displayData, GeoLevelController level, Action<bool> onDone)
         {
@@ -749,7 +1007,7 @@ namespace TFTV.TFTVIncidents
                 // then rebuild the builder from that list. Do the same rather than an imitation of
                 // it on a copy - that merged the same tags into our own list and still came out with
                 // the template's grey.
-                character.RefreshTags();
+                character?.RefreshTags();
 
                 AddonsManager manager = builder.AddonsManager;
                 manager.SetAutorefreshOnTagsChanged(false);
@@ -760,7 +1018,7 @@ namespace TFTV.TFTVIncidents
                 // showHelmet: false. The body itself comes from the armour items, exactly as on the
                 // personnel screen - an unarmoured operative carries their bare body parts there.
                 List<ItemDef> armour = displayData.ArmourItems
-                    .Where(item => item != null && !IsHelmetOrAttachment(item))
+                    .Where(item => item != null && !IsRemovableHeadCover(item))
                     .ToList();
 
                 CommonCharacterUtils.RebuildCharacter(builder, armour, null);
@@ -775,7 +1033,7 @@ namespace TFTV.TFTVIncidents
 
                 if (!rebuilt)
                 {
-                    TFTVLogger.Always($"{LogPrefix} Rebuild of {character.DisplayName} timed out after {RebuildTimeoutSeconds}s.");
+                    TFTVLogger.Always($"{LogPrefix} Rebuild of {displayData.Name} timed out after {RebuildTimeoutSeconds}s.");
                     onDone?.Invoke(false);
                     yield break;
                 }
@@ -789,7 +1047,7 @@ namespace TFTV.TFTVIncidents
                 // One line per portrait: what the operative is actually made of. Anything unexpected
                 // in here (a bare body part next to the armour that covers it, a missing armour piece)
                 // is what a wrong-looking portrait will be made of too.
-                TFTVLogger.Always($"{LogPrefix} {character.DisplayName} built from {string.Join(", ", VisibleItemNames(manager))} " +
+                TFTVLogger.Always($"{LogPrefix} {displayData.Name} built from {string.Join(", ", VisibleItemNames(manager))} " +
                     $"| identity {IdentityCustomization(character)} " +
                     $"| customization {string.Join(", ", CustomizationTagNames(manager))}");
 
@@ -896,7 +1154,7 @@ namespace TFTV.TFTVIncidents
         /// </summary>
         private static string IdentityCustomization(GeoCharacter character)
         {
-            CharacterIdentity identity = character.Identity;
+            CharacterIdentity identity = character?.Identity;
             if (identity == null)
             {
                 return "none";
@@ -912,7 +1170,9 @@ namespace TFTV.TFTVIncidents
         private static string[] CustomizationTagNames(AddonsManager manager)
         {
             return manager.MergeWithAddonsTags
-                .Where(tag => tag is CustomizationColorTagDef || tag is CustomizationPatternTagDef)
+                .Where(tag => tag is CustomizationColorTagDef
+                    || tag is CustomizationPatternTagDef
+                    || tag is ConditionalCustomizationTagDef)
                 .Select(tag => tag.name)
                 .ToArray();
         }
@@ -981,7 +1241,7 @@ namespace TFTV.TFTVIncidents
         /// to the Characters layer and clipped 2.5m out, so nothing else in the scene can reach the
         /// image - all we have to do is light the subject and make sure it is on that layer.
         /// </summary>
-        private static Texture2D RenderSubject(AddonsCharacterBuilder builder, UnitDisplayData displayData, Vector2Int resolution)
+        private static Texture2D RenderSubject(AddonsCharacterBuilder builder, UnitDisplayData displayData, Vector2Int resolution, PortraitFraming framing, bool requireFaceBone)
         {
             GameObject subject = builder.gameObject;
             SetLayerRecursively(subject, LayerMask.NameToLayer("Characters"));
@@ -1046,7 +1306,7 @@ namespace TFTV.TFTVIncidents
                 // - which would leave fresh renderers with no property block on them.
                 RefreshAddonTags(builder.AddonsManager);
                 HideCoveredAddonVisuals(builder.AddonsManager);
-                return CapturePortrait(builder, resolution);
+                return CapturePortrait(builder, resolution, framing, requireFaceBone);
             }
             finally
             {
@@ -1108,13 +1368,25 @@ namespace TFTV.TFTVIncidents
         /// portraits come out in factory colours for the same reason. Copying the live camera keeps
         /// the shader on the path it takes in the scene, which is where the customization shows.
         /// </summary>
-        private static Texture2D CapturePortrait(AddonsCharacterBuilder builder, Vector2Int resolution)
+        private static Texture2D CapturePortrait(AddonsCharacterBuilder builder, Vector2Int resolution, PortraitFraming framing, bool requireFaceBone)
         {
             Transform target = builder.AddonsManager?.FindTransform("Nose", rigBonesOnly: true)
-                ?? builder.AddonsManager?.FindTransform("Head", rigBonesOnly: true)
-                ?? builder.transform;
+                ?? builder.AddonsManager?.FindTransform("Head", rigBonesOnly: true);
 
-            float distance = target.name == "Head" ? HeadDistance : NoseDistance;
+            if (target == null)
+            {
+                // Nothing with a face: a vehicle chassis, or a rig whose bones are named otherwise.
+                // The framing below is a head-and-shoulders framing, so pointing it at the object
+                // root gives a close-up of whatever happens to sit at the origin.
+                if (requireFaceBone)
+                {
+                    return null;
+                }
+
+                target = builder.transform;
+            }
+
+            float distance = target.name == "Head" ? framing.HeadDistance : framing.NoseDistance;
 
             // Render bigger than the portrait is shown at, then average the extra samples down.
             // Nothing in this path anti-aliases on its own, so this is where edge quality comes from.
@@ -1147,7 +1419,7 @@ namespace TFTV.TFTVIncidents
                 camera.allowHDR = false;
                 camera.allowMSAA = msaa > 1;
                 camera.orthographic = false;
-                camera.fieldOfView = CameraFoV;
+                camera.fieldOfView = framing.FieldOfView;
                 camera.nearClipPlane = 0.01f;
                 camera.farClipPlane = 2.5f;
 
@@ -1159,14 +1431,14 @@ namespace TFTV.TFTVIncidents
                 // Swing the camera around the head for a three-quarter view. The yaw is taken about
                 // world up rather than the bone's, since rig bones do not carry a dependable up, and
                 // the look-at levels the shot so the portrait is never tilted.
-                Vector3 viewDirection = Quaternion.AngleAxis(CameraYawDegrees, Vector3.up) * target.forward;
+                Vector3 viewDirection = Quaternion.AngleAxis(framing.YawDegrees, Vector3.up) * target.forward;
                 camera.transform.position = target.position
                     + viewDirection.normalized * distance
-                    + Vector3.up * CameraHeight;
+                    + Vector3.up * framing.Height;
 
                 // Aiming below the face rather than straight at it lifts the head out of the middle
                 // of the frame and leaves the shoulders under it.
-                camera.transform.LookAt(target.position + Vector3.up * LookAtVerticalOffset);
+                camera.transform.LookAt(target.position + Vector3.up * framing.LookAtVerticalOffset);
 
                 camera.Render();
 
@@ -1505,9 +1777,21 @@ namespace TFTV.TFTVIncidents
         /// <summary>
         /// Same test as UIModuleActorCycle.IsHelmetOrAttachment.
         /// </summary>
-        private static bool IsHelmetOrAttachment(ItemDef armourItem)
+        /// <summary>
+        /// Whether an item covers the head and can simply be taken off for the portrait.
+        ///
+        /// A helmet can. A mutated or bionic head cannot: it is not worn over the face, it *is* the
+        /// face, and stripping it leaves the portrait showing the plain human head the augment
+        /// replaced - a face the operative does not have. Vanilla draws the same line, by whether the
+        /// head slot holds a permanent augment (UIStateMemorial's showHelmet, and the customization
+        /// screen's _hasMutatedHead, which greys out the hide-helmet toggle for exactly this case).
+        ///
+        /// Vanilla decides it once for the whole unit; this decides it per item, so an operative
+        /// wearing a helmet over an augmented head still loses the helmet and keeps the augment.
+        /// </summary>
+        private static bool IsRemovableHeadCover(ItemDef armourItem)
         {
-            if (armourItem?.RequiredSlotBinds == null)
+            if (armourItem?.RequiredSlotBinds == null || armourItem.IsPermanentAugment)
             {
                 return false;
             }
@@ -1524,6 +1808,35 @@ namespace TFTV.TFTVIncidents
             return false;
         }
 
+        /// <summary>
+        /// Runs a portrait coroutine on the geoscape level's own runner, which is where every render
+        /// in this file happens. Returns null when there is no geoscape to run it on.
+        /// </summary>
+        internal static Coroutine RunPortraitCoroutine(IEnumerator routine)
+        {
+            try
+            {
+                if (routine == null)
+                {
+                    return null;
+                }
+
+                CoroutineRunner runner = GetCoroutineRunner();
+                if (runner == null)
+                {
+                    TFTVLogger.Always($"{LogPrefix} No coroutine runner - there is no geoscape to render on.");
+                    return null;
+                }
+
+                return runner.StartCoroutine(routine);
+            }
+            catch (Exception e)
+            {
+                TFTVLogger.Error(e);
+                return null;
+            }
+        }
+
         private static CoroutineRunner GetCoroutineRunner()
         {
             GeoLevelController level = GameUtl.CurrentLevel()?.GetComponent<GeoLevelController>();
@@ -1532,7 +1845,11 @@ namespace TFTV.TFTVIncidents
                 return null;
             }
 
-            return level.GetComponent<CoroutineRunner>() ?? level.gameObject.AddComponent<CoroutineRunner>();
+            // Deliberately not ??: a destroyed component is a live C# reference that only Unity's
+            // own == knows is dead, so ?? would hand back the previous level's runner and every
+            // StartCoroutine on it would throw.
+            CoroutineRunner existing = level.GetComponent<CoroutineRunner>();
+            return existing != null ? existing : level.gameObject.AddComponent<CoroutineRunner>();
         }
 
         private sealed class CoroutineRunner : MonoBehaviour

--- a/TFTV/TFTVUI/Geoscape/TFTVHavenRecruitsUI/HavenRecruitPortrait.cs
+++ b/TFTV/TFTVUI/Geoscape/TFTVHavenRecruitsUI/HavenRecruitPortrait.cs
@@ -1,0 +1,450 @@
+﻿using PhoenixPoint.Geoscape.Entities;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using TFTV.TFTVIncidents;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TFTV.TFTVHavenRecruitsUI
+{
+    /// <summary>
+    /// The rendered head shown in the recruit details panel.
+    ///
+    /// The render itself is the incident portrait generator's - the same subject build, framing and
+    /// lighting the incident leader picture uses, fed a GeoUnitDescriptor instead of a GeoCharacter.
+    /// What lives here is everything that keeps that render from being expensive:
+    ///
+    ///  - nothing renders for the list, only for the recruit whose details are open;
+    ///  - a selection has to hold still for <see cref="DebounceSeconds"/> before it is paid for, so
+    ///    walking the list with a stick or the arrow keys renders the recruit stopped on, not each
+    ///    one passed over;
+    ///  - one render at a time, and a second request while one is in flight replaces the target
+    ///    rather than queueing behind it;
+    ///  - every result is cached for the session, including the failures, so a recruit is never
+    ///    rendered twice and a Scarab is never attempted twice.
+    ///
+    /// A render is a rig build plus a camera pass plus a GPU readback: single-digit-to-tens of
+    /// milliseconds, once per recruit the player actually looks at, and zero per frame after that.
+    /// </summary>
+    internal static class HavenRecruitPortrait
+    {
+        private const string LogPrefix = "[TFTV][HavenRecruitPortrait]";
+
+        /// <summary>Name of the slot GameObject, used to find one a previous panel left behind.</summary>
+        private const string SlotName = "RecruitPortrait";
+
+        // Where the slot sits, as a fraction of the detail panel: upper right, clear of the header
+        // above it and of the faction, name and level rows to its left. Anchors rather than pixels,
+        // because the panel is sized against the screen and the canvas it hangs on is scaled - a
+        // fixed size would be right at one resolution and wrong at the next. The slot is outside
+        // every layout group in the panel, so its presence cannot move any of those rows around.
+        private const float PortraitAnchorMinX = 0.60f;
+        private const float PortraitAnchorMaxX = 0.905f;
+        private const float PortraitAnchorMinY = 0.735f;
+        private const float PortraitAnchorMaxY = 0.905f;
+
+        /// <summary>
+        /// How long a recruit has to stay selected before its portrait is rendered. Long enough that
+        /// scrolling the list with a controller costs nothing, short enough not to be felt on a click.
+        /// </summary>
+        private const float DebounceSeconds = 0.2f;
+
+        /// <summary>
+        /// Rendered portraits kept at once. Twelve heads at this slot size is under two megabytes,
+        /// and no haven list the player walks through in one sitting is much longer.
+        /// </summary>
+        private const int CacheCapacity = 12;
+
+        /// <summary>
+        /// Ceiling on the rendered portrait's pixel size. The slot is small, so this only bites on
+        /// very high-DPI displays, where a head rendered at the full slot size would cost more than
+        /// the extra sharpness is worth.
+        /// </summary>
+        private const int MaxPortraitResolution = 512;
+
+        /// <summary>
+        /// Used when the slot cannot be measured, which is a slot with no layout pass behind it yet.
+        /// </summary>
+        private const int FallbackResolution = 256;
+
+        private static GameObject _holder;
+        private static RectTransform _holderRect;
+        private static Image _portraitImage;
+
+        /// <summary>
+        /// The slot's rect, so the panel can keep its own text clear of it. Valid whether or not a
+        /// portrait is currently shown - the header text should stop at the same column either way,
+        /// rather than running wider on the recruits that happen to have no portrait.
+        /// </summary>
+        internal static RectTransform SlotRect => _holderRect;
+
+        // Rendered portraits by recruit. A null value is a recruit that has been tried and cannot be
+        // rendered (a vehicle has no face bone) - cached so it is not attempted again.
+        private static readonly Dictionary<GeoUnitDescriptor, Sprite> Cache =
+            new Dictionary<GeoUnitDescriptor, Sprite>(ReferenceComparer.Instance);
+
+        // Cache keys oldest first, so the least recently shown portrait is the one evicted.
+        private static readonly List<GeoUnitDescriptor> CacheOrder = new List<GeoUnitDescriptor>();
+
+        // The recruit the panel currently wants shown. The render loop reads this every time it is
+        // about to commit to work, so a newer selection always wins over an older one.
+        private static GeoUnitDescriptor _requested;
+        private static bool _renderLoopRunning;
+
+        /// <summary>
+        /// The recruit detail panel, or null if there is not one right now. Unity's own null test,
+        /// not C#'s: a destroyed GameObject is still a live reference, and ?. would happily walk into
+        /// it and throw.
+        /// </summary>
+        private static Transform DetailPanelTransform()
+        {
+            GameObject panel = HavenRecruitsDetailsPanel._detailPanel;
+            return panel != null ? panel.transform : null;
+        }
+
+        /// <summary>
+        /// Adds the portrait slot to the detail panel, as the panel is built and again on demand if
+        /// it ever goes missing. Does nothing when there is already a slot.
+        /// </summary>
+        internal static void Create(Transform detailPanel)
+        {
+            try
+            {
+                if (detailPanel == null || _holder != null)
+                {
+                    return;
+                }
+
+                // A slot left over from a previous panel that outlived its reference - otherwise
+                // rebuilding would stack a second one on top of it.
+                Transform stale = detailPanel.Find(SlotName);
+                if (stale != null)
+                {
+                    UnityEngine.Object.Destroy(stale.gameObject);
+                }
+
+                var (holderGO, holderRT) = RecruitOverlayManagerHelpers.NewUI(SlotName, detailPanel);
+
+                // Stretched between its anchors rather than laid out, so nothing in the panel's
+                // vertical stack shifts when a portrait appears - or when one never does.
+                holderRT.anchorMin = new Vector2(PortraitAnchorMinX, PortraitAnchorMinY);
+                holderRT.anchorMax = new Vector2(PortraitAnchorMaxX, PortraitAnchorMaxY);
+                holderRT.pivot = new Vector2(0.5f, 0.5f);
+                holderRT.offsetMin = Vector2.zero;
+                holderRT.offsetMax = Vector2.zero;
+
+                _portraitImage = holderGO.AddComponent<Image>();
+                _portraitImage.raycastTarget = false;
+
+                // The slot's shape follows the panel's; the head keeps the shape it was rendered at
+                // and is centred in whatever the slot turns out to be.
+                _portraitImage.preserveAspect = true;
+
+                _holder = holderGO;
+                _holderRect = holderRT;
+                _holder.SetActive(false);
+
+                TFTVLogger.Always($"{LogPrefix} Portrait slot created.");
+
+                // A fresh panel means a fresh session. Reaching here proves there was no slot, so any
+                // loop still believing it is running belongs to a level that is gone.
+                _renderLoopRunning = false;
+            }
+            catch (Exception ex) { TFTVLogger.Error(ex); }
+        }
+
+        /// <summary>
+        /// Shows the given recruit's portrait, rendering it if this is the first time it is asked for.
+        /// </summary>
+        internal static void Show(GeoUnitDescriptor recruit)
+        {
+            try
+            {
+                // Rebuild the slot if it has gone missing. The detail panel is torn down and put back
+                // on every load, and this class is static, so the two can get out of step: the slot
+                // reference is cleared while the panel that was meant to carry the replacement is
+                // never rebuilt, and portraits stop appearing for the rest of the session. Asking for
+                // the slot here rather than trusting it was created makes that unable to happen,
+                // whatever order the panel's own lifecycle runs in.
+                if (_holder == null)
+                {
+                    Create(DetailPanelTransform());
+                }
+
+                if (_holder == null)
+                {
+                    TFTVLogger.Always($"{LogPrefix} No slot to show {recruit?.GetName() ?? "nobody"} in, and no panel to build one on.");
+                    return;
+                }
+
+                _requested = recruit;
+
+                if (recruit == null)
+                {
+                    Detach();
+                    return;
+                }
+
+                if (Cache.TryGetValue(recruit, out Sprite cached))
+                {
+                    Touch(recruit);
+                    Apply(cached);
+                    return;
+                }
+
+                // Nothing to show yet, and the previous recruit's head must not stand in for it.
+                Detach();
+
+                if (!_renderLoopRunning)
+                {
+                    // Set before starting: StartCoroutine runs the loop up to its first yield
+                    // synchronously, and that stretch can reach the loop's own finally. Assigning
+                    // the result afterwards would then flag a loop that has already exited as running,
+                    // and no later selection would ever be rendered.
+                    _renderLoopRunning = true;
+
+                    if (PortraitGenerator.RunPortraitCoroutine(RenderLoop()) == null)
+                    {
+                        _renderLoopRunning = false;
+                        TFTVLogger.Always($"{LogPrefix} Could not start the render loop for {recruit.GetName()}.");
+                    }
+                }
+                else
+                {
+                    TFTVLogger.Always($"{LogPrefix} {recruit.GetName()} queued behind a render loop already running.");
+                }
+            }
+            catch (Exception ex) { TFTVLogger.Error(ex); }
+        }
+
+        /// <summary>
+        /// Clears the slot and abandons any render still to come. Called when the details panel is
+        /// hidden - the panel is shared by every recruit, so a stale head must not survive into the
+        /// next one.
+        /// </summary>
+        internal static void Hide()
+        {
+            try
+            {
+                _requested = null;
+                Detach();
+            }
+            catch (Exception ex) { TFTVLogger.Error(ex); }
+        }
+
+        /// <summary>
+        /// Frees every rendered portrait and forgets the slot. Called when the overlay tears its
+        /// panels down, which is also when the GameObjects these sprites are shown on go away.
+        /// </summary>
+        internal static void ResetState()
+        {
+            try
+            {
+                _requested = null;
+
+                // The loop runs on a coroutine runner that lives on the geoscape level, and a load
+                // destroys that level without the loop's own finally ever getting to clear this. Left
+                // set, it makes every later request believe a loop is already on the way, and no
+                // portrait renders again for the rest of the session.
+                _renderLoopRunning = false;
+
+                if (_portraitImage != null)
+                {
+                    _portraitImage.sprite = null;
+                }
+
+                foreach (Sprite sprite in Cache.Values)
+                {
+                    DestroySprite(sprite);
+                }
+
+                Cache.Clear();
+                CacheOrder.Clear();
+
+                // Destroyed, not merely forgotten: the panel that carries it is usually torn down
+                // with it, but when it is not, a forgotten slot would linger as an orphan and the
+                // rebuild would stack a second one beside it.
+                if (_holder != null)
+                {
+                    UnityEngine.Object.Destroy(_holder);
+                }
+
+                _holder = null;
+                _holderRect = null;
+                _portraitImage = null;
+            }
+            catch (Exception ex) { TFTVLogger.Error(ex); }
+        }
+
+        /// <summary>
+        /// Renders whatever recruit is selected, one at a time, until nothing is left wanting a
+        /// portrait. Runs only while there is work; it is not a per-frame cost of having the panel open.
+        /// </summary>
+        private static IEnumerator RenderLoop()
+        {
+            try
+            {
+                while (true)
+                {
+                    GeoUnitDescriptor target = _requested;
+                    if (target == null || _holder == null)
+                    {
+                        TFTVLogger.Always($"{LogPrefix} Render loop stopping: " +
+                            $"{(target == null ? "nothing selected" : "no slot")}.");
+                        yield break;
+                    }
+
+                    if (Cache.TryGetValue(target, out Sprite cached))
+                    {
+                        Touch(target);
+                        Apply(cached);
+                        yield break;
+                    }
+
+                    // Let the selection settle. A player running down the list with a controller
+                    // passes over every recruit in it, and none of those are worth a render.
+                    float deadline = Time.realtimeSinceStartup + DebounceSeconds;
+                    while (Time.realtimeSinceStartup < deadline && _requested == target)
+                    {
+                        yield return null;
+                    }
+
+                    if (_requested != target)
+                    {
+                        continue;
+                    }
+
+                    Sprite portrait = null;
+                    yield return PortraitGenerator.RenderPortrait(target, ResolveResolution(), s => portrait = s);
+
+                    // The overlay can be torn down while a render is in flight, and ResetState has
+                    // then already freed everything it knew about. Nothing would ever free this one.
+                    if (_holder == null)
+                    {
+                        DestroySprite(portrait);
+                        yield break;
+                    }
+
+                    // Cache the failure too: a recruit with no face bone would otherwise be
+                    // re-rendered from scratch every time it is selected.
+                    Store(target, portrait);
+
+                    if (_requested == target)
+                    {
+                        Apply(portrait);
+                        yield break;
+                    }
+                }
+            }
+            finally
+            {
+                _renderLoopRunning = false;
+            }
+        }
+
+        /// <summary>
+        /// Render size for the slot as it is actually drawn on this display, so the portrait is
+        /// neither magnified nor rendered into pixels the Image throws away.
+        /// </summary>
+        private static Vector2Int ResolveResolution()
+        {
+            Vector2Int measured = PortraitGenerator.ResolveSlotResolution(_holderRect, 1f, MaxPortraitResolution);
+            if (measured.x > 0 && measured.y > 0)
+            {
+                return measured;
+            }
+
+            return new Vector2Int(FallbackResolution, FallbackResolution);
+        }
+
+        private static void Apply(Sprite portrait)
+        {
+            if (_portraitImage == null || _holder == null)
+            {
+                return;
+            }
+
+            _portraitImage.sprite = portrait;
+            _holder.SetActive(portrait != null);
+        }
+
+        /// <summary>
+        /// Empties the slot and hides it. The sprite itself stays in the cache - only the Image's
+        /// reference to it is dropped.
+        /// </summary>
+        private static void Detach()
+        {
+            Apply(null);
+        }
+
+        private static void Store(GeoUnitDescriptor recruit, Sprite portrait)
+        {
+            if (recruit == null)
+            {
+                DestroySprite(portrait);
+                return;
+            }
+
+            Cache[recruit] = portrait;
+            Touch(recruit);
+
+            while (CacheOrder.Count > CacheCapacity)
+            {
+                GeoUnitDescriptor oldest = CacheOrder[0];
+                CacheOrder.RemoveAt(0);
+
+                if (Cache.TryGetValue(oldest, out Sprite evicted))
+                {
+                    Cache.Remove(oldest);
+
+                    // Never free what the panel is drawing: a destroyed texture left on an Image
+                    // renders as garbage until something replaces it.
+                    if (_portraitImage == null || _portraitImage.sprite != evicted)
+                    {
+                        DestroySprite(evicted);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Moves a recruit to the young end of the eviction order.
+        /// </summary>
+        private static void Touch(GeoUnitDescriptor recruit)
+        {
+            CacheOrder.Remove(recruit);
+            CacheOrder.Add(recruit);
+        }
+
+        private static void DestroySprite(Sprite sprite)
+        {
+            if (sprite == null)
+            {
+                return;
+            }
+
+            if (sprite.texture != null)
+            {
+                UnityEngine.Object.Destroy(sprite.texture);
+            }
+
+            UnityEngine.Object.Destroy(sprite);
+        }
+
+        /// <summary>
+        /// Keys the cache on the descriptor object itself. Two recruits can be identical in every
+        /// field a value comparison would look at, and a haven's recruit is one persistent object
+        /// until that haven rolls a new one, which is exactly the lifetime a portrait is valid for.
+        /// </summary>
+        private sealed class ReferenceComparer : IEqualityComparer<GeoUnitDescriptor>
+        {
+            internal static readonly ReferenceComparer Instance = new ReferenceComparer();
+
+            public bool Equals(GeoUnitDescriptor x, GeoUnitDescriptor y) => ReferenceEquals(x, y);
+
+            public int GetHashCode(GeoUnitDescriptor obj) => RuntimeHelpers.GetHashCode(obj);
+        }
+    }
+}

--- a/TFTV/TFTVUI/Geoscape/TFTVHavenRecruitsUI/HavenRecruitsDetailsPanel.cs
+++ b/TFTV/TFTVUI/Geoscape/TFTVHavenRecruitsUI/HavenRecruitsDetailsPanel.cs
@@ -312,6 +312,7 @@ namespace TFTV
                 rt.offsetMax = Vector2.zero;
 
                 CreateDetailHeader(_detailPanel.transform);
+                HavenRecruitPortrait.Create(_detailPanel.transform);
 
                 var (contentGO, contentRT) = RecruitOverlayManagerHelpers.NewUI("Content", _detailPanel.transform);
                 contentRT.anchorMin = new Vector2(0f, 0f);
@@ -725,6 +726,8 @@ namespace TFTV
                 _detailInfoRoot?.gameObject.SetActive(false);
 
                 _detailEmptyState?.SetActive(true);
+
+                HavenRecruitPortrait.Hide();
 
                 if (_detailClassIconImage != null)
                 {
@@ -1328,6 +1331,16 @@ namespace TFTV
                 {
                     string factionName = GetFactionDisplayName(data?.HavenOwner);
                     string location = data?.Site?.LocalizedSiteName;
+
+                    // Shortened before the colour markup goes on, and each line on its own: this
+                    // label is two coloured lines, and there is no prefix of the finished string that
+                    // is both short enough and still valid markup. The label's own left edge does not
+                    // move with its text - the faction icon beside it is a fixed size - so the room
+                    // can be measured now rather than after a rebuild.
+                    float room = RoomBeforePortrait(_detailFactionNameLabel);
+                    factionName = HavenRecruitsUtils.Ellipsize(_detailFactionNameLabel, factionName, room);
+                    location = HavenRecruitsUtils.Ellipsize(_detailFactionNameLabel, location, room);
+
                     _detailFactionNameLabel.text = BuildFactionHeaderText(factionName, location, factionHeaderColor);
                 }
 
@@ -1370,11 +1383,66 @@ namespace TFTV
                 PopulateArmorSlots(data.Recruit);
                 PopulateEquipmentSlots(data.Recruit);
 
+                // Sits outside the layout below, so it is deliberately not followed by a rebuild.
+                HavenRecruitPortrait.Show(data.Recruit);
+
                 var infoRect = _detailInfoRoot as RectTransform;
                 if (infoRect != null)
                 {
                     LayoutRebuilder.ForceRebuildLayoutImmediate(infoRect);
                 }
+
+                // After the rebuild: the label's left edge follows the class icon beside it, and only
+                // the settled layout knows where that put it.
+                FitHeaderTextToPortrait();
+            }
+            catch (Exception ex) { TFTVLogger.Error(ex); }
+        }
+
+        /// <summary>
+        /// Space left between the shortened text and the portrait slot.
+        /// </summary>
+        private const float DetailPortraitGutter = 16f;
+
+        /// <summary>
+        /// Room a label in the panel has before it reaches the portrait slot, in the label's own
+        /// units. Zero when there is no slot, which the shortening reads as "no limit known".
+        /// </summary>
+        private static float RoomBeforePortrait(Text label)
+        {
+            RectTransform portrait = HavenRecruitPortrait.SlotRect;
+            if (portrait == null || label == null)
+            {
+                return 0f;
+            }
+
+            return HavenRecruitsUtils.MeasureRoomBefore(
+                label.rectTransform,
+                HavenRecruitsUtils.WorldLeft(portrait),
+                DetailPortraitGutter);
+        }
+
+        /// <summary>
+        /// Shortens the level and name line so it stops before the portrait.
+        ///
+        /// It is set to overflow rather than wrap - a recruit's name is one line by design - so
+        /// nothing else would stop it, and a three-part name at a two-digit level is comfortably
+        /// wider than the room left beside a portrait. Unlike the faction line above, this one is
+        /// plain text, so the finished string can be cut directly.
+        /// </summary>
+        private static void FitHeaderTextToPortrait()
+        {
+            try
+            {
+                if (_detailLevelNameLabel == null)
+                {
+                    return;
+                }
+
+                HavenRecruitsUtils.SetEllipsizedText(
+                    _detailLevelNameLabel,
+                    _detailLevelNameLabel.text,
+                    RoomBeforePortrait(_detailLevelNameLabel));
             }
             catch (Exception ex) { TFTVLogger.Error(ex); }
         }

--- a/TFTV/TFTVUI/Geoscape/TFTVHavenRecruitsUI/HavenRecruitsMain.cs
+++ b/TFTV/TFTVUI/Geoscape/TFTVHavenRecruitsUI/HavenRecruitsMain.cs
@@ -580,6 +580,10 @@ namespace TFTV
                         _resourcePoolRoot = null;
                     }
 
+                    // Before the panel goes: the cached portraits are textures of our own, and the
+                    // slot they are shown in is a child of it.
+                    HavenRecruitPortrait.ResetState();
+
                     if (_detailPanel != null)
                     {
                         Object.Destroy(_detailPanel);
@@ -2096,8 +2100,19 @@ namespace TFTV
 
                     // The rows have to be measured after a layout pass: BuildNavigationRow orders each
                     // card's icons by screen position, and the layout groups have not run yet.
-                    if (_recruitListRoot is RectTransform listRect)
+                    RectTransform listRect = _recruitListRoot as RectTransform;
+                    if (listRect != null)
                     {
+                        LayoutRebuilder.ForceRebuildLayoutImmediate(listRect);
+
+                        // Names are shortened against the ability icons they would otherwise run
+                        // under, which needs the pass above; shortening one changes its width, so the
+                        // pass below settles the cards again before the navigation rows read them.
+                        foreach (var cardView in builtCards)
+                        {
+                            HavenRecruitsRecruitItem.FitNameToCard(cardView);
+                        }
+
                         LayoutRebuilder.ForceRebuildLayoutImmediate(listRect);
                     }
 

--- a/TFTV/TFTVUI/Geoscape/TFTVHavenRecruitsUI/HavenRecruitsRecruitItem.cs
+++ b/TFTV/TFTVUI/Geoscape/TFTVHavenRecruitsUI/HavenRecruitsRecruitItem.cs
@@ -296,6 +296,46 @@ namespace TFTV.TFTVHavenRecruitsUI
             }
         }
 
+        /// <summary>
+        /// Space left between a shortened name and whatever it was about to run into.
+        /// </summary>
+        private const float NameGutter = 12f;
+
+        /// <summary>
+        /// Shortens the card's name until it stops before the ability icons.
+        ///
+        /// Those icons are pinned to the card's right edge and ignore the layout, so the layout does
+        /// not know they are there and will not stop the name reaching them - a long name simply
+        /// draws underneath them, which is what the list did before this.
+        ///
+        /// Must be called only once the list's layout has run: during PopulateRecruitItem the card
+        /// has no width yet, so there would be nothing to measure against. RefreshColumns rebuilds
+        /// the list for its own reasons, and this rides on that pass.
+        /// </summary>
+        internal static void FitNameToCard(RecruitCardView cardView)
+        {
+            try
+            {
+                Text label = cardView?.NameLabel;
+                RectTransform cardRect = cardView?.transform as RectTransform;
+                if (label == null || cardRect == null)
+                {
+                    return;
+                }
+
+                // With no abilities (a vehicle) nothing is pinned over the name, so the card's own
+                // right edge is the limit.
+                RectTransform abilities = cardView.AbilityContainer as RectTransform;
+                float boundary = abilities != null && abilities.gameObject.activeSelf
+                    ? HavenRecruitsUtils.WorldLeft(abilities)
+                    : HavenRecruitsUtils.WorldRight(cardRect);
+
+                float room = HavenRecruitsUtils.MeasureRoomBefore(label.rectTransform, boundary, NameGutter);
+                HavenRecruitsUtils.SetEllipsizedText(label, label.text, room);
+            }
+            catch (Exception ex) { TFTVLogger.Error(ex); }
+        }
+
         internal static RecruitCardView CreateRecruitItem(Transform parent, RecruitAtSite data, bool collapse)
         {
             var cardView = EnsureCardHierarchy(parent);

--- a/TFTV/TFTVUI/Geoscape/TFTVHavenRecruitsUI/HavenRecruitsUtils.cs
+++ b/TFTV/TFTVUI/Geoscape/TFTVHavenRecruitsUI/HavenRecruitsUtils.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using UnityEngine;
+using UnityEngine.UI;
 using static TFTV.HavenRecruitsMain;
 using static TFTV.TFTVHavenRecruitsUI.HavenRecruitsPrice;
 
@@ -45,6 +46,141 @@ namespace TFTV.TFTVHavenRecruitsUI
             catch (Exception ex)
             {
                 TFTVLogger.Error(ex);
+            }
+        }
+
+        private const string Ellipsis = "...";
+
+        /// <summary>
+        /// Sets a label's text, cut short with an ellipsis if it would be wider than
+        /// <paramref name="maxWidth"/>.
+        ///
+        /// Unity's Text has no truncation of its own worth using: HorizontalWrapMode.Wrap moves the
+        /// overflow to a second line, Truncate cuts it mid-word with no ellipsis to say it did, and
+        /// Overflow - what the recruit labels use - simply draws the rest of the name over whatever
+        /// is next to it. Recruit names are three parts long (given name, nickname in quotes, family
+        /// name) and routinely outrun the space they have.
+        ///
+        /// The measurement is the label's own font metrics, which is what Text.preferredWidth is
+        /// built on, so it accounts for the font and size actually in use.
+        /// </summary>
+        internal static void SetEllipsizedText(Text label, string value, float maxWidth)
+        {
+            if (label == null)
+            {
+                return;
+            }
+
+            label.text = Ellipsize(label, value, maxWidth);
+        }
+
+        /// <summary>
+        /// The shortened string on its own, measured with <paramref name="metrics"/>'s font.
+        ///
+        /// Use this rather than <see cref="SetEllipsizedText"/> whenever the label's text is built up
+        /// out of parts with rich-text markup around them: cutting the finished string can land in
+        /// the middle of a colour tag, whereas cutting each part before it is wrapped cannot. Markup
+        /// costs no width, so measuring the bare part is also the honest measurement.
+        /// </summary>
+        internal static string Ellipsize(Text metrics, string value, float maxWidth)
+        {
+            try
+            {
+                value = value ?? string.Empty;
+
+                if (metrics == null || maxWidth <= 0f || value.Length == 0 || MeasureTextWidth(metrics, value) <= maxWidth)
+                {
+                    return value;
+                }
+
+                // Longest prefix that still fits once the ellipsis is on it. Width grows with every
+                // character kept, so the answer can be bisected instead of walked.
+                int shortest = 0;
+                int longest = value.Length - 1;
+                string best = Ellipsis;
+
+                while (shortest <= longest)
+                {
+                    int keep = (shortest + longest) / 2;
+                    string candidate = value.Substring(0, keep).TrimEnd() + Ellipsis;
+
+                    if (MeasureTextWidth(metrics, candidate) <= maxWidth)
+                    {
+                        best = candidate;
+                        shortest = keep + 1;
+                    }
+                    else
+                    {
+                        longest = keep - 1;
+                    }
+                }
+
+                return best;
+            }
+            catch (Exception ex)
+            {
+                TFTVLogger.Error(ex);
+                return value ?? string.Empty;
+            }
+        }
+
+        private static float MeasureTextWidth(Text label, string value)
+        {
+            TextGenerationSettings settings = label.GetGenerationSettings(Vector2.zero);
+
+            // Measuring, not laying out: let the generator report the width the string wants rather
+            // than the width the label currently has.
+            settings.horizontalOverflow = HorizontalWrapMode.Overflow;
+            settings.verticalOverflow = VerticalWrapMode.Overflow;
+            settings.updateBounds = false;
+
+            return label.cachedTextGeneratorForLayout.GetPreferredWidth(value, settings) / label.pixelsPerUnit;
+        }
+
+        /// <summary>
+        /// World-space x of a rect's left and right edges. Rects that overlap in a UI are only
+        /// comparable in world space - they can sit under different parents, anchors and pivots.
+        /// </summary>
+        internal static float WorldLeft(RectTransform rect) => WorldEdge(rect, 0);
+
+        internal static float WorldRight(RectTransform rect) => WorldEdge(rect, 2);
+
+        private static float WorldEdge(RectTransform rect, int corner)
+        {
+            Vector3[] corners = new Vector3[4];
+            rect.GetWorldCorners(corners);
+            return corners[corner].x;
+        }
+
+        /// <summary>
+        /// Horizontal room a label has before it reaches <paramref name="boundaryWorldX"/>, in the
+        /// label's own units - the world distance converted back through the label's scale, so the
+        /// answer is right whatever the canvas is scaled to.
+        ///
+        /// Returns zero when the label has no scale yet, which <see cref="SetEllipsizedText"/> reads
+        /// as "no limit known" and leaves the text whole.
+        /// </summary>
+        internal static float MeasureRoomBefore(RectTransform label, float boundaryWorldX, float gutter)
+        {
+            try
+            {
+                if (label == null)
+                {
+                    return 0f;
+                }
+
+                float scale = Mathf.Abs(label.lossyScale.x);
+                if (scale <= 0.0001f)
+                {
+                    return 0f;
+                }
+
+                return (boundaryWorldX - WorldLeft(label)) / scale - gutter;
+            }
+            catch (Exception ex)
+            {
+                TFTVLogger.Error(ex);
+                return 0f;
             }
         }
 


### PR DESCRIPTION
Shows a rendered head of the selected recruit in the upper right of the haven recruit details panel.

## What changed

**Reused the incident portrait renderer instead of writing a second one.** `PortraitGenerator` was hardwired to `GeoCharacter`, but a recruit only exists as a `GeoUnitDescriptor` until hired. Its render core now takes `UnitDisplayData`, with a descriptor entry point built on the same overload vanilla uses for its own recruit screen (`UIModuleActorCycle.Init`), so the same appearance tags reach the builder. The descriptor path skips `RefreshTags` (a descriptor reads its tags straight off the identity) and Delirium (a recruit has none), and abandons the render when there is no face bone — a Scarab renders nothing rather than a close-up of a hull.

**Framing is now per-portrait.** Incidents keep their existing bust framing and the live `portrait_*` console tunables. Recruits get a tighter face crop, narrowed at the lens rather than by walking the camera in, so the face is not distorted the way a close camera distorts one.

**Mutated and bionic heads show.** The head-stripping filter dropped anything in the Head slot; it now keeps permanent augments, so an augmented head shows instead of the human face it replaced. Vanilla draws the same line per unit (`UIStateMemorial`'s `showHelmet`, and the customization screen's `_hasMutatedHead`); this draws it per item, so a helmet worn over an augmented head still comes off.

**Armour is painted in one fixed pair of palette colours.** A recruit's own colours are randomised per recruit when their identity is first materialised, which made a haven's offers read as a paint chart. Hair and eye colour are left alone — they are separate tag subtypes — so faces stay individual. Both def names are constants.

**Over-long labels are shortened with a measured ellipsis.** Recruit names in the list ran underneath the ability icons, which are pinned to the card edge and ignore the layout, so nothing stopped them. The name and faction lines in the details panel would likewise have run into the portrait.

## Performance

A render is a rig build, a camera pass and a GPU readback, so the work is gated:

- nothing renders for the list, only for the recruit whose details are open;
- a selection must hold still 0.2s before it is paid for, so walking the list with a controller or the arrow keys renders the recruit you stop on, not each one passed over;
- one render at a time, and a newer selection replaces the target rather than queueing behind it;
- results are cached per session **including failures**, so a vehicle is attempted once and never again; the cache is bounded to 12 with textures destroyed on eviction and on the overlay teardown that already runs on load.

Steady state once a portrait is up is zero per frame.

## Notes for review

- **`DumpRenderToDisk` default flipped to `false`.** It shipped on and wrote a PNG to `persistentDataPath` inline with every incident portrait render. `portrait_dump on` restores it for a tuning session. This is the only change in behaviour outside the recruit panel.
- **The portrait slot rebuilds itself on demand.** It is a child of a panel that is torn down and recreated on every load while this state is static, so the two could get out of step and portraits would stop appearing for the rest of the session. `Show()` now rebuilds the slot if it is missing, `ResetState` destroys the slot object rather than only dropping the reference, and `Create` clears a stale slot left on a surviving panel so two cannot stack.
- **`GetCoroutineRunner` used `??` on a Unity component.** A destroyed component is a live C# reference that only Unity's overloaded `==` knows is dead, so `??` would hand back the previous level's runner and every `StartCoroutine` on it would throw. Now a Unity-safe check.
- **Opening the recruit panel now materialises each viewed recruit's identity**, because the portrait calls `GetIdentity()`, which generates and caches the appearance on first access. Vanilla does the same thing when you open a recruit's 3D screen; this just happens earlier. The practical effect is that a recruit's appearance stops re-rolling on load sooner than it used to.
- The card-name fit had to move out of `PopulateRecruitItem` into `RefreshColumns` after the existing list rebuild — during populate the cards have no width yet, so there is nothing to measure against. That adds one extra `ForceRebuildLayoutImmediate` over the list, since shortening a name changes its width and the navigation rows read positions afterwards.
- Builds clean; the new file is registered in `TFTV.csproj` (old-style project, no globbing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
